### PR TITLE
Replace deprecated League\Url with League\Uri

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "php": "^5.5.0|^7.0",
         "payum/iso4217": "~1.0",
         "guzzlehttp/guzzle": "~6.0",
-        "league/url": "~3.0",
+        "league/uri": "~4.0",
         "twig/twig": "~1.0"
     },
     "require-dev": {

--- a/src/Payum/Be2Bill/Action/CaptureOffsiteNullAction.php
+++ b/src/Payum/Be2Bill/Action/CaptureOffsiteNullAction.php
@@ -1,7 +1,8 @@
 <?php
 namespace Payum\Be2Bill\Action;
 
-use League\Url\Url;
+use League\Uri\Schemes\Http as HttpUri;
+use League\Uri\Components\Query;
 use Payum\Core\Action\GatewayAwareAction;
 use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\Reply\HttpRedirect;
@@ -39,10 +40,11 @@ class CaptureOffsiteNullAction extends GatewayAwareAction
 
         $this->gateway->execute($getToken = new GetToken($extraData['capture_token']));
 
-        $url = Url::createFromUrl($getToken->getToken()->getTargetUrl());
-        $url->setQuery($httpRequest->query);
+        $uri = HttpUri::createFromString($getToken->getToken()->getTargetUrl());
+        $uri = $uri->withQuery(Query::createFromArray($httpRequest->query)->__toString());
 
-        throw new HttpRedirect((string) $url);
+
+        throw new HttpRedirect((string) $uri);
     }
 
     /**

--- a/src/Payum/Be2Bill/Action/CaptureOffsiteNullAction.php
+++ b/src/Payum/Be2Bill/Action/CaptureOffsiteNullAction.php
@@ -41,7 +41,7 @@ class CaptureOffsiteNullAction extends GatewayAwareAction
         $this->gateway->execute($getToken = new GetToken($extraData['capture_token']));
 
         $uri = HttpUri::createFromString($getToken->getToken()->getTargetUrl());
-        $uri = $uri->withQuery(Query::createFromArray($httpRequest->query)->__toString());
+        $uri = $uri->withQuery((string)Query::createFromArray($httpRequest->query));
 
 
         throw new HttpRedirect((string) $uri);

--- a/src/Payum/Core/Bridge/PlainPhp/Security/TokenFactory.php
+++ b/src/Payum/Core/Bridge/PlainPhp/Security/TokenFactory.php
@@ -44,7 +44,7 @@ class TokenFactory extends AbstractTokenFactory
 
         $uri = HttpUri::createFromString($this->baseUrl);
         $uri = $uri->withPath($path);
-        $uri = $uri->withQuery(Query::createFromArray($parameters)->__toString());
+        $uri = $uri->withQuery((string)Query::createFromArray($parameters));
 
         return (string)$uri;
     }

--- a/src/Payum/Core/Security/AbstractTokenFactory.php
+++ b/src/Payum/Core/Security/AbstractTokenFactory.php
@@ -40,11 +40,11 @@ abstract class AbstractTokenFactory implements TokenFactoryInterface
 
         if (0 === strpos($targetPath, 'http')) {
             $targetUri = HttpUri::createFromString($targetPath);
-            $targetUri = $targetUri->withQuery( Query::createFromArray(array_replace(
+            $targetUri = $targetUri->withQuery( (string) Query::createFromArray(array_replace(
                 array('payum_token' => $token->getHash()),
                 $targetUri->query->toArray(),
                 $targetParameters
-            ))->__toString());
+            )));
             $token->setTargetUrl((string) $targetUri);
         } else {
             $token->setTargetUrl($this->generateUrl($targetPath, array_replace(
@@ -56,8 +56,8 @@ abstract class AbstractTokenFactory implements TokenFactoryInterface
         if ($afterPath && 0 === strpos($afterPath, 'http')) {
             $afterUri = HttpUri::createFromString($afterPath);
 
-            $modifier = new MergeQuery(Query::createFromArray($afterParameters)->__toString());
-            $afterUri = $modifier->__invoke($afterUri);
+            $modifier = new MergeQuery((string)Query::createFromArray($afterParameters));
+            $afterUri = $modifier($afterUri);
 
             $token->setAfterUrl((string) $afterUri);
         } elseif ($afterPath) {

--- a/src/Payum/Core/Tests/Bridge/PlainPhp/Security/TokenFactoryTest.php
+++ b/src/Payum/Core/Tests/Bridge/PlainPhp/Security/TokenFactoryTest.php
@@ -37,7 +37,7 @@ class TokenFactoryTest extends \PHPUnit_Framework_TestCase
         new TokenFactory(
             $this->createStorageMock(),
             $this->createStorageRegistryMock(),
-            'http://example.com:80'
+            'http://example.com:8080'
         );
     }
 
@@ -80,7 +80,7 @@ class TokenFactoryTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($modelStorage))
         ;
 
-        $factory = new TokenFactory($tokenStorageMock, $storageRegistryMock, 'http://example.com:80');
+        $factory = new TokenFactory($tokenStorageMock, $storageRegistryMock, 'http://example.com:8080');
 
         $actualToken = $factory->createToken(
             $gatewayName,
@@ -93,7 +93,7 @@ class TokenFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($gatewayName, $token->getGatewayName());
         $this->assertSame($identity, $token->getDetails());
         $this->assertEquals(
-            'http://example.com:80/theTargetPath?payum_token='.$token->getHash().'&target=val',
+            'http://example.com:8080/theTargetPath?payum_token='.$token->getHash().'&target=val',
             $token->getTargetUrl()
         );
         $this->assertNull($token->getAfterUrl());
@@ -138,7 +138,7 @@ class TokenFactoryTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($modelStorage))
         ;
 
-        $factory = new TokenFactory($tokenStorageMock, $storageRegistryMock, 'http://example.com:80');
+        $factory = new TokenFactory($tokenStorageMock, $storageRegistryMock, 'http://example.com:8080');
 
         $actualToken = $factory->createToken(
             $gatewayName,
@@ -153,10 +153,10 @@ class TokenFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($gatewayName, $token->getGatewayName());
         $this->assertSame($identity, $token->getDetails());
         $this->assertEquals(
-            'http://example.com:80/theTargetPath?payum_token='.$token->getHash().'&target=val',
+            'http://example.com:8080/theTargetPath?payum_token='.$token->getHash().'&target=val',
             $token->getTargetUrl()
         );
-        $this->assertEquals('http://example.com:80/theAfterPath?after=val', $token->getAfterUrl());
+        $this->assertEquals('http://example.com:8080/theAfterPath?after=val', $token->getAfterUrl());
     }
 
     /**
@@ -187,7 +187,7 @@ class TokenFactoryTest extends \PHPUnit_Framework_TestCase
             ->method('getStorage')
         ;
 
-        $factory = new TokenFactory($tokenStorageMock, $storageRegistryMock, 'http://example.com:80');
+        $factory = new TokenFactory($tokenStorageMock, $storageRegistryMock, 'http://example.com:8080');
 
         $actualToken = $factory->createToken(
             $gatewayName,
@@ -229,7 +229,7 @@ class TokenFactoryTest extends \PHPUnit_Framework_TestCase
             ->method('getStorage')
         ;
 
-        $factory = new TokenFactory($tokenStorageMock, $storageRegistryMock, 'http://example.com:80');
+        $factory = new TokenFactory($tokenStorageMock, $storageRegistryMock, 'http://example.com:8080');
 
         $actualToken = $factory->createToken(
             $gatewayName,
@@ -283,12 +283,12 @@ class TokenFactoryTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($modelStorage))
         ;
 
-        $factory = new TokenFactory($tokenStorageMock, $storageRegistryMock, 'http://example.com:80');
+        $factory = new TokenFactory($tokenStorageMock, $storageRegistryMock, 'http://example.com:8080');
 
         $actualToken = $factory->createToken(
             $gatewayName,
             $model,
-            'http://google.com?foo=fooVal',
+            'http://google.com/?foo=fooVal',
             array('target' => 'val'),
             'theAfterPath',
             array('after' => 'val')
@@ -301,7 +301,7 @@ class TokenFactoryTest extends \PHPUnit_Framework_TestCase
             'http://google.com/?payum_token='.$token->getHash().'&foo=fooVal&target=val',
             $token->getTargetUrl()
         );
-        $this->assertEquals('http://example.com:80/theAfterPath?after=val', $token->getAfterUrl());
+        $this->assertEquals('http://example.com:8080/theAfterPath?after=val', $token->getAfterUrl());
     }
 
     /**
@@ -343,7 +343,7 @@ class TokenFactoryTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($modelStorage))
         ;
 
-        $factory = new TokenFactory($tokenStorageMock, $storageRegistryMock, 'http://example.com:80');
+        $factory = new TokenFactory($tokenStorageMock, $storageRegistryMock, 'http://example.com:8080');
 
         $actualToken = $factory->createToken(
             $gatewayName,
@@ -406,7 +406,7 @@ class TokenFactoryTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($modelStorage))
         ;
 
-        $factory = new TokenFactory($tokenStorageMock, $storageRegistryMock, 'http://example.com:80');
+        $factory = new TokenFactory($tokenStorageMock, $storageRegistryMock, 'http://example.com:8080');
 
         $actualToken = $factory->createToken(
             $gatewayName,
@@ -425,7 +425,7 @@ class TokenFactoryTest extends \PHPUnit_Framework_TestCase
             $authorizeToken->getTargetUrl()
         );
         $this->assertEquals(
-            'http://google.com/?afterKey=afterVal',
+            'http://google.com/?payum_token&afterKey=afterVal',
             $authorizeToken->getAfterUrl()
         );
     }
@@ -469,7 +469,7 @@ class TokenFactoryTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($modelStorage))
         ;
 
-        $factory = new TokenFactory($tokenStorageMock, $storageRegistryMock, 'http://example.com:80');
+        $factory = new TokenFactory($tokenStorageMock, $storageRegistryMock, 'http://example.com:8080');
 
         $actualToken = $factory->createToken(
             $gatewayName,
@@ -488,7 +488,7 @@ class TokenFactoryTest extends \PHPUnit_Framework_TestCase
             $authorizeToken->getTargetUrl()
         );
         $this->assertEquals(
-            'http://google.com/foo/bar?foo=fooVal#fragment',
+            'http://google.com/foo/bar?foo=fooVal&payum_token#fragment',
             $authorizeToken->getAfterUrl()
         );
     }

--- a/src/Payum/Core/Tests/Bridge/Symfony/Security/TokenFactoryTest.php
+++ b/src/Payum/Core/Tests/Bridge/Symfony/Security/TokenFactoryTest.php
@@ -289,7 +289,7 @@ class TokenFactoryTest extends \PHPUnit_Framework_TestCase
         $actualToken = $factory->createToken(
             $gatewayName,
             $model,
-            'http://google.com?foo=fooVal',
+            'http://google.com/?foo=fooVal',
             array('target' => 'val'),
             'theAfterPath',
             array('after' => 'val')
@@ -426,7 +426,7 @@ class TokenFactoryTest extends \PHPUnit_Framework_TestCase
             $authorizeToken->getTargetUrl()
         );
         $this->assertEquals(
-            'http://google.com/?afterKey=afterVal',
+            'http://google.com/?payum_token&afterKey=afterVal',
             $authorizeToken->getAfterUrl()
         );
     }
@@ -489,7 +489,7 @@ class TokenFactoryTest extends \PHPUnit_Framework_TestCase
             $authorizeToken->getTargetUrl()
         );
         $this->assertEquals(
-            'http://google.com/foo/bar?foo=fooVal#fragment',
+            'http://google.com/foo/bar?foo=fooVal&payum_token#fragment',
             $authorizeToken->getAfterUrl()
         );
     }

--- a/src/Payum/Core/Tests/Security/AbstractTokenFactoryTest.php
+++ b/src/Payum/Core/Tests/Security/AbstractTokenFactoryTest.php
@@ -284,7 +284,7 @@ class AbstractTokenFactoryTest extends \PHPUnit_Framework_TestCase
         $actualToken = $factory->createToken(
             $gatewayName,
             $model,
-            'http://google.com?foo=fooVal',
+            'http://google.com/?foo=fooVal',
             array('target' => 'val'),
             'theAfterPath',
             array('after' => 'val')
@@ -421,7 +421,7 @@ class AbstractTokenFactoryTest extends \PHPUnit_Framework_TestCase
             $authorizeToken->getTargetUrl()
         );
         $this->assertEquals(
-            'http://google.com/?afterKey=afterVal',
+            'http://google.com/?payum_token&afterKey=afterVal',
             $authorizeToken->getAfterUrl()
         );
     }
@@ -484,7 +484,7 @@ class AbstractTokenFactoryTest extends \PHPUnit_Framework_TestCase
             $authorizeToken->getTargetUrl()
         );
         $this->assertEquals(
-            'http://google.com/foo/bar?foo=fooVal#fragment',
+            'http://google.com/foo/bar?foo=fooVal&payum_token#fragment',
             $authorizeToken->getAfterUrl()
         );
     }

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Action/PurchaseAction.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Action/PurchaseAction.php
@@ -1,7 +1,8 @@
 <?php
 namespace Payum\Paypal\ExpressCheckout\Nvp\Action;
 
-use League\Url\Url;
+use League\Uri\Schemes\Http as HttpUri;
+use League\Uri\Modifiers\MergeQuery;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Request\Capture;
 use Payum\Core\Request\GetHttpRequest;
@@ -77,12 +78,11 @@ abstract class PurchaseAction extends GatewayAwareAction implements GenericToken
             }
 
             if ($details['CANCELURL']) {
-                $cancelUrl = Url::createFromUrl($details['CANCELURL']);
-                $query = $cancelUrl->getQuery();
-                $query->modify(['cancelled' => 1]);
-                $cancelUrl->setQuery($query);
+                $cancelUri = HttpUri::createFromString($details['CANCELURL']);
+                $modifier = new MergeQuery('cancelled=1');
+                $cancelUri = $modifier->__invoke($cancelUri);
 
-                $details['CANCELURL'] = (string) $cancelUrl;
+                $details['CANCELURL'] = (string) $cancelUri;
             }
 
             $this->gateway->execute(new SetExpressCheckout($details));

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Action/PurchaseAction.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Action/PurchaseAction.php
@@ -80,7 +80,7 @@ abstract class PurchaseAction extends GatewayAwareAction implements GenericToken
             if ($details['CANCELURL']) {
                 $cancelUri = HttpUri::createFromString($details['CANCELURL']);
                 $modifier = new MergeQuery('cancelled=1');
-                $cancelUri = $modifier->__invoke($cancelUri);
+                $cancelUri = $modifier($cancelUri);
 
                 $details['CANCELURL'] = (string) $cancelUri;
             }


### PR DESCRIPTION
- Url null parameters  are used to be omitted now they are just empty
   Url lib:    ['var1'=>null]  -->  http://example.com/  
   Uri lib:    ['var1'=>null]  -->  http://example.com/?var1  
- Uri's are normalized out of the box. http://uri.thephpleague.com/uri/instantiation/
  http://example.com:80/xxx   -->   http://example.com/xxx  
