### PR TITLE
Fix BOM at start of stream

### DIFF
--- a/src/Payum/Core/Bridge/Buzz/JsonResponse.php
+++ b/src/Payum/Core/Bridge/Buzz/JsonResponse.php
@@ -13,9 +13,16 @@ class JsonResponse extends Response
      */
     public function getContentJson()
     {
-        $json = json_decode($this->getContent());
+        $content = $this->getContent();
+
+        // Remove unexpected utf8 BOM
+        if(substr($content, 0, 3) == pack('CCC', 239, 187, 191)) {
+            $content = substr($content, 3);
+        }
+
+        $json = json_decode($content);
         if (null === $json) {
-            throw new LogicException("Response content is not valid json: \n\n{$this->getContent()}");
+            throw new LogicException("Response content is not valid json: \n\n".$content);
         }
 
         return $json;

--- a/src/Payum/Core/Bridge/Buzz/JsonResponse.php
+++ b/src/Payum/Core/Bridge/Buzz/JsonResponse.php
@@ -7,11 +7,13 @@ use Payum\Core\Exception\LogicException;
 class JsonResponse extends Response
 {
     /**
+     * @param bool $array Whether to decode json in array (default false)
+     *
      * @throws \Payum\Core\Exception\LogicException
      *
      * @return array|object
      */
-    public function getContentJson()
+    public function getContentJson($array = false)
     {
         $content = $this->getContent();
 
@@ -20,7 +22,7 @@ class JsonResponse extends Response
             $content = substr($content, 3);
         }
 
-        $json = json_decode($content);
+        $json = json_decode($content, $array);
         if (null === $json) {
             throw new LogicException("Response content is not valid json: \n\n".$content);
         }

--- a/src/Payum/Core/Tests/Bridge/Buzz/JsonResponseTest.php
+++ b/src/Payum/Core/Tests/Bridge/Buzz/JsonResponseTest.php
@@ -1,0 +1,35 @@
+<?php
+namespace Payum\Core\Tests\Bridge\Buzz;
+
+use Payum\Core\Bridge\Buzz\JsonResponse;
+
+class JsonResponseTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldDecodeJson()
+    {
+        $obj = new \stdClass();
+        $obj->foo = 'bar';
+
+        $response = new JsonResponse();
+        $response->setContent(json_encode($obj));
+
+        $this->assertEquals($obj, $response->getContentJson());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldDecodeJsonWithBOM()
+    {
+        $obj = new \stdClass();
+        $obj->foo = 'bar';
+
+        $response = new JsonResponse();
+        $response->setContent(pack('CCC', 239, 187, 191).json_encode($obj));
+
+        $this->assertEquals($obj, $response->getContentJson());
+    }
+}

--- a/src/Payum/Core/Tests/Bridge/Buzz/JsonResponseTest.php
+++ b/src/Payum/Core/Tests/Bridge/Buzz/JsonResponseTest.php
@@ -32,4 +32,20 @@ class JsonResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($obj, $response->getContentJson());
     }
+
+    /**
+     * @test
+     */
+    public function shouldDecodeJsonInArray()
+    {
+        $array = array('foo' => 'bar');
+
+        $response = new JsonResponse();
+        $response->setContent(json_encode($array));
+
+        $content = $response->getContentJson(true);
+
+        $this->assertInternalType('array', $content);
+        $this->assertEquals($array, $content);
+    }
 }


### PR DESCRIPTION
Blank utf8 character that makes json_decode fail because of syntax error.
cf. http://en.wikipedia.org/wiki/Byte_order_mark