### PR TITLE
[POC][model] encrypt payment details

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
         "payum/omnipay-bridge": "If you want to use omnipay's gateways",
         "doctrine/orm": "If you want to store models to database using doctrin2 ORM",
         "doctrine/mongodb-odm": "If you want to store models to mongo doctrin2 ODM",
-        "monolog/monolog": "In case you want to use logger"
+        "monolog/monolog": "In case you want to use logger",
+        "phpseclib/phpseclib": "If you want store payment details encrypted"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Payum/Bridge/Phpseclib/EncryptionExtension.php
+++ b/src/Payum/Bridge/Phpseclib/EncryptionExtension.php
@@ -1,0 +1,96 @@
+<?php
+namespace Payum\Bridge\Phpseclib;
+
+use Payum\Action\ActionInterface;
+use Payum\Extension\ExtensionInterface;
+use Payum\Request\InteractiveRequestInterface;
+use Payum\Request\ModelRequestInterface;
+
+class EncryptionExtension implements ExtensionInterface
+{
+    /**
+     * @var \Crypt_Base
+     */
+    protected $crypt;
+
+    public function __construct(\Crypt_Base $crypt)
+    {
+        $this->crypt = $crypt;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function onPreExecute($request)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function onExecute($request, ActionInterface $action)
+    {
+        if (false == $request instanceof ModelRequestInterface) {
+            return;
+        }
+        if (false == $request->getModel() instanceof \ArrayAccess) {
+
+        }
+
+        $model = $request->getModel();
+        if (false == $model['encrypted']) {
+            return;
+        }
+
+        foreach ($model as $name => $value) {
+            $model[$name] = $this->crypt->decrypt($value);
+        }
+
+        $model['encrypted'] = false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function onPostExecute($request, ActionInterface $action)
+    {
+        $this->onPostXXX($request);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function onInteractiveRequest(InteractiveRequestInterface $interactiveRequest, $request, ActionInterface $action)
+    {
+        $this->onPostXXX($request);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function onException(\Exception $exception, $request, ActionInterface $action = null)
+    {
+        $this->onPostXXX($request);
+    }
+
+    protected function onPostXXX($request)
+    {
+        if (false == $request instanceof ModelRequestInterface) {
+            return;
+        }
+        if (false == $request->getModel() instanceof \ArrayAccess) {
+
+        }
+
+        $model = $request->getModel();
+        if ($model['encrypted']) {
+            return;
+        }
+
+        foreach ($model as $name => $value) {
+            $model[$name] = $this->crypt->encrypt($value);
+        }
+
+        $model['encrypted'] = true;
+    }
+}


### PR DESCRIPTION
This PR is a proof of payment details encryption concept. The main goal is to save data encrypted to a storage and decrypt before passing it to an action where it should be handled.

I've decided to use [phpseclib/phpseclib](https://packagist.org/packages/phpseclib/phpseclib). Will see if it is good enough.

The extension will encrypt\decrypt all models that implemenst `\ArrayAccess`. 