### PR TITLE
Do not use the Cipher List for NSS

### DIFF
--- a/src/Payum/Core/Bridge/Buzz/ClientFactory.php
+++ b/src/Payum/Core/Bridge/Buzz/ClientFactory.php
@@ -15,7 +15,12 @@ class ClientFactory
         //reaction to the ssl3.0 shutdown from paypal
         //https://www.paypal-community.com/t5/PayPal-Forward/PayPal-Response-to-SSL-3-0-Vulnerability-aka-POODLE/ba-p/891829
         //http://googleonlinesecurity.blogspot.com/2014/10/this-poodle-bites-exploiting-ssl-30.html
-        $client->setOption(CURLOPT_SSL_CIPHER_LIST, 'TLSv1');
+        $curl = curl_version();
+        $sslVersion = isset($curl['ssl_version']) ? $curl['ssl_version'] : '';
+        //Do not use the Cipher List for NSS
+        if (substr_compare($sslVersion, "NSS/", 0, strlen("NSS/")) !== 0) {
+            $client->setOption(CURLOPT_SSL_CIPHER_LIST, 'TLSv1');
+        }
 
         //There is a constant for that CURL_SSLVERSION_TLSv1, but it is not present on some versions of php.
         $client->setOption(CURLOPT_SSLVERSION, $curlSslVersionTlsV1 = 1);


### PR DESCRIPTION
According to this issues:
https://github.com/Payum/Payum/issues/250
https://github.com/Payum/PayumBundle/issues/294

I know that in the current master branch Buzz replaced by the Guzzle PSR-7, but a lot of projects uses stable branch. Could you fix this issue in the current stable version?