### PR TITLE
[storage] add identity map for filesystem storage.

### DIFF
--- a/src/Payum/Storage/FilesystemStorage.php
+++ b/src/Payum/Storage/FilesystemStorage.php
@@ -17,6 +17,11 @@ class FilesystemStorage extends AbstractStorage
     protected $idProperty;
 
     /**
+     * @var array
+     */
+    protected $identityMap;
+
+    /**
      * @param string $storageDir
      * @param string $modelClass
      * @param string $idProperty
@@ -34,8 +39,12 @@ class FilesystemStorage extends AbstractStorage
      */
     public function findModelById($id)
     {
+        if (isset($this->identityMap[$id])) {
+            return $this->identityMap[$id];
+        }
+
         if (file_exists($this->storageDir.'/payum-model-'.$id)) {
-            return unserialize(file_get_contents($this->storageDir.'/payum-model-'.$id));
+            return $this->identityMap[$id] = unserialize(file_get_contents($this->storageDir.'/payum-model-'.$id));
         }
     }
 
@@ -60,6 +69,7 @@ class FilesystemStorage extends AbstractStorage
 
         $rp->setAccessible(false);
 
+        $this->identityMap[$id] = $model;
         file_put_contents($this->storageDir.'/payum-model-'.$id, serialize($model));
     }
 
@@ -73,6 +83,7 @@ class FilesystemStorage extends AbstractStorage
 
         if ($id = $rp->getValue($model)) {
             unlink($this->storageDir.'/payum-model-'.$id);
+            unset($this->identityMap[$id]);
         }
     }
 

--- a/tests/Payum/Tests/Storage/FilesystemStorageTest.php
+++ b/tests/Payum/Tests/Storage/FilesystemStorageTest.php
@@ -288,7 +288,7 @@ class FilesystemStorageTest extends \PHPUnit_Framework_TestCase
 
         $foundModel = $storage->findModelById($model->getId());
 
-        $this->assertNotSame($model, $foundModel);
+        $this->assertSame($model, $foundModel);
         $this->assertEquals($expectedPrice, $foundModel->getPrice());
         $this->assertEquals($expectedCurrency, $foundModel->getCurrency());
     }
@@ -312,11 +312,33 @@ class FilesystemStorageTest extends \PHPUnit_Framework_TestCase
 
         $foundModel = $storage->findModelById($model->payum_id);
 
-        $this->assertNotSame($model, $foundModel);
+        $this->assertSame($model, $foundModel);
         $this->assertEquals($expectedPrice, $foundModel->getPrice());
         $this->assertEquals($expectedCurrency, $foundModel->getCurrency());
 
         $this->assertObjectHasAttribute('payum_id', $foundModel);
         $this->assertNotEmpty($foundModel->payum_id);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldAllowDeleteModel()
+    {
+        $storage = new FilesystemStorage(sys_get_temp_dir(), 'Payum\Examples\Model\TestModel');
+
+        $model = $storage->createModel();
+        $model->setPrice($expectedPrice = 123);
+        $model->setCurrency($expectedCurrency = 'FOO');
+
+        $storage->updateModel($model);
+
+        //guard
+        $this->assertObjectHasAttribute('payum_id', $model);
+        $this->assertNotEmpty($model->payum_id);
+
+        $storage->deleteModel($model);
+
+        $this->assertNull($storage->findModelById($model->payum_id));
     }
 }


### PR DESCRIPTION
fixed bugs found while working on https://github.com/Payum/Payum/pull/79. The new model was created from the filesystem and therefor sensitive values were removed.
