### PR TITLE
Fixed "Back to examples" link

### DIFF
--- a/src/Payum/Core/Resources/docs/examples/1-paypal-create-gateway.md
+++ b/src/Payum/Core/Resources/docs/examples/1-paypal-create-gateway.md
@@ -15,5 +15,5 @@ $gateway = $factory->create(array(
 ));
 ```
 
-Back to [examples](examples/index.md).
+Back to [examples](index.md).
 Back to [index](https://github.com/Payum/Core/tree/master/Resources/docs/index.md).

--- a/src/Payum/Core/Resources/docs/examples/2-paypal-capture.md
+++ b/src/Payum/Core/Resources/docs/examples/2-paypal-capture.md
@@ -25,5 +25,5 @@ $model = array(
 $gateway->execute(new \Payum\Core\Request\Capture($model);
 ```
 
-Back to [examples](examples/index.md).
+Back to [examples](index.md).
 Back to [index](https://github.com/Payum/Core/tree/master/Resources/docs/index.md).

--- a/src/Payum/Core/Resources/docs/examples/3-paypal-redirects.md
+++ b/src/Payum/Core/Resources/docs/examples/3-paypal-redirects.md
@@ -17,5 +17,5 @@ try {
 }
 ```
 
-Back to [examples](examples/index.md).
+Back to [examples](index.md).
 Back to [index](https://github.com/Payum/Core/tree/master/Resources/docs/index.md).

--- a/src/Payum/Core/Resources/docs/examples/4-get-status.md
+++ b/src/Payum/Core/Resources/docs/examples/4-get-status.md
@@ -18,5 +18,5 @@ $status->isUnknown();
 $status->getValue(); // 'new', 'authorized', 'captured' and so on.
 ```
 
-Back to [examples](examples/index.md).
+Back to [examples](index.md).
 Back to [index](https://github.com/Payum/Core/tree/master/Resources/docs/index.md).

--- a/src/Payum/Core/Resources/docs/examples/5-stripe-js-create-gateway.md
+++ b/src/Payum/Core/Resources/docs/examples/5-stripe-js-create-gateway.md
@@ -13,5 +13,5 @@ $gateway = $factory->create(array(
 ));
 ```
 
-Back to [examples](examples/index.md).
+Back to [examples](index.md).
 Back to [index](https://github.com/Payum/Core/tree/master/Resources/docs/index.md).

--- a/src/Payum/Core/Resources/docs/examples/6-stripe-js-capture.md
+++ b/src/Payum/Core/Resources/docs/examples/6-stripe-js-capture.md
@@ -19,5 +19,5 @@ $model = array(
 $gateway->execute(new \Payum\Core\Request\Capture($model);
 ```
 
-Back to [examples](examples/index.md).
+Back to [examples](index.md).
 Back to [index](https://github.com/Payum/Core/tree/master/Resources/docs/index.md).

--- a/src/Payum/Core/Resources/docs/examples/7-stripe-js-render-form.md
+++ b/src/Payum/Core/Resources/docs/examples/7-stripe-js-render-form.md
@@ -16,5 +16,5 @@ try {
 }
 ```
 
-Back to [examples](examples/index.md).
+Back to [examples](index.md).
 Back to [index](https://github.com/Payum/Core/tree/master/Resources/docs/index.md).

--- a/src/Payum/Core/Resources/docs/examples/8-stripe-credit-card.md
+++ b/src/Payum/Core/Resources/docs/examples/8-stripe-credit-card.md
@@ -16,5 +16,5 @@ $model->setCreditCard($card);
 $gateway->execute(new \Payum\Core\Request\Capture($model));
 ```
 
-Back to [examples](examples/index.md).
+Back to [examples](index.md).
 Back to [index](https://github.com/Payum/Core/tree/master/Resources/docs/index.md).


### PR DESCRIPTION
Fixed broken link, as now it follows to 404 page.