### PR TITLE
[request] change meaning of capture request. add purchase request.

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,8 @@
 0.6 to 0.7
 ==========
 
+* [Request] Meaning of `CaptureRequest` was changed. Replace all `CaptureRequest` usages with `PurchaseRequest` one.
+* [Doctrine] Entities and Documents classes were removed. Mapping provided for basic models.
 * `PaymentRegistryInterface::getPayments` method is added.
 
 0.6.2 to 0.6.3

--- a/src/Payum/Request/PurchaseRequest.php
+++ b/src/Payum/Request/PurchaseRequest.php
@@ -1,0 +1,6 @@
+<?php
+namespace Payum\Request;
+
+class PurchaseRequest extends BaseModelRequest
+{
+}

--- a/src/Payum/Request/SecuredPurchaseRequest.php
+++ b/src/Payum/Request/SecuredPurchaseRequest.php
@@ -1,0 +1,30 @@
+<?php
+namespace Payum\Request;
+
+use Payum\Security\TokenInterface;
+
+class SecuredPurchaseRequest extends PurchaseRequest implements SecuredRequestInterface
+{
+    /**
+     * @var TokenInterface
+     */
+    protected $token;
+
+    /**
+     * @param TokenInterface $token
+     */
+    public function __construct(TokenInterface $token)
+    {
+        $this->token = $token;
+
+        $this->setModel($token);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getToken()
+    {
+        return $this->token;
+    }
+}

--- a/tests/Payum/Tests/Request/PurchaseRequestTest.php
+++ b/tests/Payum/Tests/Request/PurchaseRequestTest.php
@@ -1,0 +1,15 @@
+<?php
+namespace Payum\Tests\Request;
+
+class PurchaseRequestTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldBeSubClassOfBaseModelRequest()
+    {
+        $rc = new \ReflectionClass('Payum\Request\PurchaseRequest');
+        
+        $this->assertTrue($rc->isSubclassOf('Payum\Request\BaseModelRequest'));
+    }
+}

--- a/tests/Payum/Tests/Request/SecuredPurchaseRequestTest.php
+++ b/tests/Payum/Tests/Request/SecuredPurchaseRequestTest.php
@@ -1,0 +1,70 @@
+<?php
+namespace Payum\Tests\Request;
+
+use Payum\Request\SecuredPurchaseRequest;
+use Payum\Model\Token;
+
+class SecuredPurchaseRequestTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldBeSubClassOfPurchaseRequest()
+    {
+        $rc = new \ReflectionClass('Payum\Request\SecuredPurchaseRequest');
+
+        $this->assertTrue($rc->isSubclassOf('Payum\Request\PurchaseRequest'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldImplementsSecuredRequestInterface()
+    {
+        $rc = new \ReflectionClass('Payum\Request\SecuredPurchaseRequest');
+
+        $this->assertTrue($rc->implementsInterface('Payum\Request\SecuredRequestInterface'));
+    }
+
+    /**
+     * @test
+     */
+    public function couldBeConstructedWithTokenAsFirstArgument()
+    {
+        new SecuredPurchaseRequest($this->getMock('Payum\Security\TokenInterface'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldAllowGetTokenSetInConstructor()
+    {
+        $expectedToken = new Token;
+        
+        $request = new SecuredPurchaseRequest($expectedToken);
+        
+        $this->assertSame($expectedToken, $request->getToken());
+        $this->assertSame($expectedToken, $request->getModel());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldAllowSetModelAndKeepTokenSame()
+    {
+        $token = new Token;
+
+        $request = new SecuredPurchaseRequest($token);
+
+        //guard
+        $this->assertSame($token, $request->getToken());
+        $this->assertSame($token, $request->getModel());
+
+        $newModel = new \stdClass;
+            
+        $request->setModel($newModel);
+
+        $this->assertSame($token, $request->getToken());
+        $this->assertSame($newModel, $request->getModel());
+    }
+}


### PR DESCRIPTION
Current `CaptureRequest` will be replaced with `PurchaseRequest`. 

In future purcahse request will use combination of authorize and capture requests. 
