### PR TITLE
Fix typos in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "payum/payum",
     "type": "library",
-    "description": "Domain friendly payment framework. Paypal, payex, authorize.net, be2bill, omnipay, recurring paymens, instant notifications and many more",
+    "description": "Domain friendly payment framework. Paypal, payex, authorize.net, be2bill, omnipay, recurring payments, instant notifications and many more",
     "keywords": [
         "payment",
         "recurring payment",

--- a/src/Payum/Core/composer.json
+++ b/src/Payum/Core/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "payum/core",
     "type": "library",
-    "description": "Domain friendly payment framework. Paypal, payex, authorize.net, be2bill, omnipay, recurring paymens, instant notifications and many more",
+    "description": "Domain friendly payment framework. Paypal, payex, authorize.net, be2bill, omnipay, recurring payments, instant notifications and many more",
     "keywords": [
         "payment",
         "recurring payment",


### PR DESCRIPTION
Typo in composer.json's.  Typo also exists in the repo description.
