### PR TITLE
POST redirect in capture action for Omnipay Bridge

### DIFF
--- a/src/Payum/OmnipayBridge/Action/CaptureAction.php
+++ b/src/Payum/OmnipayBridge/Action/CaptureAction.php
@@ -28,7 +28,14 @@ class CaptureAction extends BaseApiAwareAction
         }
 
         if ($response->isRedirect()) {
-            throw new RedirectUrlInteractiveRequest($response->getRedirectUrl());
+            $options['_completeCaptureRequired'] = 1;
+            
+            if ($response->getRedirectMethod() == 'POST') {
+                throw new PostRedirectUrlInteractiveRequest($response->getRedirectUrl(), $response->getRedirectData());
+            }
+            else {
+                throw new RedirectUrlInteractiveRequest($response->getRedirectUrl());
+            }
         }
 
         $options['_reference']      = $response->getTransactionReference();


### PR DESCRIPTION
At the moment there is only possible to do GET redirect if purchase method returns redirect response. It should be possible to perform POST redirect if getRedirectMethod() (from Omnipay\Common\Message\RedirectResponseInterface) returns "POST".

I have also added $options['_completeCaptureRequired'] = 1 if the redirect is required. In this action we check if _completeCaptureRequired option is set:

if (isset($options['_completeCaptureRequired'])) {
    unset($options['_completeCaptureRequired']);
    $response = $this->gateway->completePurchase($options->toUnsafeArray())->send();
} else {
    $response = $this->gateway->purchase($options->toUnsafeArray())->send();
}

but there isn't any place where the option is set. I believe it was accidentally removed in commit 2ade68323fa13d4d149259a2933e3ea1d8e205d8

@makasim Answering your question - yes, it will work will omnipay 1
