### PR TITLE
Bump Stripe API to version 2.1.3 [WIP]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "paypal/rest-api-sdk-php" : "0.5.*",
         "klarna/checkout": "~1",
         "fp/klarna-invoice": "0.1.*",
-        "stripe/stripe-php": "~1.0",
+        "stripe/stripe-php": "2.1.3",
         "ext-soap": "*",
         "twig/twig": "~1.0"
     },


### PR DESCRIPTION
Investigating updating the Stripe API version in Payum

## End Objective
Latest Stripe API in Payum 1.x

## First step
Testing 2.1.3 in .14

## Next steps
Either 2.1.3 in Payum 1.x or directly latest Stripe in Payum 1.x

## Why 2.1.3?
`Network requests are now done through a swappable class for easier mocking` https://github.com/stripe/stripe-php/blob/v2.1.3/CHANGELOG.md