### PR TITLE
Fix error in payment name

### DIFF
--- a/src/Payum/Paypal/ProCheckout/Nvp/Resources/docs/get-it-started.md
+++ b/src/Payum/Paypal/ProCheckout/Nvp/Resources/docs/get-it-started.md
@@ -1,6 +1,6 @@
 # Get it started.
 
-In this chapter we are going to talk about the most common task: purchase of a product using [Paypal ExpressCheckout](https://www.paypal.com/webapps/mpp/paypal-payments-pro).
+In this chapter we are going to talk about the most common task: purchase of a product using [Paypal Pro Checkout](https://www.paypal.com/webapps/mpp/paypal-payments-pro).
 We assume you already read [get it started](https://github.com/Payum/Payum/blob/master/src/Payum/Core/Resources/docs/get-it-started.md) from core.
 Here we just show you modifications you have to put to the files shown there.
 


### PR DESCRIPTION
In http://payum.org/doc/0.14/PaypalProCheckoutNvp/get-it-started the description links to the right paypal page, but the linked name is still paypal express, it should be pay pal pro checkout.