### PR TITLE
Fix stripe auto open

### DIFF
--- a/src/Payum/Stripe/Resources/views/Action/obtain_checkout_token.html.twig
+++ b/src/Payum/Stripe/Resources/views/Action/obtain_checkout_token.html.twig
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 
     <script type="text/javascript">
-        $('form .stripe-button-el').click();
+        $(function() {$('form .stripe-button-el').click();});
     </script>
 
 {% endblock %}


### PR DESCRIPTION
The stripe modal doesn't auto-open on load for me, possibly due to ordering of the block output? 

Using $(document).ready fixes it for me at least, and probably others - I'm seeing the issue whilst using sylius/sylius-standard.