### PR TITLE
Using Httplug instead of Guzzle6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 composer.phar
 composer.lock
+phpunit.xml
 cov
 vendor
 bin

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,7 +2,7 @@
 
 ## 1.3.0
 
-* [http-client] guzzlehttp/guzzle was decoupled and replaced by [Httplug](http://docs.php-http.org/en/latest/httplug/introduction.html). This gives you option to use Guzzle6, Guzzle5, Buzz or any other library to send HTTP messages. Make sure to specify `httplug.client` and `httplug.message_factory` or use [Httplug discovery](http://docs.php-http.org/en/latest/discovery.html). 
+* [http-client] When you update to Payum 1.3.0 the installation will fail because you need to install a client implementation. If you choose php-http/guzzle6-adapter everything will work exactly as before.
 
 ## 1.2.0
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrades
 
+## 1.3.0
+
+* [http-client] guzzlehttp/guzzle was decoupled and replaced by [Httplug](http://docs.php-http.org/en/latest/httplug/introduction.html). This gives you option to use Guzzle6, Guzzle5, Buzz or any other library to send HTTP messages. Make sure to specify `httplug.client` and `httplug.message_factory` or use [Httplug discovery](http://docs.php-http.org/en/latest/discovery.html). 
+
 ## 1.2.0
 
 * [stripe] Stripe api version updated to 2.0 - 3.x. You'll have to update any custom actions that use the Stripe api directly.

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,10 @@
     "require": {
         "php": "^5.5.0|^7.0",
         "payum/iso4217": "~1.0",
-        "guzzlehttp/guzzle": "~6.0",
+        "php-http/httplug": "^1.0",
+        "php-http/message-factory": "^1.0",
+        "php-http/client-implementation": "^1.0",
+        "php-http/discovery": "^0.8",
         "league/url": "~3.0",
         "twig/twig": "~1.0"
     },
@@ -66,6 +69,10 @@
         "klarna/checkout": "~1|~2.0",
         "fp/klarna-invoice": "0.1.*",
         "stripe/stripe-php": "~2.0|~3.0",
+        "php-http/guzzle6-adapter": "^1.0",
+        "php-http/message": "^1.0",
+        "puli/composer-plugin": "^1.0",
+        "guzzlehttp/psr7": "^1.1",
         "ext-soap": "*"
     },
     "replace": {
@@ -102,6 +109,7 @@
         "stripe/stripe-php": "~2.0|~3.0 If you want to use Stripe install stripe/stripe-php:~2.0|~3.0 library",
         "ext-soap": "* If you want to use Payex extension you have to install soap extension"
     },
+    "minimum-stability": "beta",
     "config": {
         "bin-dir": "bin"
     },

--- a/src/Payum/AuthorizeNet/Aim/Resources/docs/get-it-started.md
+++ b/src/Payum/AuthorizeNet/Aim/Resources/docs/get-it-started.md
@@ -10,7 +10,7 @@ The preferred way to install the library is using [composer](http://getcomposer.
 Run composer require to add dependencies to _composer.json_:
 
 ```bash
-php composer.phar require payum/authorize-net-aim
+php composer.phar require payum/authorize-net-aim php-http/guzzle6-adapter
 ```
 
 ## config.php

--- a/src/Payum/Be2Bill/Api.php
+++ b/src/Payum/Be2Bill/Api.php
@@ -1,9 +1,7 @@
 <?php
 namespace Payum\Be2Bill;
 
-use Http\Discovery\MessageFactoryDiscovery;
 use Http\Message\MessageFactory;
-use Payum\Core\Bridge\Guzzle\HttpClientFactory;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Exception\InvalidArgumentException;
 use Payum\Core\Exception\Http\HttpException;
@@ -130,7 +128,7 @@ class Api
      *
      * @throws \Payum\Core\Exception\InvalidArgumentException if an option is invalid
      */
-    public function __construct(array $options, HttpClientInterface $client = null, MessageFactory $messageFactory = null)
+    public function __construct(array $options, HttpClientInterface $client, MessageFactory $messageFactory )
     {
         $options = ArrayObject::ensureArrayObject($options);
         $options->defaults($this->options);
@@ -144,8 +142,8 @@ class Api
         }
 
         $this->options = $options;
-        $this->client = $client ?: HttpClientFactory::create();
-        $this->messageFactory = $messageFactory ?: MessageFactoryDiscovery::find();
+        $this->client = $client;
+        $this->messageFactory = $messageFactory;
     }
 
     /**

--- a/src/Payum/Be2Bill/Api.php
+++ b/src/Payum/Be2Bill/Api.php
@@ -1,7 +1,8 @@
 <?php
 namespace Payum\Be2Bill;
 
-use GuzzleHttp\Psr7\Request;
+use Http\Discovery\MessageFactoryDiscovery;
+use Http\Message\MessageFactory;
 use Payum\Core\Bridge\Guzzle\HttpClientFactory;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Exception\InvalidArgumentException;
@@ -109,6 +110,11 @@ class Api
     protected $client;
 
     /**
+     * @var MessageFactory
+     */
+    protected $messageFactory;
+
+    /**
      * @var array
      */
     protected $options = array(
@@ -120,10 +126,11 @@ class Api
     /**
      * @param array               $options
      * @param HttpClientInterface $client
+     * @param MessageFactory      $messageFactory
      *
      * @throws \Payum\Core\Exception\InvalidArgumentException if an option is invalid
      */
-    public function __construct(array $options, HttpClientInterface $client = null)
+    public function __construct(array $options, HttpClientInterface $client = null, MessageFactory $messageFactory = null)
     {
         $options = ArrayObject::ensureArrayObject($options);
         $options->defaults($this->options);
@@ -138,6 +145,7 @@ class Api
 
         $this->options = $options;
         $this->client = $client ?: HttpClientFactory::create();
+        $this->messageFactory = $messageFactory ?: MessageFactoryDiscovery::find();
     }
 
     /**
@@ -187,7 +195,7 @@ class Api
             'Content-Type' => 'application/x-www-form-urlencoded',
         );
 
-        $request = new Request('POST', $this->getApiEndpoint(), $headers, http_build_query($fields));
+        $request = $this->messageFactory->createRequest('POST', $this->getApiEndpoint(), $headers, http_build_query($fields));
 
         $response = $this->client->send($request);
 

--- a/src/Payum/Be2Bill/Be2BillDirectGatewayFactory.php
+++ b/src/Payum/Be2Bill/Be2BillDirectGatewayFactory.php
@@ -41,7 +41,8 @@ class Be2BillDirectGatewayFactory extends GatewayFactory
                         'password' => $config['password'],
                         'sandbox' => $config['sandbox'],
                     ),
-                    $config['payum.http_client']
+                    $config['payum.http_client'],
+                    $config['httplug.message_factory']
                 );
             };
         }

--- a/src/Payum/Be2Bill/Resources/docs/get-it-started.md
+++ b/src/Payum/Be2Bill/Resources/docs/get-it-started.md
@@ -10,7 +10,7 @@ The preferred way to install the library is using [composer](http://getcomposer.
 Run composer require to add dependencies to _composer.json_:
 
 ```bash
-php composer.phar require payum/be2bill
+php composer.phar require payum/be2bill php-http/guzzle6-adapter
 ```
 
 ## config.php

--- a/src/Payum/Be2Bill/Resources/docs/offsite.md
+++ b/src/Payum/Be2Bill/Resources/docs/offsite.md
@@ -10,7 +10,7 @@ The preferred way to install the library is using [composer](http://getcomposer.
 Run composer require to add dependencies to _composer.json_:
 
 ```bash
-php composer.phar require payum/be2bill
+php composer.phar require payum/be2bill php-http/guzzle6-adapter
 ```
 
 ## config.php

--- a/src/Payum/Be2Bill/Tests/ApiTest.php
+++ b/src/Payum/Be2Bill/Tests/ApiTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Payum\Be2Bill\Tests;
 
+use Http\Message\MessageFactory\GuzzleMessageFactory;
 use Payum\Be2Bill\Api;
 use Payum\Core\HttpClientInterface;
 
@@ -9,31 +10,19 @@ class ApiTest extends \Phpunit_Framework_TestCase
     /**
      * @test
      */
-    public function couldBeConstructedWithOptionsOnly()
-    {
-        $api = new Api(array(
-            'identifier' => 'anId',
-            'password' => 'aPass',
-            'sandbox' => true,
-        ));
-
-        $this->assertAttributeInstanceOf('Payum\Core\HttpClientInterface', 'client', $api);
-    }
-
-    /**
-     * @test
-     */
     public function couldBeConstructedWithOptionsAndHttpClient()
     {
         $client = $this->createHttpClientMock();
+        $factory = $this->createHttpMessageFactory();
 
         $api = new Api(array(
             'identifier' => 'anId',
             'password' => 'aPass',
             'sandbox' => true,
-        ), $client);
+        ), $client, $factory);
 
         $this->assertAttributeSame($client, 'client', $api);
+        $this->assertAttributeSame($factory, 'messageFactory', $api);
     }
 
     /**
@@ -44,7 +33,7 @@ class ApiTest extends \Phpunit_Framework_TestCase
      */
     public function throwIfRequiredOptionsNotSetInConstructor()
     {
-        new Api(array());
+        new Api(array(), $this->createHttpClientMock(), $this->createHttpMessageFactory());
     }
 
     /**
@@ -59,7 +48,7 @@ class ApiTest extends \Phpunit_Framework_TestCase
             'identifier' => 'anId',
             'password' => 'aPass',
             'sandbox' => 'notABool'
-        ));
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
     }
 
     /**
@@ -71,7 +60,7 @@ class ApiTest extends \Phpunit_Framework_TestCase
             'identifier' => 'anId',
             'password' => 'aPass',
             'sandbox' => true,
-        ), $this->createHttpClientMock());
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
 
         $post = $api->prepareOffsitePayment(array(
             'AMOUNT' => 100,
@@ -91,7 +80,7 @@ class ApiTest extends \Phpunit_Framework_TestCase
             'identifier' => 'anId',
             'password' => 'aPass',
             'sandbox' => true,
-        ), $this->createHttpClientMock());
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
 
         $post = $api->prepareOffsitePayment(array(
             'AMOUNT' => 100,
@@ -112,7 +101,7 @@ class ApiTest extends \Phpunit_Framework_TestCase
             'identifier' => 'anId',
             'password' => 'aPass',
             'sandbox' => true,
-        ), $this->createHttpClientMock());
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
 
         $post = $api->prepareOffsitePayment(array(
             'AMOUNT' => 100,
@@ -134,7 +123,7 @@ class ApiTest extends \Phpunit_Framework_TestCase
             'identifier' => 'anId',
             'password' => 'aPass',
             'sandbox' => true,
-        ), $this->createHttpClientMock());
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
 
         $post = $api->prepareOffsitePayment(array(
             'AMOUNT' => 100,
@@ -159,7 +148,7 @@ class ApiTest extends \Phpunit_Framework_TestCase
             'identifier' => 'anId',
             'password' => 'aPass',
             'sandbox' => true,
-        ), $this->createHttpClientMock());
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
 
         $this->assertFalse($api->verifyHash(array()));
     }
@@ -179,7 +168,7 @@ class ApiTest extends \Phpunit_Framework_TestCase
             'identifier' => 'anId',
             'password' => 'aPass',
             'sandbox' => true,
-        ), $this->createHttpClientMock());
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
 
         //guard
         $this->assertNotEquals($invalidHash, $api->calculateHash($params));
@@ -203,7 +192,7 @@ class ApiTest extends \Phpunit_Framework_TestCase
             'identifier' => 'anId',
             'password' => 'aPass',
             'sandbox' => true,
-        ), $this->createHttpClientMock());
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
 
         $params['HASH'] = $api->calculateHash($params);
 
@@ -216,5 +205,14 @@ class ApiTest extends \Phpunit_Framework_TestCase
     protected function createHttpClientMock()
     {
         return $this->getMock('Payum\Core\HttpClientInterface');
+    }
+
+    /**
+     * @return \Http\Message\MessageFactory
+     */
+    protected function createHttpMessageFactory()
+    {
+        return new GuzzleMessageFactory();
+
     }
 }

--- a/src/Payum/Core/Bridge/Guzzle/HttpClient.php
+++ b/src/Payum/Core/Bridge/Guzzle/HttpClient.php
@@ -5,6 +5,11 @@ use GuzzleHttp\ClientInterface;
 use Payum\Core\HttpClientInterface;
 use Psr\Http\Message\RequestInterface;
 
+/**
+ * This is a HttpClient that is using Guzzle.
+ *
+ * @deprecated This will be removed in 2.0. Consider using Http\Client\HttpClient.
+ */
 class HttpClient implements HttpClientInterface
 {
     /**

--- a/src/Payum/Core/Bridge/Guzzle/HttpClientFactory.php
+++ b/src/Payum/Core/Bridge/Guzzle/HttpClientFactory.php
@@ -14,7 +14,7 @@ class HttpClientFactory
 {
     /**
      * Create a Guzzle client.
-     *
+     * 
      * @return \GuzzleHttp\Client
      */
     public static function createGuzzle()

--- a/src/Payum/Core/Bridge/Guzzle/HttpClientFactory.php
+++ b/src/Payum/Core/Bridge/Guzzle/HttpClientFactory.php
@@ -1,26 +1,43 @@
 <?php
+
 namespace Payum\Core\Bridge\Guzzle;
 
-use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\ClientInterface as GuzzleClientInterface;
+use GuzzleHttp\Client;
+use Http\Discovery\HttpClientDiscovery;
 use Payum\Core\HttpClientInterface;
 
+/**
+ * @deprecated This will be removed in 2.0. Consider using Http\Discovery\HttpClientDiscovery.
+ */
 class HttpClientFactory
 {
     /**
-     * @return GuzzleClientInterface
+     * Create a Guzzle client.
+     *
+     * @return \GuzzleHttp\Client
      */
     public static function createGuzzle()
     {
+        $client = null;
+        if (!class_exists(Client::class)) {
+            @trigger_error('The function "HttpClientFactory::createGuzzle" is depcrecated and will be removed in 2.0.', E_USER_DEPRECATED);
+            throw new \LogicException('Can not use "HttpClientFactory::createGuzzle" since Guzzle is not installed. This function is deprecated and will be removed in 2.0.');
+        }
+
+        $version = \GuzzleHttp\ClientInterface::VERSION;
+        if (substr($version, 0, 1) !== '6') {
+            throw new \LogicException('This version of Guzzle is not supported.');
+        }
+
         $curl = curl_version();
 
         $curlOptions = [
-            CURLOPT_USERAGENT => sprintf('Payum/1.x curl/%s PHP/%s', $curl['version'], phpversion()),
-        ];
+             CURLOPT_USERAGENT => sprintf('Payum/1.x curl/%s PHP/%s', $curl['version'], phpversion()),
+         ];
 
-        return new GuzzleClient([
-            'curl' => $curlOptions
-        ]);
+        return new \GuzzleHttp\Client([
+             'curl' => $curlOptions,
+         ]);
     }
 
     /**
@@ -28,6 +45,6 @@ class HttpClientFactory
      */
     public static function create()
     {
-        return new HttpClient(static::createGuzzle());
+        return new HttplugClient(HttpClientDiscovery::find());
     }
 }

--- a/src/Payum/Core/Bridge/Guzzle/HttpClientFactory.php
+++ b/src/Payum/Core/Bridge/Guzzle/HttpClientFactory.php
@@ -4,7 +4,6 @@ namespace Payum\Core\Bridge\Guzzle;
 
 use GuzzleHttp\Client;
 use Http\Discovery\HttpClientDiscovery;
-use Payum\Core\Bridge\Httplug\HttplugClient;
 use Payum\Core\HttpClientInterface;
 
 /**
@@ -46,6 +45,6 @@ class HttpClientFactory
      */
     public static function create()
     {
-        return new HttplugClient(HttpClientDiscovery::find());
+        return new HttpClient(static::createGuzzle());
     }
 }

--- a/src/Payum/Core/Bridge/Guzzle/HttplugClient.php
+++ b/src/Payum/Core/Bridge/Guzzle/HttplugClient.php
@@ -1,0 +1,36 @@
+<?php
+namespace Payum\Core\Bridge\Guzzle;
+
+use Payum\Core\HttpClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Http\Client\HttpClient;
+
+/**
+ * This is a HttpClient that support Httplug. This is an adapter class that make sure we can use Httplug without breaking
+ * backward compatibility. At 2.0 we will be using Http\Client\HttpClient. 
+ *
+ * @deprecated This will be removed in 2.0. Consider using Http\Client\HttpClient.
+ */
+class HttplugClient implements HttpClientInterface
+{
+    /**
+     * @var HttpClient
+     */
+    private $client;
+
+    /**
+     * @param HttpClient $client
+     */
+    public function __construct(HttpClient $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function send(RequestInterface $request)
+    {
+        return $this->client->sendRequest($request);
+    }
+}

--- a/src/Payum/Core/CoreGatewayFactory.php
+++ b/src/Payum/Core/CoreGatewayFactory.php
@@ -67,35 +67,38 @@ class CoreGatewayFactory implements GatewayFactoryInterface
 
         $config->defaults(array(
             'httplug.client'=>function(ArrayObject $config) {
+                if (class_exists(HttpClientDiscovery::class)) {
+                    return HttpClientDiscovery::find();
+                }
+
                 if (class_exists(HttpGuzzle6Client::class)) {
                     return new HttpGuzzle6Client(new GuzzleClient());
                 }
                 
                 // TODO add "if else" for other clients provided by httplug.
 
-                if (class_exists(HttpClientDiscovery::class)) {
-                    return HttpClientDiscovery::find();
-                }
+
 
                 throw new \LogicException('The httpplug.client could not be guessed. Install one of the following packages: php-http/guzzle6-adapter. You can also overwrite the config option with your implementation.');
             },
             'httplug.message_factory'=>function(ArrayObject $config) {
+                if (class_exists(MessageFactoryDiscovery::class)) {
+                    return MessageFactoryDiscovery::find();
+                }
+
                 if (class_exists(GuzzleClient::class)) {
                     return new GuzzleMessageFactory();
                 }
 
                 // TODO add "if else" for other message factories provided by httplug.
                 
-                if (class_exists(MessageFactoryDiscovery::class)) {
-                    return MessageFactoryDiscovery::find();
-                }
+
 
                 throw new \LogicException('The httpplug.message_factory could not be guessed. Install one of the following packages: php-http/guzzle6-adapter. You can also overwrite the config option with your implementation.');
             },
             'payum.http_client'=>function(ArrayObject $config) {
                   return new HttplugClient($config['httplug.client']);
             },
-            'guzzle.client' => HttpClientFactory::createGuzzle(),
             'payum.template.layout' => '@PayumCore/layout.html.twig',
             'twig.env' => function(ArrayObject $config) use ($twig) {
                 $twig = $twig ?: new \Twig_Environment(new \Twig_Loader_Chain());

--- a/src/Payum/Core/Resources/docs/get-it-started.md
+++ b/src/Payum/Core/Resources/docs/get-it-started.md
@@ -13,12 +13,14 @@ The preferred way to install the library is using [composer](http://getcomposer.
 Run composer require to add dependencies to _composer.json_:
 
 ```bash
-php composer.phar require payum/offline
+php composer.phar require payum/offline php-http/message php-http/guzzle6-adapter
 ```
 
 _**Note**: Where payum/offline is a php payum extension, you can for example change it to payum/paypal-express-checkout-nvp or payum/stripe. Look at [supported gateways](supported-gateways.md) to find out what you can use._
 
 _**Note**: Use payum/payum if you want to install all gateways at once._
+
+_**Note**: Use php-http/guzzle6-adapter is just an example. You can use any of [these adapters](https://packagist.org/providers/php-http/client-implementation)._
 
 Before we configure the payum let's look at the flow diagram.
 This flow is same for all gateways so once you familiar with it any other gateways could be added easily.
@@ -48,7 +50,9 @@ $paymentClass = Payment::class;
 $payum = (new PayumBuilder())
     ->addDefaultStorages()
     ->addGateway('aGateway', [
-        'factory' => 'offline'
+        'factory' => 'offline',
+        'httplug.client' => new Http\Adapter\Guzzle6\Client(),
+        'httplug.message_factory' => new Http\Message\MessageFactory\GuzzleMessageFactory(),
     ])
 
     ->getPayum()
@@ -58,6 +62,8 @@ $payum = (new PayumBuilder())
 _**Note**: There are other [storages](storages.md) available. Such as Doctrine ORM\MongoODM._
 
 _**Note**: Consider using something other than `FilesystemStorage` in production._
+
+_**Note**: Instead of specifying `httplug.client` and `httplug.message_factory` you could use [Httplug discovery](http://docs.php-http.org/en/latest/discovery.html)._
 
 ## prepare.php
 

--- a/src/Payum/Core/Tests/Bridge/Guzzle/HttpClientFactoryTest.php
+++ b/src/Payum/Core/Tests/Bridge/Guzzle/HttpClientFactoryTest.php
@@ -4,6 +4,7 @@ namespace Payum\Core\Tests\Bridge\Guzzle;
 use GuzzleHttp\ClientInterface as GuzzleClientInterface;
 use Payum\Core\Bridge\Guzzle\HttpClient;
 use Payum\Core\Bridge\Guzzle\HttpClientFactory;
+use Payum\Core\Bridge\Guzzle\HttplugClient;
 use Payum\Core\HttpClientInterface;
 
 class HttpClientFactoryTest extends \PHPUnit_Framework_TestCase
@@ -16,16 +17,6 @@ class HttpClientFactoryTest extends \PHPUnit_Framework_TestCase
         $client = HttpClientFactory::create();
 
         $this->assertInstanceOf(HttpClientInterface::class, $client);
-        $this->assertInstanceOf(HttpClient::class, $client);
-    }
-
-    /**
-     * @test
-     */
-    public function shouldReturnGuzzleClient()
-    {
-        $client = HttpClientFactory::createGuzzle();
-
-        $this->assertInstanceOf(GuzzleClientInterface::class, $client);
+        $this->assertInstanceOf(HttplugClient::class, $client);
     }
 }

--- a/src/Payum/Core/Tests/Bridge/Guzzle/HttpClientFactoryTest.php
+++ b/src/Payum/Core/Tests/Bridge/Guzzle/HttpClientFactoryTest.php
@@ -1,10 +1,8 @@
 <?php
 namespace Payum\Core\Tests\Bridge\Guzzle;
 
-use GuzzleHttp\ClientInterface as GuzzleClientInterface;
 use Payum\Core\Bridge\Guzzle\HttpClient;
 use Payum\Core\Bridge\Guzzle\HttpClientFactory;
-use Payum\Core\Bridge\Httplug\HttplugClient;
 use Payum\Core\HttpClientInterface;
 
 class HttpClientFactoryTest extends \PHPUnit_Framework_TestCase
@@ -17,6 +15,6 @@ class HttpClientFactoryTest extends \PHPUnit_Framework_TestCase
         $client = HttpClientFactory::create();
 
         $this->assertInstanceOf(HttpClientInterface::class, $client);
-        $this->assertInstanceOf(HttplugClient::class, $client);
+        $this->assertInstanceOf(HttpClient::class, $client);
     }
 }

--- a/src/Payum/Core/Tests/CoreGatewayFactoryTest.php
+++ b/src/Payum/Core/Tests/CoreGatewayFactoryTest.php
@@ -96,8 +96,7 @@ class CoreGatewayFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $config);
         $this->assertNotEmpty($config);
 
-        $this->assertInstanceOf(HttpClientInterface::class, $config['payum.http_client']);
-        $this->assertInstanceOf(GuzzleClientInterface::class, $config['guzzle.client']);
+        $this->assertInstanceOf(\Closure::class, $config['payum.http_client']);
         $this->assertInstanceOf(GetHttpRequestAction::class, $config['payum.action.get_http_request']);
         $this->assertInstanceOf(CapturePaymentAction::class, $config['payum.action.capture_payment']);
         $this->assertInstanceOf(ExecuteSameRequestWithModelDetailsAction::class, $config['payum.action.execute_same_request_with_model_details']);

--- a/src/Payum/Core/Tests/PayumTest.php
+++ b/src/Payum/Core/Tests/PayumTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace Payum\Core\Tests;
 
-use Payum\Core\Bridge\Guzzle\HttpClientFactory;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\CoreGatewayFactory;
 use Payum\Core\GatewayInterface;

--- a/src/Payum/Core/Tests/SkipOnPhp7Trait.php
+++ b/src/Payum/Core/Tests/SkipOnPhp7Trait.php
@@ -1,7 +1,6 @@
 <?php
 namespace Payum\Core\Tests;
 
-use Payum\Core\Bridge\Guzzle\HttpClientFactory;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\CoreGatewayFactory;
 use Payum\Core\GatewayInterface;

--- a/src/Payum/Core/composer.json
+++ b/src/Payum/Core/composer.json
@@ -37,7 +37,10 @@
     "require": {
         "php": "^5.5.0|^7.0",
         "payum/iso4217": "~1.0",
-        "guzzlehttp/guzzle": "~6.0",
+        "php-http/httplug": "^1.0",
+        "php-http/message-factory": "^1.0",
+        "php-http/client-implementation": "^1.0",
+        "php-http/discovery": "^0.8",
         "league/url": "~3.0",
         "twig/twig": "~1.0"
     },

--- a/src/Payum/Klarna/Checkout/Resources/docs/get-it-started.md
+++ b/src/Payum/Klarna/Checkout/Resources/docs/get-it-started.md
@@ -9,7 +9,7 @@ The preferred way to install the library is using [composer](http://getcomposer.
 Run composer require to add dependencies to _composer.json_:
 
 ```bash
-php composer.phar require payum/klarna-checkout
+php composer.phar require payum/klarna-checkout php-http/guzzle6-adapter
 ```
 
 ## config.php

--- a/src/Payum/Klarna/Invoice/Resources/docs/get-it-started.md
+++ b/src/Payum/Klarna/Invoice/Resources/docs/get-it-started.md
@@ -9,7 +9,7 @@ The preferred way to install the library is using [composer](http://getcomposer.
 Run composer require to add dependencies to _composer.json_:
 
 ```bash
-php composer.phar require payum/klarna-invoice
+php composer.phar require payum/klarna-invoice php-http/guzzle6-adapter
 ```
 
 ## config.php

--- a/src/Payum/Offline/Resources/docs/get-it-started.md
+++ b/src/Payum/Offline/Resources/docs/get-it-started.md
@@ -10,7 +10,7 @@ The preferred way to install the library is using [composer](http://getcomposer.
 Run composer require to add dependencies to _composer.json_:
 
 ```bash
-php composer.phar require payum/offline
+php composer.phar require payum/offline php-http/guzzle6-adapter
 ```
 
 ## config.php

--- a/src/Payum/Payex/Resources/docs/get-it-started.md
+++ b/src/Payum/Payex/Resources/docs/get-it-started.md
@@ -10,7 +10,7 @@ The preferred way to install the library is using [composer](http://getcomposer.
 Run composer require to add dependencies to _composer.json_:
 
 ```bash
-php composer.phar require payum/payex
+php composer.phar require payum/payex php-http/guzzle6-adapter
 ```
 
 ## config.php

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Api.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Api.php
@@ -1,7 +1,8 @@
 <?php
 namespace Payum\Paypal\ExpressCheckout\Nvp;
 
-use GuzzleHttp\Psr7\Request;
+use Http\Discovery\MessageFactoryDiscovery;
+use Http\Message\MessageFactory;
 use Payum\Core\Bridge\Guzzle\HttpClientFactory;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Exception\Http\HttpException;
@@ -289,7 +290,15 @@ class Api
 
     const VERSION = '65.1';
 
+    /**
+     * @var HttpClientInterface
+     */
     protected $client;
+
+    /**
+     * @var MessageFactory
+     */
+    protected $messageFactory;
 
     protected $options = array(
         'username' => null,
@@ -303,10 +312,11 @@ class Api
     );
 
     /**
-     * @param array                $options
+     * @param array                    $options
      * @param HttpClientInterface|null $client
+     * @param MessageFactory|null      $messageFactory
      */
-    public function __construct(array $options, HttpClientInterface $client = null)
+    public function __construct(array $options, HttpClientInterface $client = null, MessageFactory $messageFactory = null)
     {
         $options = ArrayObject::ensureArrayObject($options);
         $options->defaults($this->options);
@@ -322,6 +332,7 @@ class Api
 
         $this->options = $options;
         $this->client = $client ?: HttpClientFactory::create();
+        $this->messageFactory = $messageFactory ?: MessageFactoryDiscovery::find();
     }
 
     /**
@@ -532,7 +543,7 @@ class Api
             'Content-Type' => 'application/x-www-form-urlencoded',
         );
 
-        $request = new Request('POST', $this->getApiEndpoint(), $headers, http_build_query($fields));
+        $request = $this->messageFactory->createRequest('POST', $this->getApiEndpoint(), $headers, http_build_query($fields));
 
         $response = $this->client->send($request);
 

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Api.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Api.php
@@ -1,9 +1,7 @@
 <?php
 namespace Payum\Paypal\ExpressCheckout\Nvp;
 
-use Http\Discovery\MessageFactoryDiscovery;
 use Http\Message\MessageFactory;
-use Payum\Core\Bridge\Guzzle\HttpClientFactory;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Exception\Http\HttpException;
 use Payum\Core\Exception\InvalidArgumentException;
@@ -316,7 +314,7 @@ class Api
      * @param HttpClientInterface|null $client
      * @param MessageFactory|null      $messageFactory
      */
-    public function __construct(array $options, HttpClientInterface $client = null, MessageFactory $messageFactory = null)
+    public function __construct(array $options, HttpClientInterface $client, MessageFactory $messageFactory)
     {
         $options = ArrayObject::ensureArrayObject($options);
         $options->defaults($this->options);
@@ -331,8 +329,8 @@ class Api
         }
 
         $this->options = $options;
-        $this->client = $client ?: HttpClientFactory::create();
-        $this->messageFactory = $messageFactory ?: MessageFactoryDiscovery::find();
+        $this->client = $client;
+        $this->messageFactory = $messageFactory;
     }
 
     /**

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/PaypalExpressCheckoutGatewayFactory.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/PaypalExpressCheckoutGatewayFactory.php
@@ -86,7 +86,7 @@ class PaypalExpressCheckoutGatewayFactory extends GatewayFactory
                     'sandbox' => $config['sandbox'],
                 );
 
-                return new Api($paypalConfig, $config['payum.http_client']);
+                return new Api($paypalConfig, $config['payum.http_client'], $config['httplug.message_factory']);
             };
         }
 

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Resources/docs/get-it-started.md
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Resources/docs/get-it-started.md
@@ -10,7 +10,7 @@ The preferred way to install the library is using [composer](http://getcomposer.
 Run composer require to add dependencies to _composer.json_:
 
 ```bash
-php composer.phar require payum/paypal-express-checkout-nvp
+php composer.phar require payum/paypal-express-checkout-nvp php-http/guzzle6-adapter
 ```
 
 ## config.php

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/ApiTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/ApiTest.php
@@ -2,6 +2,7 @@
 namespace Payum\Paypal\ExpressCheckout\Nvp\Tests;
 
 use GuzzleHttp\Psr7\Response;
+use Http\Message\MessageFactory\GuzzleMessageFactory;
 use Payum\Core\HttpClientInterface;
 use Payum\Paypal\ExpressCheckout\Nvp\Api;
 use Psr\Http\Message\RequestInterface;
@@ -11,33 +12,20 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function couldBeConstructedWithOptionsOnly()
-    {
-        $api = new Api(array(
-            'username' => 'a_username',
-            'password' => 'a_password',
-            'signature' => 'a_signature',
-            'sandbox' => true,
-        ));
-
-        $this->assertAttributeInstanceOf('Payum\Core\HttpClientInterface', 'client', $api);
-    }
-
-    /**
-     * @test
-     */
     public function couldBeConstructedWithOptionsAndHttpClient()
     {
         $client = $this->createHttpClientMock();
+        $factory = $this->createHttpMessageFactory();
 
         $api = new Api(array(
             'username' => 'a_username',
             'password' => 'a_password',
             'signature' => 'a_signature',
             'sandbox' => true,
-        ), $client);
+        ), $client, $factory);
 
         $this->assertAttributeSame($client, 'client', $api);
+        $this->assertAttributeSame($factory, 'messageFactory', $api);
     }
 
     /**
@@ -48,7 +36,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
      */
     public function throwIfRequiredOptionsNotSetInConstructor()
     {
-        new Api(array());
+        new Api(array(), $this->createHttpClientMock(), $this->createHttpMessageFactory());
     }
 
     /**
@@ -63,7 +51,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'username' => 'a_username',
             'password' => 'a_password',
             'signature' => 'a_signature',
-        ));
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
     }
 
     /**
@@ -79,7 +67,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'password' => 'a_password',
             'signature' => 'a_signature',
             'sandbox' => true,
-        ));
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
 
         $api->setExpressCheckout(array());
     }
@@ -96,7 +84,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'sandbox' => true,
             'return_url' => 'optionReturnUrl',
             'cancel_url' => 'optionCancelUrl',
-        ), $this->createSuccessHttpClientStub());
+        ), $this->createSuccessHttpClientStub(), $this->createHttpMessageFactory());
 
         $result = $api->setExpressCheckout(array('RETURNURL' => 'formRequestReturnUrl'));
 
@@ -115,7 +103,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'sandbox' => true,
             'return_url' => 'optionReturnUrl',
             'cancel_url' => 'optionCancelUrl',
-        ), $this->createSuccessHttpClientStub());
+        ), $this->createSuccessHttpClientStub(), $this->createHttpMessageFactory());
 
         $result = $api->setExpressCheckout(array());
 
@@ -135,7 +123,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'password' => 'a_password',
             'signature' => 'a_signature',
             'sandbox' => true,
-        ), $this->createHttpClientMock());
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
 
         $api->setExpressCheckout(array());
     }
@@ -152,7 +140,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'sandbox' => true,
             'return_url' => 'optionReturnUrl',
             'cancel_url' => 'optionCancelUrl',
-        ), $this->createSuccessHttpClientStub());
+        ), $this->createSuccessHttpClientStub(), $this->createHttpMessageFactory());
 
         $result = $api->setExpressCheckout(array('CANCELURL' => 'formRequestCancelUrl'));
 
@@ -171,7 +159,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'sandbox' => true,
             'return_url' => 'optionReturnUrl',
             'cancel_url' => 'optionCancelUrl',
-        ), $this->createSuccessHttpClientStub());
+        ), $this->createSuccessHttpClientStub(), $this->createHttpMessageFactory());
 
         $result = $api->setExpressCheckout(array());
 
@@ -190,7 +178,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'sandbox' => true,
             'return_url' => 'optionReturnUrl',
             'cancel_url' => 'optionCancelUrl',
-        ), $this->createSuccessHttpClientStub());
+        ), $this->createSuccessHttpClientStub(), $this->createHttpMessageFactory());
 
         $result = $api->setExpressCheckout(array());
 
@@ -210,7 +198,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'sandbox' => true,
             'return_url' => 'optionReturnUrl',
             'cancel_url' => 'optionCancelUrl',
-        ), $this->createSuccessHttpClientStub());
+        ), $this->createSuccessHttpClientStub(), $this->createHttpMessageFactory());
 
         $result = $api->setExpressCheckout(array());
 
@@ -236,7 +224,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'sandbox' => true,
             'return_url' => 'optionReturnUrl',
             'cancel_url' => 'optionCancelUrl',
-        ), $this->createSuccessHttpClientStub());
+        ), $this->createSuccessHttpClientStub(), $this->createHttpMessageFactory());
 
         $result = $api->setExpressCheckout(array());
 
@@ -254,7 +242,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'password' => 'a_password',
             'signature' => 'a_signature',
             'sandbox' => true,
-        ), $this->createHttpClientMock());
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
 
         $this->assertEquals(
             'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=theToken',
@@ -273,7 +261,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'signature' => 'a_signature',
             'sandbox' => true,
             'useraction' => 'aCustomUserAction',
-        ), $this->createHttpClientMock());
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
 
         $this->assertEquals(
             'https://www.sandbox.paypal.com/cgi-bin/webscr?useraction=aCustomUserAction&cmd=_express-checkout&token=theToken',
@@ -292,7 +280,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'signature' => 'a_signature',
             'sandbox' => true,
             'useraction' => 'notUsedUseraction',
-        ), $this->createHttpClientMock());
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
 
         $this->assertEquals(
             'https://www.sandbox.paypal.com/cgi-bin/webscr?useraction=theUseraction&cmd=_express-checkout&token=theToken',
@@ -311,7 +299,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'signature' => 'a_signature',
             'sandbox' => true,
             'cmd' => 'theCmd',
-        ), $this->createHttpClientMock());
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
 
         $this->assertEquals(
             'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=theCmd&token=theToken',
@@ -330,7 +318,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'signature' => 'a_signature',
             'sandbox' => true,
             'cmd' => 'thisCmdNotUsed',
-        ), $this->createHttpClientMock());
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
 
         $this->assertEquals(
             'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=theCmd&token=theToken',
@@ -348,7 +336,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'password' => 'a_password',
             'signature' => 'a_signature',
             'sandbox' => true,
-        ), $this->createHttpClientMock());
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
 
         $this->assertEquals(
             'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=theToken&foo=fooVal',
@@ -366,7 +354,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'password' => 'a_password',
             'signature' => 'a_signature',
             'sandbox' => true,
-        ), $this->createHttpClientMock());
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
 
         $this->assertEquals(
             'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=theToken',
@@ -384,7 +372,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'password' => 'a_password',
             'signature' => 'a_signature',
             'sandbox' => false,
-        ), $this->createHttpClientMock());
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
 
         $this->assertEquals(
             'https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=theToken',
@@ -417,7 +405,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'sandbox' => false,
             'return_url' => 'optionReturnUrl',
             'cancel_url' => 'optionCancelUrl',
-        ), $clientMock);
+        ), $clientMock, $this->createHttpMessageFactory());
 
         $api->setExpressCheckout(array());
     }
@@ -447,7 +435,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'sandbox' => true,
             'return_url' => 'optionReturnUrl',
             'cancel_url' => 'optionCancelUrl',
-        ), $clientMock);
+        ), $clientMock, $this->createHttpMessageFactory());
 
         $api->setExpressCheckout(array());
     }
@@ -458,6 +446,14 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     protected function createHttpClientMock()
     {
         return $this->getMock('Payum\Core\HttpClientInterface');
+    }
+
+    /**
+     * @return \Http\Message\MessageFactory
+     */
+    protected function createHttpMessageFactory()
+    {
+        return new GuzzleMessageFactory();
     }
 
     /**

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/composer.json
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/composer.json
@@ -24,8 +24,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
-        "symfony/phpunit-bridge": "~2.8|~3.0",
-        "guzzlehttp/psr7": "^1.1"
+        "symfony/phpunit-bridge": "~2.8|~3.0"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/composer.json
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/composer.json
@@ -24,7 +24,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
-        "symfony/phpunit-bridge": "~2.8|~3.0"
+        "symfony/phpunit-bridge": "~2.8|~3.0",
+        "guzzlehttp/psr7": "^1.1"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Payum/Paypal/Ipn/Api.php
+++ b/src/Payum/Paypal/Ipn/Api.php
@@ -1,9 +1,7 @@
 <?php
 namespace Payum\Paypal\Ipn;
 
-use Http\Discovery\MessageFactoryDiscovery;
 use Http\Message\MessageFactory;
-use Payum\Core\Bridge\Guzzle\HttpClientFactory;
 use Payum\Core\Exception\Http\HttpException;
 use Payum\Core\Exception\InvalidArgumentException;
 use Payum\Core\HttpClientInterface;
@@ -45,10 +43,10 @@ class Api
      * @param HttpClientInterface $client
      * @param MessageFactory      $messageFactory
      */
-    public function __construct(array $options, HttpClientInterface $client = null, MessageFactory $messageFactory = null)
+    public function __construct(array $options, HttpClientInterface $client, MessageFactory $messageFactory)
     {
-        $this->client = $client ?: HttpClientFactory::create();
-        $this->messageFactory = $messageFactory ?: MessageFactoryDiscovery::find();
+        $this->client = $client;
+        $this->messageFactory = $messageFactory;
 
         $this->options = $options;
 

--- a/src/Payum/Paypal/Ipn/Api.php
+++ b/src/Payum/Paypal/Ipn/Api.php
@@ -1,7 +1,8 @@
 <?php
 namespace Payum\Paypal\Ipn;
 
-use GuzzleHttp\Psr7\Request;
+use Http\Discovery\MessageFactoryDiscovery;
+use Http\Message\MessageFactory;
 use Payum\Core\Bridge\Guzzle\HttpClientFactory;
 use Payum\Core\Exception\Http\HttpException;
 use Payum\Core\Exception\InvalidArgumentException;
@@ -30,6 +31,11 @@ class Api
     protected $client;
 
     /**
+     * @var MessageFactory
+     */
+    protected $messageFactory;
+
+    /**
      * @var array
      */
     protected $options;
@@ -37,10 +43,12 @@ class Api
     /**
      * @param array               $options
      * @param HttpClientInterface $client
+     * @param MessageFactory      $messageFactory
      */
-    public function __construct(array $options, HttpClientInterface $client = null)
+    public function __construct(array $options, HttpClientInterface $client = null, MessageFactory $messageFactory = null)
     {
         $this->client = $client ?: HttpClientFactory::create();
+        $this->messageFactory = $messageFactory ?: MessageFactoryDiscovery::find();
 
         $this->options = $options;
 
@@ -62,7 +70,7 @@ class Api
             'Content-Type' => 'application/x-www-form-urlencoded',
         );
 
-        $request = new Request('POST', $this->getIpnEndpoint(), $headers, http_build_query($fields));
+        $request = $this->messageFactory->createRequest('POST', $this->getIpnEndpoint(), $headers, http_build_query($fields));
 
         $response = $this->client->send($request);
 

--- a/src/Payum/Paypal/Ipn/Tests/ApiTest.php
+++ b/src/Payum/Paypal/Ipn/Tests/ApiTest.php
@@ -2,6 +2,7 @@
 namespace Payum\Paypal\Ipn\Tests;
 
 use GuzzleHttp\Psr7\Response;
+use Http\Message\MessageFactory\GuzzleMessageFactory;
 use Payum\Core\HttpClientInterface;
 use Payum\Paypal\Ipn\Api;
 use Psr\Http\Message\RequestInterface;
@@ -15,7 +16,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     {
         new Api(array(
             'sandbox' => true,
-        ), $this->createHttpClientMock());
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
     }
 
     /**
@@ -26,7 +27,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
      */
     public function throwIfSandboxOptionNotSetInConstructor()
     {
-        new Api(array(), $this->createHttpClientMock());
+        new Api(array(), $this->createHttpClientMock(), $this->createHttpMessageFactory());
     }
 
     /**
@@ -36,7 +37,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     {
         $api = new Api(array(
             'sandbox' => true,
-        ), $this->createHttpClientMock());
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
 
         $this->assertEquals('https://www.sandbox.paypal.com/cgi-bin/webscr', $api->getIpnEndpoint());
     }
@@ -48,7 +49,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     {
         $api = new Api(array(
             'sandbox' => false,
-        ), $this->createHttpClientMock());
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
 
         $this->assertEquals('https://www.paypal.com/cgi-bin/webscr', $api->getIpnEndpoint());
     }
@@ -72,7 +73,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
 
         $api = new Api(array(
             'sandbox' => false,
-        ), $clientMock);
+        ), $clientMock, $this->createHttpMessageFactory());
 
         $api->notifyValidate(array());
     }
@@ -98,7 +99,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
 
         $api = new Api(array(
             'sandbox' => false,
-        ), $clientMock);
+        ), $clientMock, $this->createHttpMessageFactory());
 
         $expectedNotification = array(
             'foo' => 'foo',
@@ -132,7 +133,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
 
         $api = new Api(array(
             'sandbox' => false,
-        ), $clientMock);
+        ), $clientMock, $this->createHttpMessageFactory());
 
         $this->assertEquals(Api::NOTIFY_VERIFIED, $api->notifyValidate(array()));
     }
@@ -153,7 +154,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
 
         $api = new Api(array(
             'sandbox' => false,
-        ), $clientMock);
+        ), $clientMock, $this->createHttpMessageFactory());
 
         $this->assertEquals(Api::NOTIFY_INVALID, $api->notifyValidate(array()));
     }
@@ -174,7 +175,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
 
         $api = new Api(array(
             'sandbox' => false,
-        ), $clientMock);
+        ), $clientMock, $this->createHttpMessageFactory());
 
         $this->assertEquals(Api::NOTIFY_INVALID, $api->notifyValidate(array()));
     }
@@ -185,6 +186,14 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     protected function createHttpClientMock()
     {
         return $this->getMock('Payum\Core\HttpClientInterface', array('send'));
+    }
+
+    /**
+     * @return \Http\Message\MessageFactory
+     */
+    protected function createHttpMessageFactory()
+    {
+        return new GuzzleMessageFactory();
     }
 
     /**

--- a/src/Payum/Paypal/Ipn/composer.json
+++ b/src/Payum/Paypal/Ipn/composer.json
@@ -24,8 +24,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
-        "symfony/phpunit-bridge": "~2.8|~3.0",
-        "guzzlehttp/psr7": "^1.1"
+        "symfony/phpunit-bridge": "~2.8|~3.0"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Payum/Paypal/Ipn/composer.json
+++ b/src/Payum/Paypal/Ipn/composer.json
@@ -24,7 +24,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
-        "symfony/phpunit-bridge": "~2.8|~3.0"
+        "symfony/phpunit-bridge": "~2.8|~3.0",
+        "guzzlehttp/psr7": "^1.1"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Payum/Paypal/ProCheckout/Nvp/Api.php
+++ b/src/Payum/Paypal/ProCheckout/Nvp/Api.php
@@ -1,7 +1,8 @@
 <?php
 namespace Payum\Paypal\ProCheckout\Nvp;
 
-use GuzzleHttp\Psr7\Request;
+use Http\Discovery\MessageFactoryDiscovery;
+use Http\Message\MessageFactory;
 use Payum\Core\Bridge\Guzzle\HttpClientFactory;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Exception\Http\HttpException;
@@ -164,6 +165,11 @@ class Api
     protected $client;
 
     /**
+     * @var MessageFactory
+     */
+    protected $messageFactory;
+
+    /**
      * @var array
      */
     protected $options = array(
@@ -176,12 +182,13 @@ class Api
     );
 
     /**
-     * @param array $options
+     * @param array               $options
      * @param HttpClientInterface $client
+     * @param MessageFactory      $messageFactory
      *
      * @throw InvalidArgumentException
      */
-    public function __construct(array $options, HttpClientInterface $client = null)
+    public function __construct(array $options, HttpClientInterface $client = null, MessageFactory $messageFactory = null)
     {
         $options = ArrayObject::ensureArrayObject($options);
         $options->defaults($this->options);
@@ -199,6 +206,7 @@ class Api
 
         $this->options = $options;
         $this->client = $client ?: HttpClientFactory::create();
+        $this->messageFactory = $messageFactory ?: MessageFactoryDiscovery::find();
     }
 
     /**
@@ -244,7 +252,7 @@ class Api
             'Content-Type' => 'application/x-www-form-urlencoded',
         );
 
-        $request = new Request('POST', $this->getApiEndpoint(), $headers, http_build_query($fields));
+        $request = $this->messageFactory->createRequest('POST', $this->getApiEndpoint(), $headers, http_build_query($fields));
 
         $response = $this->client->send($request);
 

--- a/src/Payum/Paypal/ProCheckout/Nvp/Api.php
+++ b/src/Payum/Paypal/ProCheckout/Nvp/Api.php
@@ -1,9 +1,7 @@
 <?php
 namespace Payum\Paypal\ProCheckout\Nvp;
 
-use Http\Discovery\MessageFactoryDiscovery;
 use Http\Message\MessageFactory;
-use Payum\Core\Bridge\Guzzle\HttpClientFactory;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Exception\Http\HttpException;
 use Payum\Core\Exception\LogicException;
@@ -188,7 +186,7 @@ class Api
      *
      * @throw InvalidArgumentException
      */
-    public function __construct(array $options, HttpClientInterface $client = null, MessageFactory $messageFactory = null)
+    public function __construct(array $options, HttpClientInterface $client, MessageFactory $messageFactory)
     {
         $options = ArrayObject::ensureArrayObject($options);
         $options->defaults($this->options);
@@ -205,8 +203,8 @@ class Api
         }
 
         $this->options = $options;
-        $this->client = $client ?: HttpClientFactory::create();
-        $this->messageFactory = $messageFactory ?: MessageFactoryDiscovery::find();
+        $this->client = $client;
+        $this->messageFactory = $messageFactory;
     }
 
     /**

--- a/src/Payum/Paypal/ProCheckout/Nvp/PaypalProCheckoutGatewayFactory.php
+++ b/src/Payum/Paypal/ProCheckout/Nvp/PaypalProCheckoutGatewayFactory.php
@@ -49,7 +49,7 @@ class PaypalProCheckoutGatewayFactory extends GatewayFactory
                     'sandbox' => $config['sandbox'],
                 );
 
-                return new Api($paypalConfig, $config['payum.http_client']);
+                return new Api($paypalConfig, $config['payum.http_client'], $config['httplug.message_factory']);
             };
         }
     }

--- a/src/Payum/Paypal/ProCheckout/Nvp/Tests/ApiTest.php
+++ b/src/Payum/Paypal/ProCheckout/Nvp/Tests/ApiTest.php
@@ -2,6 +2,7 @@
 namespace Payum\Paypal\ProCheckout\Nvp\Tests;
 
 use GuzzleHttp\Psr7\Response;
+use Http\Message\MessageFactory\GuzzleMessageFactory;
 use Payum\Core\HttpClientInterface;
 use Payum\Paypal\ProCheckout\Nvp\Api;
 use Psr\Http\Message\RequestInterface;
@@ -11,25 +12,10 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function couldBeConstructedWithOptionsOnly()
-    {
-        $api = new Api(array(
-            'username' => 'aUsername',
-            'password' => 'aPassword',
-            'partner' => 'aPartner',
-            'vendor' => 'aVendor',
-            'tender' => 'aTender'
-        ));
-
-        $this->assertAttributeInstanceOf('Payum\Core\HttpClientInterface', 'client', $api);
-    }
-
-    /**
-     * @test
-     */
     public function couldBeConstructedWithOptionsAndHttpClient()
     {
         $client = $this->createHttpClientMock();
+        $factory = $this->createHttpMessageFactory();
 
         $api = new Api(array(
             'username' => 'aUsername',
@@ -37,9 +23,10 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'partner' => 'aPartner',
             'vendor' => 'aVendor',
             'tender' => 'aTender'
-        ), $client);
+        ), $client, $factory);
 
         $this->assertAttributeSame($client, 'client', $api);
+        $this->assertAttributeSame($factory, 'messageFactory', $api);
     }
 
     /**
@@ -50,7 +37,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
      */
     public function throwIfRequiredOptionsNotSetInConstructor()
     {
-        new Api(array());
+        new Api(array(), $this->createHttpClientMock(), $this->createHttpMessageFactory());
     }
 
     /**
@@ -68,7 +55,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'vendor' => 'aVendor',
             'tender' => 'aTender',
             'sandbox' => 'notABool'
-        ));
+        ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
     }
 
     /**
@@ -82,7 +69,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'partner' => 'aPartner',
             'vendor' => 'aVendor',
             'tender' => 'aTender'
-        ), $this->createSuccessHttpClientStub());
+        ), $this->createSuccessHttpClientStub(), $this->createHttpMessageFactory());
 
         $result = $api->doSale(array());
 
@@ -101,7 +88,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'partner' => 'aPartner',
             'vendor' => 'aVendor',
             'tender' => 'aTender'
-        ), $this->createSuccessHttpClientStub());
+        ), $this->createSuccessHttpClientStub(), $this->createHttpMessageFactory());
 
         $result = $api->doCredit(array());
 
@@ -120,7 +107,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'partner' => 'thePartner',
             'vendor' => 'theVendor',
             'tender' => 'theTender'
-        ), $this->createSuccessHttpClientStub());
+        ), $this->createSuccessHttpClientStub(), $this->createHttpMessageFactory());
 
         $result = $api->doSale(array());
 
@@ -151,7 +138,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'partner' => 'thePartner',
             'vendor' => 'theVendor',
             'tender' => 'theTender'
-        ), $this->createSuccessHttpClientStub());
+        ), $this->createSuccessHttpClientStub(), $this->createHttpMessageFactory());
 
         $result = $api->doCredit(array());
 
@@ -196,7 +183,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'vendor' => 'theVendor',
             'tender' => 'theTender',
             'sandbox' => false,
-        ), $clientMock);
+        ), $clientMock, $this->createHttpMessageFactory());
 
         $api->doCredit(array());
     }
@@ -226,7 +213,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'vendor' => 'theVendor',
             'tender' => 'theTender',
             'sandbox' => true,
-        ), $clientMock);
+        ), $clientMock, $this->createHttpMessageFactory());
 
         $api->doCredit(array());
     }
@@ -237,6 +224,14 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     protected function createHttpClientMock()
     {
         return $this->getMock('Payum\Core\HttpClientInterface');
+    }
+
+    /**
+     * @return \Http\Message\MessageFactory
+     */
+    protected function createHttpMessageFactory()
+    {
+        return new GuzzleMessageFactory();
     }
 
     /**

--- a/src/Payum/Paypal/ProCheckout/Nvp/composer.json
+++ b/src/Payum/Paypal/ProCheckout/Nvp/composer.json
@@ -28,7 +28,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
-        "symfony/phpunit-bridge": "~2.8|~3.0"
+        "symfony/phpunit-bridge": "~2.8|~3.0",
+        "guzzlehttp/psr7": "^1.1"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Payum/Paypal/ProCheckout/Nvp/composer.json
+++ b/src/Payum/Paypal/ProCheckout/Nvp/composer.json
@@ -28,8 +28,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
-        "symfony/phpunit-bridge": "~2.8|~3.0",
-        "guzzlehttp/psr7": "^1.1"
+        "symfony/phpunit-bridge": "~2.8|~3.0"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Payum/Skeleton/Api.php
+++ b/src/Payum/Skeleton/Api.php
@@ -1,9 +1,7 @@
 <?php
 namespace Payum\Skeleton;
 
-use Http\Discovery\MessageFactoryDiscovery;
 use Http\Message\MessageFactory;
-use Payum\Core\Bridge\Guzzle\HttpClientFactory;
 use Payum\Core\Exception\Http\HttpException;
 use Payum\Core\HttpClientInterface;
 
@@ -31,11 +29,11 @@ class Api
      *
      * @throws \Payum\Core\Exception\InvalidArgumentException if an option is invalid
      */
-    public function __construct(array $options, HttpClientInterface $client = null, MessageFactory $messageFactory = null)
+    public function __construct(array $options, HttpClientInterface $client, MessageFactory $messageFactory)
     {
         $this->options = $options;
-        $this->client = $client ?: HttpClientFactory::create();
-        $this->messageFactory = $messageFactory ?: MessageFactoryDiscovery::find();
+        $this->client = $client;
+        $this->messageFactory = $messageFactory;
     }
 
     /**

--- a/src/Payum/Skeleton/Api.php
+++ b/src/Payum/Skeleton/Api.php
@@ -1,7 +1,8 @@
 <?php
 namespace Payum\Skeleton;
 
-use GuzzleHttp\Psr7\Request;
+use Http\Discovery\MessageFactoryDiscovery;
+use Http\Message\MessageFactory;
 use Payum\Core\Bridge\Guzzle\HttpClientFactory;
 use Payum\Core\Exception\Http\HttpException;
 use Payum\Core\HttpClientInterface;
@@ -14,6 +15,11 @@ class Api
     protected $client;
 
     /**
+     * @var MessageFactory
+     */
+    protected $messageFactory;
+
+    /**
      * @var array
      */
     protected $options = [];
@@ -21,13 +27,15 @@ class Api
     /**
      * @param array               $options
      * @param HttpClientInterface $client
+     * @param MessageFactory      $messageFactory
      *
      * @throws \Payum\Core\Exception\InvalidArgumentException if an option is invalid
      */
-    public function __construct(array $options, HttpClientInterface $client = null)
+    public function __construct(array $options, HttpClientInterface $client = null, MessageFactory $messageFactory = null)
     {
         $this->options = $options;
         $this->client = $client ?: HttpClientFactory::create();
+        $this->messageFactory = $messageFactory ?: MessageFactoryDiscovery::find();
     }
 
     /**
@@ -39,7 +47,7 @@ class Api
     {
         $headers = [];
 
-        $request = new Request($method, $this->getApiEndpoint(), $headers, http_build_query($fields));
+        $request = $this->messageFactory->createRequest($method, $this->getApiEndpoint(), $headers, http_build_query($fields));
 
         $response = $this->client->send($request);
 

--- a/src/Payum/Skeleton/SkeletonGatewayFactory.php
+++ b/src/Payum/Skeleton/SkeletonGatewayFactory.php
@@ -40,7 +40,7 @@ class SkeletonGatewayFactory extends GatewayFactory
             $config['payum.api'] = function (ArrayObject $config) {
                 $config->validateNotEmpty($config['payum.required_options']);
 
-                return new Api((array) $config, $config['payum.http_client']);
+                return new Api((array) $config, $config['payum.http_client'], $config['httplug.message_factory']);
             };
         }
     }

--- a/src/Payum/Sofort/Resources/docs/get-it-started.md
+++ b/src/Payum/Sofort/Resources/docs/get-it-started.md
@@ -10,7 +10,7 @@ The preferred way to install the library is using [composer](http://getcomposer.
 Run composer require to add dependencies to _composer.json_:
 
 ```bash
-php composer.phar require payum/sofort
+php composer.phar require payum/sofort php-http/guzzle6-adapter
 ```
 
 ## config.php

--- a/src/Payum/Stripe/Resources/docs/checkout.md
+++ b/src/Payum/Stripe/Resources/docs/checkout.md
@@ -10,7 +10,7 @@ The preferred way to install the library is using [composer](http://getcomposer.
 Run composer require to add dependencies to _composer.json_:
 
 ```bash
-php composer.phar require payum/stripe
+php composer.phar require payum/stripe php-http/guzzle6-adapter
 ```
 
 ## config.php

--- a/src/Payum/Stripe/Resources/docs/get-it-started.md
+++ b/src/Payum/Stripe/Resources/docs/get-it-started.md
@@ -10,7 +10,7 @@ The preferred way to install the library is using [composer](http://getcomposer.
 Run composer require to add dependencies to _composer.json_:
 
 ```bash
-php composer.phar require payum/stripe
+php composer.phar require payum/stripe php-http/guzzle6-adapter
 ```
 
 ## config.php


### PR DESCRIPTION
This is PR will remove our hard coupled dependency on Guzzle6 and instead rely on an interface. This will make the Payum package more SOLID. With this PR we allow users that are stuck with using Guzzle5 to use Payum. 

~~This PR introduce some small BC breaks. I've removed the function `HttpClientFactory::createGuzzle` and also the config parameter named `guzzle.client`.~~

This will fix #491

### Usage

```php
/** @var Payum $payum */
$payum = (new PayumBuilder())
    ->addDefaultStorages()
    ->addGateway('gatewayName', [
        'factory' => 'aGateway'
        'httplug.client' => new \Http\Adapter\Guzzle6\Client(),
    ])
    ->getPayum()
;
```

### TODO
* [x] Make code changes
* [x] Deprecate existing classes tightly coupled to Guzzle
* [x] Add documentation


### Implications

When you update to Payum 1.3.0 the installation will fail because you need to install a [client implementation](https://packagist.org/providers/php-http/client-implementation). If you choose `php-http/guzzle6-adapter` everything will work **exactly** as before. No BC breaks. 