### PR TITLE
[Symfony Bridge] Action for Symfony Templating Component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
         "symfony/http-kernel": "~2.8|~3.0",
         "symfony/http-foundation": "~2.8|~3.0",
         "symfony/form": "~2.8|~3.0",
+        "symfony/templating": "~2.8|~3.0",
         "symfony/validator": "~2.8|~3.0",
         "symfony/phpunit-bridge": "~2.8|~3.0",
         "symfony/dependency-injection": "~2.8|~3.0",

--- a/src/Payum/Core/Bridge/Symfony/Action/RenderTemplateAction.php
+++ b/src/Payum/Core/Bridge/Symfony/Action/RenderTemplateAction.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Payum\Core\Bridge\Symfony\Action;
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Request\RenderTemplate;
+use Symfony\Component\Templating\EngineInterface;
+
+class RenderTemplateAction implements ActionInterface
+{
+    /**
+     * @var EngineInterface
+     */
+    private $templating;
+
+    /**
+     * @var string
+     */
+    protected $layout;
+
+    public function __construct(EngineInterface $templating, $layout = null)
+    {
+        $this->templating = $templating;
+        $this->layout = $layout;
+    }
+
+    /**
+     * @param mixed $request
+     *
+     * @throws \Payum\Core\Exception\RequestNotSupportedException if the action dose not support the request.
+     */
+    public function execute($request)
+    {
+        /** @var $request RenderTemplate */
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        $request->setResult(
+            $this->templating->render(
+                $request->getTemplateName(), array_replace(
+                    ['layout' => $this->layout],
+                    $request->getParameters()
+                )
+            )
+        );
+    }
+
+    /**
+     * @param mixed $request
+     *
+     * @return boolean
+     */
+    public function supports($request)
+    {
+        return $request instanceof RenderTemplate;
+    }
+}

--- a/src/Payum/Core/Tests/Bridge/Symfony/Action/RenderTemplateActionTest.php
+++ b/src/Payum/Core/Tests/Bridge/Symfony/Action/RenderTemplateActionTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Payum\Core\Tests\Bridge\Symfony\Action\Http;
+
+use Payum\Core\Bridge\Symfony\Action\RenderTemplateAction;
+use Payum\Core\Request\Generic;
+use Payum\Core\Request\RenderTemplate;
+use Payum\Core\Tests\GenericActionTest;
+use Symfony\Component\Templating\EngineInterface;
+
+class RenderTemplateActionTest extends GenericActionTest
+{
+    /**
+     * @var string
+     */
+    protected $requestClass = RenderTemplate::class;
+
+    /**
+     * @var string
+     */
+    protected $actionClass = RenderTemplateAction::class;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $templating;
+
+    protected function setUp()
+    {
+        $this->templating = $this->getMock(EngineInterface::class);
+        $this->action = new $this->actionClass($this->templating, 'layout.html.engine');
+    }
+
+    public function couldBeConstructedWithoutAnyArguments()
+    {
+        //overwrite
+    }
+
+    public function provideNotSupportedRequests()
+    {
+        return array(
+            array('foo'),
+            array(array('foo')),
+            array(new \stdClass()),
+            array($this->getMockForAbstractClass(Generic::class, array(array()))),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCallRenderWithCorrectArguments()
+    {
+        $this->templating
+            ->expects($this->once())
+            ->method('render')
+            ->with(
+                'template.html.engine',
+                [
+                    'layout' => 'layout.html.engine',
+                    'foo' => 'bar',
+                ]
+            );
+
+        $request = new $this->requestClass('template.html.engine', ['foo' => 'bar']);
+        $this->action->execute($request);
+    }
+}


### PR DESCRIPTION
Payum currently has a hard dependency on Twig. Adding this Action allows using other template engines easily. In the PayumBundle we could add a service definition like this...

```yml
services:
    payum.render_action:
        class: Payum\Core\Bridge\Symfony\Action\RenderTemplateAction
        arguments: ["@templating", '@PayumCore/layout.html.twig']
        tags:
            - { name: payum.action, all: true, alias: payum.action.render_template }
```

...and override the default twig render action.

This is backward compatible as long as twig is enabled in Symfony. And it also allows overriding the templates and using other template engines.