### PR TITLE
Fixed small typo in doc files

### DIFF
--- a/src/Payum/AuthorizeNet/Aim/Resources/docs/get-it-started.md
+++ b/src/Payum/AuthorizeNet/Aim/Resources/docs/get-it-started.md
@@ -15,7 +15,7 @@ php composer.phar require "payum/authorize-net-aim:*@stable"
 
 ## config.php
 
-We have to only add a the payment factory. All the rest remain the same:
+We have to only add the payment factory. All the rest remain the same:
 
 ```php
 <?php

--- a/src/Payum/Be2Bill/Resources/docs/get-it-started.md
+++ b/src/Payum/Be2Bill/Resources/docs/get-it-started.md
@@ -15,7 +15,7 @@ php composer.phar require "payum/be2bill:*@stable"
 
 ## config.php
 
-We have to only add a the payment factory. All the rest remain the same:
+We have to only add the payment factory. All the rest remain the same:
 
 ```php
 <?php

--- a/src/Payum/Payex/Resources/docs/get-it-started.md
+++ b/src/Payum/Payex/Resources/docs/get-it-started.md
@@ -15,7 +15,7 @@ php composer.phar require "payum/payex:*@stable"
 
 ## config.php
 
-We have to only add a the payment factory. All the rest remain the same:
+We have to only add the payment factory. All the rest remain the same:
 
 ```php
 <?php

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Resources/docs/get-it-started.md
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Resources/docs/get-it-started.md
@@ -15,7 +15,7 @@ php composer.phar require "payum/paypal-express-checkout-nvp:*@stable"
 
 ## config.php
 
-We have to only add a the payment factory. All the rest remain the same:
+We have to only add the payment factory. All the rest remain the same:
 
 ```php
 <?php

--- a/src/Payum/Paypal/ProCheckout/Nvp/Resources/docs/get-it-started.md
+++ b/src/Payum/Paypal/ProCheckout/Nvp/Resources/docs/get-it-started.md
@@ -15,7 +15,7 @@ php composer.phar require "payum/paypal-pro-checkout-nvp:*@stable"
 
 ## config.php
 
-We have to only add a the payment factory. All the rest remain the same:
+We have to only add the payment factory. All the rest remain the same:
 
 
 ```php

--- a/src/Payum/Stripe/Resources/docs/checkout.md
+++ b/src/Payum/Stripe/Resources/docs/checkout.md
@@ -15,7 +15,7 @@ php composer.phar require "payum/stripe:*@stable"
 
 ## config.php
 
-We have to only add a the payment factory. All the rest remain the same:
+We have to only add the payment factory. All the rest remain the same:
 
 ```php
 <?php

--- a/src/Payum/Stripe/Resources/docs/get-it-started.md
+++ b/src/Payum/Stripe/Resources/docs/get-it-started.md
@@ -15,7 +15,7 @@ php composer.phar require "payum/stripe:*@stable"
 
 ## config.php
 
-We have to only add a the payment factory. All the rest remain the same:
+We have to only add the payment factory. All the rest remain the same:
 
 ```php
 <?php


### PR DESCRIPTION
Small fix here. the `a the` looked a bit weird. 
