### PR TITLE
Fixes incomplete annotations of magic methods

### DIFF
--- a/src/Payum/Core/Model/PaymentInterface.php
+++ b/src/Payum/Core/Model/PaymentInterface.php
@@ -2,7 +2,7 @@
 namespace Payum\Core\Model;
 
 /**
- * @method array getDetails
+ * @method array getDetails()
  */
 interface PaymentInterface extends DetailsAggregateInterface, DetailsAwareInterface
 {

--- a/src/Payum/Core/Security/TokenInterface.php
+++ b/src/Payum/Core/Security/TokenInterface.php
@@ -6,7 +6,7 @@ use Payum\Core\Model\DetailsAwareInterface;
 use Payum\Core\Storage\IdentityInterface;
 
 /**
- * @method IdentityInterface getDetails
+ * @method IdentityInterface getDetails()
  */
 interface TokenInterface extends DetailsAggregateInterface, DetailsAwareInterface
 {


### PR DESCRIPTION
According the [docs](https://phpdoc.org/docs/latest/references/phpdoc/tags/method.html) method definition should contain brackets. Omitting those breaks any test suite which depends on Prophecy, when trying to double class, inherited from interface with magic method.

Example can be found [here](https://gist.github.com/ZloeSabo/5c9233753d0c8c493c90)