### PR TITLE
[payment] add forcePrepend argument to Payment::addApi method.

### DIFF
--- a/src/Payum/Payment.php
+++ b/src/Payum/Payment.php
@@ -34,15 +34,18 @@ class Payment implements PaymentInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
-    public function addApi($api)
+    public function addApi($api, $forcePrepend = false)
     {
-        $this->apis[] = $api;
+        $forcePrepend ?
+            array_unshift($this->apis, $api) :
+            array_push($this->apis, $api)
+        ;
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function addAction(ActionInterface $action, $forcePrepend = false)
     {
@@ -75,7 +78,7 @@ class Payment implements PaymentInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function addExtension(ExtensionInterface $extension, $forcePrepend = false)
     {
@@ -83,7 +86,7 @@ class Payment implements PaymentInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function execute($request, $catchInteractive = false)
     {

--- a/src/Payum/PaymentInterface.php
+++ b/src/Payum/PaymentInterface.php
@@ -8,10 +8,11 @@ interface PaymentInterface
 {
     /**
      * @param mixed $api
+     * @param bool $forcePrepend
      *
      * @return void
      */
-    function addApi($api);
+    function addApi($api, $forcePrepend = false);
 
     /**
      * @param ActionInterface $action

--- a/tests/Payum/Tests/PaymentTest.php
+++ b/tests/Payum/Tests/PaymentTest.php
@@ -110,6 +110,27 @@ class PaymentTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function shouldAllowAddApiWithPrependForced()
+    {
+        $expectedFirstApi = new \stdClass;
+        $expectedSecondApi = new \stdClass;
+
+        $payment = new Payment;
+
+        $payment->addApi($expectedSecondApi);
+        $payment->addApi($expectedFirstApi, $forcePrepend = true);
+
+        $actualApis = $this->readAttribute($payment, 'apis');
+
+        $this->assertInternalType('array', $actualApis);
+        $this->assertCount(2, $actualApis);
+        $this->assertSame($expectedFirstApi, $actualApis[0]);
+        $this->assertSame($expectedSecondApi, $actualApis[1]);
+    }
+
+    /**
+     * @test
+     */
     public function shouldSetFirstApiToActionApiAware()
     {
         $payment = new Payment();


### PR DESCRIPTION
it fixes bug found while working on custom api example PR: https://github.com/Payum/PayumBundleSandbox/pull/30
