### PR TITLE
Made ApiAwareTrait interface tolerant

### DIFF
--- a/src/Payum/Core/ApiAwareTrait.php
+++ b/src/Payum/Core/ApiAwareTrait.php
@@ -24,7 +24,7 @@ trait ApiAwareTrait
         if (empty($this->apiClass)) {
             throw new LogicException(sprintf('You must configure apiClass in __constructor method of the class the trait is applied to.'));
         }
-        if (false == class_exists($this->apiClass)) {
+        if (false == (class_exists($this->apiClass) || interface_exists($this->apiClass))) {
             throw new LogicException(sprintf('Api class not found or invalid class. "%s", $this->apiClass', $this->apiClass));
         }
         

--- a/src/Payum/Core/Tests/ApiAwareTraitTest.php
+++ b/src/Payum/Core/Tests/ApiAwareTraitTest.php
@@ -45,6 +45,18 @@ class ApiAwareTraitTest extends \PHPUnit_Framework_TestCase
 
         $this->assertAttributeSame($expectedApi, 'api', $object);
     }
+
+    public function testShouldSetApiIfSupportedWithInterface()
+    {
+        $expectedApi = new FooApi;
+
+        $object = new ApiAwareClass;
+        $object->setApiClass(FooInterface::class);
+
+        $object->setApi($expectedApi);
+
+        $this->assertAttributeSame($expectedApi, 'api', $object);
+    }
 }
 
 class ApiAwareClass
@@ -56,4 +68,12 @@ class ApiAwareClass
 
 
     use ApiAwareTrait;
+}
+
+interface FooInterface
+{
+}
+
+class FooApi implements FooInterface
+{
 }


### PR DESCRIPTION
In some cases, one may want to define `$apiClass` as an interface, not the implementation. This helps building more generic and subsitutable components.

Fixes https://github.com/Payum/JMSPaymentBridge/pull/6