### PR TITLE
[paypal-ec] add support of order confirmation step.

### DIFF
--- a/src/Payum/Core/Bridge/Twig/TwigFactory.php
+++ b/src/Payum/Core/Bridge/Twig/TwigFactory.php
@@ -1,6 +1,9 @@
 <?php
 namespace Payum\Core\Bridge\Twig;
 
+/**
+ * @deprecated since 1.0.0-BETA4
+ */
 class TwigFactory
 {
     /**

--- a/src/Payum/Klarna/Checkout/KlarnaCheckoutGatewayFactory.php
+++ b/src/Payum/Klarna/Checkout/KlarnaCheckoutGatewayFactory.php
@@ -70,5 +70,9 @@ class KlarnaCheckoutGatewayFactory extends GatewayFactory
                 return $klarnaConfig;
             };
         }
+
+        $config['payum.paths'] = array_replace([
+            'PayumKlarnaCheckout' => __DIR__.'/Resources/views',
+        ], $config['payum.paths'] ?: []);
     }
 }

--- a/src/Payum/Klarna/Checkout/Tests/KlarnaCheckoutGatewayFactoryTest.php
+++ b/src/Payum/Klarna/Checkout/Tests/KlarnaCheckoutGatewayFactoryTest.php
@@ -160,4 +160,28 @@ class KlarnaCheckoutGatewayFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->create();
     }
+
+    /**
+     * @test
+     */
+    public function shouldConfigurePaths()
+    {
+        $factory = new KlarnaCheckoutGatewayFactory();
+
+        $config = $factory->createConfig();
+
+        $this->assertInternalType('array', $config);
+        $this->assertNotEmpty($config);
+
+        $this->assertInternalType('array', $config['payum.paths']);
+        $this->assertNotEmpty($config['payum.paths']);
+
+        $this->assertArrayHasKey('PayumCore', $config['payum.paths']);
+        $this->assertStringEndsWith('Resources/views', $config['payum.paths']['PayumCore']);
+        $this->assertTrue(file_exists($config['payum.paths']['PayumCore']));
+
+        $this->assertArrayHasKey('PayumKlarnaCheckout', $config['payum.paths']);
+        $this->assertStringEndsWith('Resources/views', $config['payum.paths']['PayumKlarnaCheckout']);
+        $this->assertTrue(file_exists($config['payum.paths']['PayumKlarnaCheckout']));
+    }
 }

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Action/Api/ConfirmOrderAction.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Action/Api/ConfirmOrderAction.php
@@ -1,0 +1,75 @@
+<?php
+namespace Payum\Paypal\ExpressCheckout\Nvp\Action\Api;
+
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Exception\LogicException;
+use Payum\Core\GatewayAwareInterface;
+use Payum\Core\GatewayInterface;
+use Payum\Core\Reply\HttpResponse;
+use Payum\Core\Request\GetHttpRequest;
+use Payum\Core\Request\RenderTemplate;
+use Payum\Paypal\ExpressCheckout\Nvp\Request\Api\ConfirmOrder;
+use Payum\Paypal\ExpressCheckout\Nvp\Request\Api\SetExpressCheckout;
+
+class ConfirmOrderAction extends BaseApiAwareAction implements GatewayAwareInterface
+{
+    /**
+     * @var GatewayInterface
+     */
+    protected $gateway;
+
+    /**
+     * @var string
+     */
+    private $templateName;
+
+    /**
+     * @param string $templateName
+     */
+    public function __construct($templateName)
+    {
+        $this->templateName = $templateName;
+    }
+
+    /**
+     * @param GatewayInterface $gateway
+     */
+    public function setGateway(GatewayInterface $gateway)
+    {
+        $this->gateway = $gateway;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function execute($request)
+    {
+        /** @var $request SetExpressCheckout */
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        $this->gateway->execute($httpRequest = new GetHttpRequest());
+        if ('POST' == $httpRequest->method && false == empty($httpRequest->request['confirm'])) {
+            return;
+        }
+
+        $renderTemplate = new RenderTemplate($this->templateName, array(
+            'model' => ArrayObject::ensureArrayObject($request->getModel()),
+            'firstModel' => $request->getFirstModel(),
+        ));
+        $this->gateway->execute($renderTemplate);
+
+        throw new HttpResponse($renderTemplate->getResult());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports($request)
+    {
+        return
+            $request instanceof ConfirmOrder &&
+            $request->getModel() instanceof \ArrayAccess
+        ;
+    }
+}

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Action/CaptureAction.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Action/CaptureAction.php
@@ -79,7 +79,7 @@ class CaptureAction extends GatewayAwareAction implements GenericTokenFactoryAwa
             Api::CHECKOUTSTATUS_PAYMENT_ACTION_NOT_INITIATED == $details['CHECKOUTSTATUS'] &&
             $details['PAYMENTREQUEST_0_AMT'] > 0
         ) {
-            if (Api::USERACTION_COMMIT == $details['AUTHORIZE_TOKEN_USERACTION']) {
+            if (Api::USERACTION_COMMIT !== $details['AUTHORIZE_TOKEN_USERACTION']) {
                 $confirmOrder = new ConfirmOrder($request->getFirstModel());
                 $confirmOrder->setModel($request->getModel());
 

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/PaypalExpressCheckoutGatewayFactory.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/PaypalExpressCheckoutGatewayFactory.php
@@ -3,6 +3,7 @@ namespace Payum\Paypal\ExpressCheckout\Nvp;
 
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\GatewayFactory;
+use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\ConfirmOrderAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\CreateRecurringPaymentProfileAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\DoExpressCheckoutPaymentAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\GetExpressCheckoutDetailsAction;
@@ -34,6 +35,8 @@ class PaypalExpressCheckoutGatewayFactory extends GatewayFactory
             'payum.factory_name' => 'paypal_express_checkout_nvp',
             'payum.factory_title' => 'PayPal ExpressCheckout',
 
+            'payum.template.confirm_order' => '@PayumPaypalExpressCheckout/confirmOrder.html.twig',
+
             'payum.action.capture' => new CaptureAction(),
             'payum.action.convert_payment' => new ConvertPaymentAction(),
             'payum.action.notify' => new NotifyAction(),
@@ -54,6 +57,9 @@ class PaypalExpressCheckoutGatewayFactory extends GatewayFactory
             'payum.action.api.create_billing_agreement' => new CreateBillingAgreementAction(),
             'payum.action.api.do_reference_transaction' => new DoReferenceTransactionAction(),
             'payum.action.api.authorize_token' => new AuthorizeTokenAction(),
+            'payum.action.api.confirm_order' => function (ArrayObject $config) {
+                return new ConfirmOrderAction($config['payum.template.confirm_order']);
+            },
         ));
 
         if (false == $config['payum.api']) {
@@ -79,5 +85,9 @@ class PaypalExpressCheckoutGatewayFactory extends GatewayFactory
                 return new Api($paypalConfig, $config['payum.http_client']);
             };
         }
+
+        $config['payum.paths'] = array_replace([
+            'PayumPaypalExpressCheckout' => __DIR__.'/Resources/views',
+        ], $config['payum.paths'] ?: []);
     }
 }

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Request/Api/ConfirmOrder.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Request/Api/ConfirmOrder.php
@@ -1,0 +1,8 @@
+<?php
+namespace Payum\Paypal\ExpressCheckout\Nvp\Request\Api;
+
+use Payum\Core\Request\Generic;
+
+class ConfirmOrder extends Generic
+{
+}

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Resources/docs/confirm-order-step.md
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Resources/docs/confirm-order-step.md
@@ -1,0 +1,41 @@
+# Confirm order step.
+
+Paypal official documentation [suggest you to show a confirm order page](https://developer.paypal.com/docs/classic/express-checkout/integration-guide/ECGettingStarted/#id084RN0F0OPN), once user is back from Paypal.
+By default Payum skip this step, at Paypal site you will see "Pay Now" button. If you want to use confirm step you have to reset
+`AUTHORIZE_TOKEN_USERACTION`. Set it to empty string
+
+```
+<?php
+// prepare.php
+
+$payment->setDetails(array(
+  'AUTHORIZE_TOKEN_USERACTION' => '',
+));
+```
+
+That's it. Payum will render a page with a confirm button. The page is pretty simple and you most likely want to customize it.
+You can tell the gateway to use your own template by providing it in the gateway config.
+
+```
+<?php
+// config.php
+
+```php
+<?php
+//config.php
+
+use Payum\Core\PayumBuilder;
+use Payum\Core\Payum;
+
+/** @var Payum $payum */
+$payum = (new PayumBuilder())
+    ->addGateway('gatewayName', [
+        'factory' => 'paypal_express_checkout'
+        'payum.template.confirm_order' => '@Acme/confirm_paypal_order.html.twig',
+    ])
+
+    ->getPayum()
+;
+```
+
+Back to [index](index.md).

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Resources/docs/index.md
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Resources/docs/index.md
@@ -1,7 +1,9 @@
-#Payum Paypal ExpressCheckout Nvp
+# Payum Paypal ExpressCheckout Nvp
 
 * [Get it started](get-it-started.md)
 * [Recurring payments basics](recurring-payments-basics.md)
 * [Cancel recurring payment](cancel-recurring-payment.md)
+* [Confirm order step](confirm-order-step.md)
 * [Authorize token custom query parameters](authorize-token-custom-query-parameters.md)
+
 

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Resources/docs/recurring-payments-basics.md
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Resources/docs/recurring-payments-basics.md
@@ -1,4 +1,4 @@
-# Recurring payments basics.
+ # Recurring payments basics.
 
 In this chapter we describe the basic steps you have to follow to set up recurring payments.
 We will use weather subscription as example.

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Resources/views/confirmOrder.html.twig
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Resources/views/confirmOrder.html.twig
@@ -1,0 +1,7 @@
+{% extends layout ?: "@PayumCore/layout.html.twig" %}
+
+{% block payum_body %}
+    <form method="POST">
+        <input type="submit" name="confirm" value="I confirm order purchase">
+    </form>
+{% endblock %}

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/Api/CancelRecurringPaymentsProfileActionTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/Api/CancelRecurringPaymentsProfileActionTest.php
@@ -9,7 +9,6 @@ use Payum\Core\Tests\GenericActionTest;
 
 class CancelRecurringPaymentsProfileActionTest extends GenericActionTest
 {
-
     /**
      * @var Generic
      */
@@ -36,7 +35,7 @@ class CancelRecurringPaymentsProfileActionTest extends GenericActionTest
             array(new \stdClass()),
             array(new $this->requestClass('foo')),
             array(new $this->requestClass(new \stdClass())),
-            array($this->getMockForAbstractClass('Payum\Core\Request\Generic', array(array()))),
+            array($this->getMockForAbstractClass(Generic::class, array(array()))),
         );
     }
 

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/Api/ConfirmOrderActionTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/Api/ConfirmOrderActionTest.php
@@ -1,0 +1,174 @@
+<?php
+namespace Payum\Paypal\ExpressCheckout\Nvp\Tests\Action;
+
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\GatewayAwareInterface;
+use Payum\Core\Reply\HttpResponse;
+use Payum\Core\Request\GetHttpRequest;
+use Payum\Core\Request\RenderTemplate;
+use Payum\Core\Tests\GenericActionTest;
+use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\ConfirmOrderAction;
+use Payum\Paypal\ExpressCheckout\Nvp\Request\Api\ConfirmOrder;
+
+class ConfirmOrderActionTest extends GenericActionTest
+{
+    protected $requestClass = ConfirmOrder::class;
+
+    protected $actionClass = ConfirmOrderAction::class;
+
+    protected function setUp()
+    {
+        $this->action = new ConfirmOrderAction('theConfirmOrderTemplate');
+    }
+
+    public function couldBeConstructedWithoutAnyArguments()
+    {
+        //overwrite
+    }
+
+    /**
+     * @test
+     */
+    public function shouldBeSubClassOfGatewayAwareAction()
+    {
+        $rc = new \ReflectionClass(ConfirmOrderAction::class);
+
+        $this->assertTrue($rc->isSubclassOf(GatewayAwareInterface::class));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldRenderConfirmOrderTemplateIfHttpRequestNotPost()
+    {
+        $firstModel = new \stdClass();
+        $model = new \ArrayObject(['foo' => 'fooVal', 'bar' => 'barVal']);
+
+
+        $gatewayMock = $this->createGatewayMock();
+        $gatewayMock
+            ->expects($this->at(0))
+            ->method('execute')
+            ->with($this->isInstanceOf(GetHttpRequest::class))
+            ->willReturnCallback(function (GetHttpRequest $request) {
+                $request->method = 'GET';
+            })
+        ;
+        $gatewayMock
+            ->expects($this->at(1))
+            ->method('execute')
+            ->with($this->isInstanceOf(RenderTemplate::class))
+            ->willReturnCallback(function (RenderTemplate $request) use ($firstModel, $model) {
+                $this->assertEquals('theConfirmOrderTemplate', $request->getTemplateName());
+                $this->assertSame($firstModel, $request->getParameters()['firstModel']);
+
+                $this->assertInstanceOf(ArrayObject::class, $request->getParameters()['model']);
+                $this->assertSame(['foo' => 'fooVal', 'bar' => 'barVal'], (array) $request->getParameters()['model']);
+
+                $request->setResult('thePage');
+            })
+        ;
+
+        $request = new ConfirmOrder($firstModel);
+        $request->setModel($model);
+
+        $this->action->setGateway($gatewayMock);
+
+        try {
+            $this->action->execute($request);
+        } catch (HttpResponse $reply) {
+            $this->assertEquals(200, $reply->getStatusCode());
+            $this->assertEquals('thePage', $reply->getContent());
+
+            return;
+        }
+
+        $this->fail('The exception is expected');
+    }
+
+    /**
+     * @test
+     */
+    public function shouldStillRenderConfirmOrderTemplateIfHttpRequestPostButWithoutConfirm()
+    {
+        $firstModel = new \stdClass();
+        $model = new \ArrayObject(['foo' => 'fooVal', 'bar' => 'barVal']);
+
+
+        $gatewayMock = $this->createGatewayMock();
+        $gatewayMock
+            ->expects($this->at(0))
+            ->method('execute')
+            ->with($this->isInstanceOf(GetHttpRequest::class))
+            ->willReturnCallback(function (GetHttpRequest $request) {
+                $request->method = 'POST';
+            })
+        ;
+        $gatewayMock
+            ->expects($this->at(1))
+            ->method('execute')
+            ->with($this->isInstanceOf(RenderTemplate::class))
+            ->willReturnCallback(function (RenderTemplate $request) use ($firstModel, $model) {
+                $this->assertEquals('theConfirmOrderTemplate', $request->getTemplateName());
+                $this->assertSame($firstModel, $request->getParameters()['firstModel']);
+
+                $this->assertInstanceOf(ArrayObject::class, $request->getParameters()['model']);
+                $this->assertSame(['foo' => 'fooVal', 'bar' => 'barVal'], (array) $request->getParameters()['model']);
+
+                $request->setResult('thePage');
+            })
+        ;
+
+        $request = new ConfirmOrder($firstModel);
+        $request->setModel($model);
+
+        $this->action->setGateway($gatewayMock);
+
+        try {
+            $this->action->execute($request);
+        } catch (HttpResponse $reply) {
+            $this->assertEquals(200, $reply->getStatusCode());
+            $this->assertEquals('thePage', $reply->getContent());
+
+            return;
+        }
+
+        $this->fail('The exception is expected');
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGiveControllBackIfHttpRequestPostWithConfirm()
+    {
+        $firstModel = new \stdClass();
+        $model = new \ArrayObject(['foo' => 'fooVal', 'bar' => 'barVal']);
+
+
+        $gatewayMock = $this->createGatewayMock();
+        $gatewayMock
+            ->expects($this->once())
+            ->method('execute')
+            ->with($this->isInstanceOf(GetHttpRequest::class))
+            ->willReturnCallback(function (GetHttpRequest $request) {
+                $request->method = 'POST';
+                $request->request = ['confirm' => 1];
+            })
+        ;
+
+        $request = new ConfirmOrder($firstModel);
+        $request->setModel($model);
+
+        $this->action->setGateway($gatewayMock);
+
+        $this->action->execute($request);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\Payum\Core\GatewayInterface
+     */
+    protected function createGatewayMock()
+    {
+        return $this->getMock('Payum\Core\GatewayInterface');
+    }
+}

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/CaptureActionTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/CaptureActionTest.php
@@ -3,9 +3,12 @@ namespace Payum\Paypal\ExpressCheckout\Nvp\Tests\Action;
 
 use Payum\Core\Model\Token;
 use Payum\Core\Request\Capture;
+use Payum\Core\Request\Sync;
 use Payum\Core\Tests\GenericActionTest;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\CaptureAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Api;
+use Payum\Paypal\ExpressCheckout\Nvp\Request\Api\ConfirmOrder;
+use Payum\Paypal\ExpressCheckout\Nvp\Request\Api\DoExpressCheckoutPayment;
 use Payum\Paypal\ExpressCheckout\Nvp\Request\Api\SetExpressCheckout;
 
 class CaptureActionTest extends GenericActionTest
@@ -162,7 +165,7 @@ class CaptureActionTest extends GenericActionTest
         $gatewayMock
             ->expects($this->at(0))
             ->method('execute')
-            ->with($this->isInstanceOf('Payum\Core\Request\Sync'))
+            ->with($this->isInstanceOf(Sync::class))
         ;
 
         $action = new CaptureAction();
@@ -176,24 +179,59 @@ class CaptureActionTest extends GenericActionTest
     /**
      * @test
      */
-    public function shouldRequestDoExpressCheckoutGatewayActionIfCheckoutStatusNotInitiatedAndPayerIdSetInModel()
+    public function shouldRequestDoExpressCheckoutGatewayActionIfCheckoutStatusNotInitiatedAndPayerIdSetInModelAndUserActionNotCommit()
     {
         $gatewayMock = $this->createGatewayMock();
         $gatewayMock
             ->expects($this->at(1))
             ->method('execute')
-            ->with($this->isInstanceOf('Payum\Paypal\ExpressCheckout\Nvp\Request\Api\DoExpressCheckoutPayment'))
+            ->with($this->isInstanceOf(DoExpressCheckoutPayment::class))
         ;
         $gatewayMock
             ->expects($this->at(2))
             ->method('execute')
-            ->with($this->isInstanceOf('Payum\Core\Request\Sync'))
+            ->with($this->isInstanceOf(Sync::class))
         ;
 
         $action = new CaptureAction();
         $action->setGateway($gatewayMock);
 
         $action->execute(new Capture(array(
+            'AUTHORIZE_TOKEN_USERACTION' => '',
+            'TOKEN' => 'aToken',
+            'PAYERID' => 'aPayerId',
+            'PAYMENTREQUEST_0_AMT' => 5,
+            'CHECKOUTSTATUS' => Api::CHECKOUTSTATUS_PAYMENT_ACTION_NOT_INITIATED,
+        )));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldRequestConfirmOrderActionIfCheckoutStatusNotInitiatedAndPayerIdSetInModelAndUserActionCommit()
+    {
+        $gatewayMock = $this->createGatewayMock();
+        $gatewayMock
+            ->expects($this->at(1))
+            ->method('execute')
+            ->with($this->isInstanceOf(ConfirmOrder::class))
+        ;
+        $gatewayMock
+            ->expects($this->at(2))
+            ->method('execute')
+            ->with($this->isInstanceOf(DoExpressCheckoutPayment::class))
+        ;
+        $gatewayMock
+            ->expects($this->at(3))
+            ->method('execute')
+            ->with($this->isInstanceOf(Sync::class))
+        ;
+
+        $action = new CaptureAction();
+        $action->setGateway($gatewayMock);
+
+        $action->execute(new Capture(array(
+            'AUTHORIZE_TOKEN_USERACTION' => Api::USERACTION_COMMIT,
             'TOKEN' => 'aToken',
             'PAYERID' => 'aPayerId',
             'PAYMENTREQUEST_0_AMT' => 5,
@@ -210,7 +248,7 @@ class CaptureActionTest extends GenericActionTest
         $gatewayMock
             ->expects($this->at(0))
             ->method('execute')
-            ->with($this->isInstanceOf('Payum\Core\Request\Sync'))
+            ->with($this->isInstanceOf(Sync::class))
         ;
 
         $action = new CaptureAction();
@@ -232,12 +270,12 @@ class CaptureActionTest extends GenericActionTest
         $gatewayMock
             ->expects($this->at(0))
             ->method('execute')
-            ->with($this->isInstanceOf('Payum\Core\Request\Sync'))
+            ->with($this->isInstanceOf(Sync::class))
         ;
         $gatewayMock
             ->expects($this->at(1))
             ->method('execute')
-            ->with($this->isInstanceOf('Payum\Core\Request\Sync'))
+            ->with($this->isInstanceOf(Sync::class))
         ;
 
         $action = new CaptureAction();
@@ -258,12 +296,12 @@ class CaptureActionTest extends GenericActionTest
         $gatewayMock
             ->expects($this->at(0))
             ->method('execute')
-            ->with($this->isInstanceOf('Payum\Core\Request\Sync'))
+            ->with($this->isInstanceOf(Sync::class))
         ;
         $gatewayMock
             ->expects($this->at(1))
             ->method('execute')
-            ->with($this->isInstanceOf('Payum\Core\Request\Sync'))
+            ->with($this->isInstanceOf(Sync::class))
         ;
 
         $action = new CaptureAction();

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/CaptureActionTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/CaptureActionTest.php
@@ -179,7 +179,7 @@ class CaptureActionTest extends GenericActionTest
     /**
      * @test
      */
-    public function shouldRequestDoExpressCheckoutGatewayActionIfCheckoutStatusNotInitiatedAndPayerIdSetInModelAndUserActionNotCommit()
+    public function shouldRequestDoExpressCheckoutGatewayActionIfCheckoutStatusNotInitiatedAndPayerIdSetInModelAndUserActionCommit()
     {
         $gatewayMock = $this->createGatewayMock();
         $gatewayMock
@@ -197,7 +197,7 @@ class CaptureActionTest extends GenericActionTest
         $action->setGateway($gatewayMock);
 
         $action->execute(new Capture(array(
-            'AUTHORIZE_TOKEN_USERACTION' => '',
+            'AUTHORIZE_TOKEN_USERACTION' => Api::USERACTION_COMMIT,
             'TOKEN' => 'aToken',
             'PAYERID' => 'aPayerId',
             'PAYMENTREQUEST_0_AMT' => 5,
@@ -208,7 +208,7 @@ class CaptureActionTest extends GenericActionTest
     /**
      * @test
      */
-    public function shouldRequestConfirmOrderActionIfCheckoutStatusNotInitiatedAndPayerIdSetInModelAndUserActionCommit()
+    public function shouldRequestConfirmOrderActionIfCheckoutStatusNotInitiatedAndPayerIdSetInModelAndUserActionNotCommit()
     {
         $gatewayMock = $this->createGatewayMock();
         $gatewayMock
@@ -231,7 +231,7 @@ class CaptureActionTest extends GenericActionTest
         $action->setGateway($gatewayMock);
 
         $action->execute(new Capture(array(
-            'AUTHORIZE_TOKEN_USERACTION' => Api::USERACTION_COMMIT,
+            'AUTHORIZE_TOKEN_USERACTION' => '',
             'TOKEN' => 'aToken',
             'PAYERID' => 'aPayerId',
             'PAYMENTREQUEST_0_AMT' => 5,

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/ConvertPaymentActionTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/ConvertPaymentActionTest.php
@@ -2,6 +2,7 @@
 namespace Payum\Paypal\ExpressCheckout\Nvp\Tests\Action\Api;
 
 use Payum\Core\Model\PaymentInterface;
+use Payum\Core\Request\Generic;
 use Payum\Core\Request\GetCurrency;
 use Payum\Core\Tests\GenericActionTest;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\ConvertPaymentAction;
@@ -29,7 +30,7 @@ class ConvertPaymentActionTest extends GenericActionTest
             array('foo'),
             array(array('foo')),
             array(new \stdClass()),
-            array($this->getMockForAbstractClass('Payum\Core\Request\Generic', array(array()))),
+            array($this->getMockForAbstractClass(Generic::class, array(array()))),
             array(new $this->requestClass(new \stdClass(), 'array')),
             array(new $this->requestClass(new Payment(), 'foobar')),
             array(new $this->requestClass($this->getMock(PaymentInterface::class), 'foobar')),

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/PaypalExpressCheckoutGatewayFactoryTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/PaypalExpressCheckoutGatewayFactoryTest.php
@@ -167,4 +167,28 @@ class PaypalExpressCheckoutGatewayFactoryTest extends \PHPUnit_Framework_TestCas
 
         $factory->create();
     }
+
+    /**
+     * @test
+     */
+    public function shouldConfigurePaths()
+    {
+        $factory = new PaypalExpressCheckoutGatewayFactory();
+
+        $config = $factory->createConfig();
+
+        $this->assertInternalType('array', $config);
+        $this->assertNotEmpty($config);
+
+        $this->assertInternalType('array', $config['payum.paths']);
+        $this->assertNotEmpty($config['payum.paths']);
+
+        $this->assertArrayHasKey('PayumCore', $config['payum.paths']);
+        $this->assertStringEndsWith('Resources/views', $config['payum.paths']['PayumCore']);
+        $this->assertTrue(file_exists($config['payum.paths']['PayumCore']));
+
+        $this->assertArrayHasKey('PayumPaypalExpressCheckout', $config['payum.paths']);
+        $this->assertStringEndsWith('Resources/views', $config['payum.paths']['PayumPaypalExpressCheckout']);
+        $this->assertTrue(file_exists($config['payum.paths']['PayumPaypalExpressCheckout']));
+    }
 }

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/AuthorizeTokenTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/AuthorizeTokenTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Payum\Paypal\ExpressCheckout\Nvp\Tests\Request\Api;
 
+use Payum\Core\Request\Generic;
 use Payum\Paypal\ExpressCheckout\Nvp\Request\Api\AuthorizeToken;
 
 class AuthorizeTokenTest extends \PHPUnit_Framework_TestCase
@@ -12,7 +13,7 @@ class AuthorizeTokenTest extends \PHPUnit_Framework_TestCase
     {
         $rc = new \ReflectionClass('Payum\Paypal\ExpressCheckout\Nvp\Request\Api\AuthorizeToken');
 
-        $this->assertTrue($rc->isSubclassOf('Payum\Core\Request\Generic'));
+        $this->assertTrue($rc->isSubclassOf(Generic::class));
     }
 
     /**

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/ConfirmOrderTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/ConfirmOrderTest.php
@@ -2,15 +2,16 @@
 namespace Payum\Paypal\ExpressCheckout\Nvp\Tests\Request\Api;
 
 use Payum\Core\Request\Generic;
+use Payum\Paypal\ExpressCheckout\Nvp\Request\Api\ConfirmOrder;
 
-class DoReferenceTransactionTest extends \PHPUnit_Framework_TestCase
+class ConfirmOrderTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @test
      */
     public function shouldBeSubClassOfGeneric()
     {
-        $rc = new \ReflectionClass('Payum\Paypal\ExpressCheckout\Nvp\Request\Api\DoReferenceTransaction');
+        $rc = new \ReflectionClass(ConfirmOrder::class);
 
         $this->assertTrue($rc->isSubclassOf(Generic::class));
     }

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/CreateBillingAgreementTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/CreateBillingAgreementTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Payum\Paypal\ExpressCheckout\Nvp\Tests\Request\Api;
 
+use Payum\Core\Request\Generic;
+
 class CreateBillingAgreementTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -10,6 +12,6 @@ class CreateBillingAgreementTest extends \PHPUnit_Framework_TestCase
     {
         $rc = new \ReflectionClass('Payum\Paypal\ExpressCheckout\Nvp\Request\Api\CreateBillingAgreement');
 
-        $this->assertTrue($rc->isSubclassOf('Payum\Core\Request\Generic'));
+        $this->assertTrue($rc->isSubclassOf(Generic::class));
     }
 }

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/CreateRecurringPaymentProfileTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/CreateRecurringPaymentProfileTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Payum\Paypal\ExpressCheckout\Nvp\Tests\Request\Api;
 
+use Payum\Core\Request\Generic;
+
 class CreateRecurringPaymentProfileTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -10,6 +12,6 @@ class CreateRecurringPaymentProfileTest extends \PHPUnit_Framework_TestCase
     {
         $rc = new \ReflectionClass('Payum\Paypal\ExpressCheckout\Nvp\Request\Api\CreateRecurringPaymentProfile');
 
-        $this->assertTrue($rc->isSubclassOf('Payum\Core\Request\Generic'));
+        $this->assertTrue($rc->isSubclassOf(Generic::class));
     }
 }

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/DoExpressCheckoutPaymentTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/DoExpressCheckoutPaymentTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Payum\Paypal\ExpressCheckout\Nvp\Tests\Request\Api;
 
+use Payum\Core\Request\Generic;
+
 class DoExpressCheckoutPaymentTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -10,6 +12,6 @@ class DoExpressCheckoutPaymentTest extends \PHPUnit_Framework_TestCase
     {
         $rc = new \ReflectionClass('Payum\Paypal\ExpressCheckout\Nvp\Request\Api\DoExpressCheckoutPayment');
 
-        $this->assertTrue($rc->isSubclassOf('Payum\Core\Request\Generic'));
+        $this->assertTrue($rc->isSubclassOf(Generic::class));
     }
 }

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/GetExpressCheckoutDetailsTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/GetExpressCheckoutDetailsTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Payum\Paypal\ExpressCheckout\Nvp\Tests\Request\Api;
 
+use Payum\Core\Request\Generic;
+
 class GetExpressCheckoutDetailsTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -10,6 +12,6 @@ class GetExpressCheckoutDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $rc = new \ReflectionClass('Payum\Paypal\ExpressCheckout\Nvp\Request\Api\GetExpressCheckoutDetails');
 
-        $this->assertTrue($rc->isSubclassOf('Payum\Core\Request\Generic'));
+        $this->assertTrue($rc->isSubclassOf(Generic::class));
     }
 }

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/GetRecurringPaymentsProfileDetailsTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/GetRecurringPaymentsProfileDetailsTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Payum\Paypal\ExpressCheckout\Nvp\Tests\Request\Api;
 
+use Payum\Core\Request\Generic;
+
 class GetRecurringPaymentsProfileDetailsTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -10,6 +12,6 @@ class GetRecurringPaymentsProfileDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $rc = new \ReflectionClass('Payum\Paypal\ExpressCheckout\Nvp\Request\Api\GetRecurringPaymentsProfileDetails');
 
-        $this->assertTrue($rc->isSubclassOf('Payum\Core\Request\Generic'));
+        $this->assertTrue($rc->isSubclassOf(Generic::class));
     }
 }

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/GetTransactionDetailsTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/GetTransactionDetailsTest.php
@@ -2,6 +2,7 @@
 namespace Payum\Paypal\ExpressCheckout\Nvp\Tests\Request\Api;
 
 use MyProject\Proxies\__CG__\stdClass;
+use Payum\Core\Request\Generic;
 use Payum\Paypal\ExpressCheckout\Nvp\Request\Api\GetTransactionDetails;
 
 class GetTransactionDetailsTest extends \PHPUnit_Framework_TestCase
@@ -13,7 +14,7 @@ class GetTransactionDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $rc = new \ReflectionClass('Payum\Paypal\ExpressCheckout\Nvp\Request\Api\GetTransactionDetails');
 
-        $this->assertTrue($rc->isSubclassOf('Payum\Core\Request\Generic'));
+        $this->assertTrue($rc->isSubclassOf(Generic::class));
     }
 
     /**

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/ManageRecurringPaymentsProfileStatusTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/ManageRecurringPaymentsProfileStatusTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Payum\Paypal\ExpressCheckout\Nvp\Tests\Request\Api;
 
+use Payum\Core\Request\Generic;
+
 class ManageRecurringPaymentsProfileStatusTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -10,6 +12,6 @@ class ManageRecurringPaymentsProfileStatusTest extends \PHPUnit_Framework_TestCa
     {
         $rc = new \ReflectionClass('Payum\Paypal\ExpressCheckout\Nvp\Request\Api\ManageRecurringPaymentsProfileStatus');
 
-        $this->assertTrue($rc->isSubclassOf('Payum\Core\Request\Generic'));
+        $this->assertTrue($rc->isSubclassOf(Generic::class));
     }
 }

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/SetExpressCheckoutTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/SetExpressCheckoutTest.php
@@ -1,6 +1,9 @@
 <?php
 namespace Payum\Paypal\ExpressCheckout\Nvp\Tests\Request\Api;
 
+use Payum\Core\Request\Generic;
+use Payum\Paypal\ExpressCheckout\Nvp\Request\Api\SetExpressCheckout;
+
 class SetExpressCheckoutTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -8,8 +11,8 @@ class SetExpressCheckoutTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldBeSubClassOfGeneric()
     {
-        $rc = new \ReflectionClass('Payum\Paypal\ExpressCheckout\Nvp\Request\Api\SetExpressCheckout');
+        $rc = new \ReflectionClass(SetExpressCheckout::class);
 
-        $this->assertTrue($rc->isSubclassOf('Payum\Core\Request\Generic'));
+        $this->assertTrue($rc->isSubclassOf(Generic::class));
     }
 }

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/UpdateRecurringPaymentProfileTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/UpdateRecurringPaymentProfileTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Payum\Paypal\ExpressCheckout\Nvp\Tests\Request\Api;
 
+use Payum\Core\Request\Generic;
+
 class UpdateRecurringPaymentProfileTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -10,6 +12,6 @@ class UpdateRecurringPaymentProfileTest extends \PHPUnit_Framework_TestCase
     {
         $rc = new \ReflectionClass('Payum\Paypal\ExpressCheckout\Nvp\Request\Api\UpdateRecurringPaymentProfile');
 
-        $this->assertTrue($rc->isSubclassOf('Payum\Core\Request\Generic'));
+        $this->assertTrue($rc->isSubclassOf(Generic::class));
     }
 }

--- a/src/Payum/Stripe/StripeCheckoutGatewayFactory.php
+++ b/src/Payum/Stripe/StripeCheckoutGatewayFactory.php
@@ -49,5 +49,9 @@ class StripeCheckoutGatewayFactory extends GatewayFactory
                 return new Keys($config['publishable_key'], $config['secret_key']);
             };
         }
+
+        $config['payum.paths'] = array_replace([
+            'PayumStripe' => __DIR__.'/Resources/views',
+        ], $config['payum.paths'] ?: []);
     }
 }

--- a/src/Payum/Stripe/Tests/StripeCheckoutGatewayFactoryTest.php
+++ b/src/Payum/Stripe/Tests/StripeCheckoutGatewayFactoryTest.php
@@ -160,4 +160,28 @@ class StripeCheckoutGatewayFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->create();
     }
+
+    /**
+     * @test
+     */
+    public function shouldConfigurePaths()
+    {
+        $factory = new StripeCheckoutGatewayFactory();
+
+        $config = $factory->createConfig();
+
+        $this->assertInternalType('array', $config);
+        $this->assertNotEmpty($config);
+
+        $this->assertInternalType('array', $config['payum.paths']);
+        $this->assertNotEmpty($config['payum.paths']);
+
+        $this->assertArrayHasKey('PayumCore', $config['payum.paths']);
+        $this->assertStringEndsWith('Resources/views', $config['payum.paths']['PayumCore']);
+        $this->assertTrue(file_exists($config['payum.paths']['PayumCore']));
+
+        $this->assertArrayHasKey('PayumStripe', $config['payum.paths']);
+        $this->assertStringEndsWith('Resources/views', $config['payum.paths']['PayumStripe']);
+        $this->assertTrue(file_exists($config['payum.paths']['PayumStripe']));
+    }
 }

--- a/src/Payum/Stripe/Tests/StripeJsGatewayFactoryTest.php
+++ b/src/Payum/Stripe/Tests/StripeJsGatewayFactoryTest.php
@@ -160,4 +160,28 @@ class StripeJsGatewayFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->create();
     }
+
+    /**
+     * @test
+     */
+    public function shouldConfigurePaths()
+    {
+        $factory = new StripeJsGatewayFactory();
+
+        $config = $factory->createConfig();
+
+        $this->assertInternalType('array', $config);
+        $this->assertNotEmpty($config);
+
+        $this->assertInternalType('array', $config['payum.paths']);
+        $this->assertNotEmpty($config['payum.paths']);
+
+        $this->assertArrayHasKey('PayumCore', $config['payum.paths']);
+        $this->assertStringEndsWith('Resources/views', $config['payum.paths']['PayumCore']);
+        $this->assertTrue(file_exists($config['payum.paths']['PayumCore']));
+
+        $this->assertArrayHasKey('PayumStripe', $config['payum.paths']);
+        $this->assertStringEndsWith('Resources/views', $config['payum.paths']['PayumStripe']);
+        $this->assertTrue(file_exists($config['payum.paths']['PayumStripe']));
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/Payum/Payum/issues/416 and https://github.com/Payum/Payum/issues/409

Default behavior is without confirmation step, you will see a "Pay Now" button at paypal side.

To enable confirmation order step you have to set:

```
$details['AUTHORIZE_TOKEN_USERACTION'] = '';
```

The default order confirmation template is pretty simply, most probably you would like to overwrite it