### PR TITLE
Improve serialize / unserialize when using FilesystemStrorage

### DIFF
--- a/src/Payum/Core/Storage/FilesystemStorage.php
+++ b/src/Payum/Core/Storage/FilesystemStorage.php
@@ -52,7 +52,13 @@ class FilesystemStorage extends AbstractStorage
         }
 
         if (file_exists($this->storageDir.'/payum-model-'.$id)) {
-            return $this->identityMap[$id] = unserialize(base64_decode(file_get_contents($this->storageDir.'/payum-model-'.$id)));
+            $data = file_get_contents($this->storageDir.'/payum-model-'.$id);
+
+            if (base64_encode(base64_decode($data, true)) === $data) {
+                $data = base64_decode($data);
+            }
+
+            return $this->identityMap[$id] = unserialize($data);
         }
     }
 

--- a/src/Payum/Core/Storage/FilesystemStorage.php
+++ b/src/Payum/Core/Storage/FilesystemStorage.php
@@ -52,7 +52,7 @@ class FilesystemStorage extends AbstractStorage
         }
 
         if (file_exists($this->storageDir.'/payum-model-'.$id)) {
-            return $this->identityMap[$id] = unserialize(file_get_contents($this->storageDir.'/payum-model-'.$id));
+            return $this->identityMap[$id] = unserialize(base64_decode(file_get_contents($this->storageDir.'/payum-model-'.$id)));
         }
     }
 
@@ -78,7 +78,7 @@ class FilesystemStorage extends AbstractStorage
         $rp->setAccessible(false);
 
         $this->identityMap[$id] = $model;
-        file_put_contents($this->storageDir.'/payum-model-'.$id, serialize($model));
+        file_put_contents($this->storageDir.'/payum-model-'.$id, base64_encode(serialize($model)));
     }
 
     /**


### PR DESCRIPTION
I encountered an issue when dealing with serialize and unserialize some "unsafe" (", ', :, or ; in the) data. This patch will fix that.