### PR TITLE
[Authorize.NET] Update order fields name.

### DIFF
--- a/src/Payum/AuthorizeNet/Aim/Action/FillOrderDetailsAction.php
+++ b/src/Payum/AuthorizeNet/Aim/Action/FillOrderDetailsAction.php
@@ -21,10 +21,10 @@ class FillOrderDetailsAction implements ActionInterface
 
         $details = $order->getDetails();
         $details['amount'] = $order->getTotalAmount() / $divisor;
-        $details['invoice_number'] = $order->getNumber();
+        $details['invoice_num'] = $order->getNumber();
         $details['description'] = $order->getDescription();
-        $details['email_address'] = $order->getClientEmail();
-        $details['customer_id'] = $order->getClientId();
+        $details['email'] = $order->getClientEmail();
+        $details['cust_id'] = $order->getClientId();
 
         $order->setDetails($details);
     }

--- a/src/Payum/AuthorizeNet/Aim/Tests/Action/FillOrderDetailsActionTest.php
+++ b/src/Payum/AuthorizeNet/Aim/Tests/Action/FillOrderDetailsActionTest.php
@@ -55,17 +55,17 @@ class FillOrderDetailsActionTest extends GenericActionTest
         $this->assertArrayHasKey('amount', $details);
         $this->assertEquals(1.23, $details['amount']);
 
-        $this->assertArrayHasKey('invoice_number', $details);
-        $this->assertEquals('theNumber', $details['invoice_number']);
+        $this->assertArrayHasKey('invoice_num', $details);
+        $this->assertEquals('theNumber', $details['invoice_num']);
 
         $this->assertArrayHasKey('description', $details);
         $this->assertEquals('the description', $details['description']);
 
-        $this->assertArrayHasKey('customer_id', $details);
-        $this->assertEquals('theClientId', $details['customer_id']);
+        $this->assertArrayHasKey('cust_id', $details);
+        $this->assertEquals('theClientId', $details['cust_id']);
 
-        $this->assertArrayHasKey('email_address', $details);
-        $this->assertEquals('theClientEmail', $details['email_address']);
+        $this->assertArrayHasKey('email', $details);
+        $this->assertEquals('theClientEmail', $details['email']);
     }
 
     /**


### PR DESCRIPTION
Hi guys,

Not sure whether Authorize.NET updated their SDK but this PR fixes some fields name in the order details as per this definition (line 80): https://github.com/AuthorizeNet/sdk-php/blob/master/lib/AuthorizeNetAIM.php

Currently, the invoice number, email and customer ID are not populated or causing an error if these fields are set as required.