### PR TITLE
Fix GetHumanStatus implementation

### DIFF
--- a/src/Payum/Core/Request/GetHumanStatus.php
+++ b/src/Payum/Core/Request/GetHumanStatus.php
@@ -184,12 +184,12 @@ class GetHumanStatus extends BaseGetStatus
     }
 
     /**
-     * @param int $expectedStatus
+     * @param string $expectedStatus
      *
      * @return boolean
      */
     protected function isCurrentStatusEqualTo($expectedStatus)
     {
-        return ($expectedStatus | $this->getValue()) == $expectedStatus;
+        return $this->getValue() === $expectedStatus;
     }
 }


### PR DESCRIPTION
It work as is because the binary OR between to identical strings returns this string but it's clearly not the best way to compare string. Most probably a copy/paste error with GetBinaryStatus :)