### PR TITLE
[WIP] Add BankAccount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.4 (2016-03-07)
+
+* [credit-card] Fixes **regression** in the bundle. Symfony's validator marks all fields as invalid on credit card form submission.
+* [skeleton] fix some typos.
+
 ## 1.2.3 (2016-03-04)
 
 * [spl] add get method to array object. with default option.

--- a/src/Payum/Core/Model/BankAccount.php
+++ b/src/Payum/Core/Model/BankAccount.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Payum\Core\Model;
+
+class BankAccount implements BankAccountInterface
+{
+    /**
+     * Name of the account holder
+     *
+     * @var string
+     */
+    private $holder;
+
+    /**
+     * The account number (BBAN)
+     *
+     * @var string
+     */
+    private $number;
+
+    /**
+     * Code that identifies the bank where the account is held
+     *
+     * @var string
+     */
+    private $bankCode;
+
+    /**
+     * The bank's country code (ISO 3166-1 ALPHA-2)
+     *
+     * @link https://en.wikipedia.org/wiki/ISO_3166-1
+     * @var string
+     */
+    private $bankCountryCode;
+
+    /**
+     * @var string
+     */
+    private $iban;
+
+    /**
+     * The bank's BIC code
+     *
+     * @link https://en.wikipedia.org/wiki/ISO_9362
+     * @var string
+     */
+    private $bic;
+
+    /**
+     * @return string
+     */
+    public function getHolder()
+    {
+        return $this->holder;
+    }
+
+    /**
+     * @param string $holder
+     */
+    public function setHolder($holder)
+    {
+        $this->holder = $holder;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNumber()
+    {
+        return $this->number;
+    }
+
+    /**
+     * @param string $number
+     */
+    public function setNumber($number)
+    {
+        $this->number = $number;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBankCode()
+    {
+        return $this->bankCode;
+    }
+
+    /**
+     * @param string $bankCode
+     */
+    public function setBankCode($bankCode)
+    {
+        $this->bankCode = $bankCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBankCountryCode()
+    {
+        return $this->bankCountryCode;
+    }
+
+    /**
+     * @param string $bankCountryCode
+     */
+    public function setBankCountryCode($bankCountryCode)
+    {
+        $this->bankCountryCode = $bankCountryCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIban()
+    {
+        return $this->iban;
+    }
+
+    /**
+     * @param string $iban
+     */
+    public function setIban($iban)
+    {
+        $this->iban = $iban;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBic()
+    {
+        return $this->bic;
+    }
+
+    /**
+     * @param string $bic
+     */
+    public function setBic($bic)
+    {
+        $this->bic = $bic;
+    }
+}

--- a/src/Payum/Core/Model/BankAccountInterface.php
+++ b/src/Payum/Core/Model/BankAccountInterface.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Payum\Core\Model;
+
+interface BankAccountInterface
+{
+    /**
+     * @return string
+     */
+    public function getHolder();
+
+    /**
+     * @param string $holder
+     */
+    public function setHolder($holder);
+
+    /**
+     * @return string
+     */
+    public function getNumber();
+
+    /**
+     * @param string $number
+     */
+    public function setNumber($number);
+
+    /**
+     * @return string
+     */
+    public function getBankCode();
+
+    /**
+     * @param string $bankCode
+     */
+    public function setBankCode($bankCode);
+
+    /**
+     * @return string
+     */
+    public function getBankCountryCode();
+
+    /**
+     * @param string $bankCountryCode
+     */
+    public function setBankCountryCode($bankCountryCode);
+
+    /**
+     * @return string
+     */
+    public function getIban();
+
+    /**
+     * @param string $iban
+     */
+    public function setIban($iban);
+
+    /**
+     * @return string
+     */
+    public function getBic();
+
+    /**
+     * @param string $bic
+     */
+    public function setBic($bic);
+}

--- a/src/Payum/Core/Model/Payment.php
+++ b/src/Payum/Core/Model/Payment.php
@@ -43,6 +43,11 @@ class Payment implements PaymentInterface
      */
     protected $creditCard;
 
+    /**
+     * @var BankAccountInterface|null
+     */
+    protected $bankAccount;
+
     public function __construct()
     {
         $this->details = array();
@@ -180,5 +185,21 @@ class Payment implements PaymentInterface
     public function setCreditCard(CreditCardInterface $creditCard = null)
     {
         $this->creditCard = $creditCard;
+    }
+
+    /**
+     * @return BankAccountInterface|null
+     */
+    public function getBankAccount()
+    {
+        return $this->bankAccount;
+    }
+
+    /**
+     * @param BankAccountInterface|null $bankAccount
+     */
+    public function setBankAccount(BankAccountInterface $bankAccount = null)
+    {
+        $this->bankAccount = $bankAccount;
     }
 }

--- a/src/Payum/Core/Model/PaymentInterface.php
+++ b/src/Payum/Core/Model/PaymentInterface.php
@@ -40,4 +40,9 @@ interface PaymentInterface extends DetailsAggregateInterface, DetailsAwareInterf
      * @return CreditCardInterface|null
      */
     public function getCreditCard();
+
+    /**
+     * @return BankAccountInterface|null
+     */
+    public function getBankAccount();
 }


### PR DESCRIPTION
To support Direct debit payment (https://en.wikipedia.org/wiki/Direct_debit) or Giropay (https://en.wikipedia.org/wiki/Giropay) with different payment providers it is very useful to have a common interface for the bank account.

The Paypal API has way more fields for the bank account (https://developer.paypal.com/docs/classic/api/adaptive-accounts/AddBankAccount_API_Operation/). But I think it makes no sense to add all those fields.

@makasim what are your thoughts about that?