### PR TITLE
Adds DoVoid PayPal express NVP method as the gateway's Cancel action.

### DIFF
--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Action/Api/DoVoidAction.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Action/Api/DoVoidAction.php
@@ -1,13 +1,27 @@
 <?php
 namespace Payum\Paypal\ExpressCheckout\Nvp\Action\Api;
 
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\ApiAwareInterface;
+use Payum\Core\ApiAwareTrait;
 use Payum\Core\Bridge\Spl\ArrayObject;
-use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\Exception\LogicException;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\GatewayAwareInterface;
+use Payum\Core\GatewayAwareTrait;
+use Payum\Paypal\ExpressCheckout\Nvp\Api;
 use Payum\Paypal\ExpressCheckout\Nvp\Request\Api\DoVoid;
 
-class DoVoidAction extends BaseApiAwareAction
+class DoVoidAction implements ActionInterface, ApiAwareInterface, GatewayAwareInterface
 {
+    use ApiAwareTrait;
+    use GatewayAwareTrait;
+
+    public function __construct()
+    {
+        $this->apiClass = Api::class;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -18,8 +32,8 @@ class DoVoidAction extends BaseApiAwareAction
 
         $model = ArrayObject::ensureArrayObject($request->getModel());
 
-        if (null === $model['TRANSACTIONID']) {
-            throw new LogicException('TRANSACTIONID must be set. Has user not authorized this transaction?');
+        if (null === $model['AUTHORIZATIONID']) {
+            throw new LogicException('AUTHORIZATIONID must be set. Has user not authorized this transaction?');
         }
 
         $model->replace(

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Action/Api/DoVoidAction.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Action/Api/DoVoidAction.php
@@ -1,0 +1,61 @@
+<?php
+namespace Payum\Paypal\ExpressCheckout\Nvp\Action\Api;
+
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\GatewayAwareInterface;
+use Payum\Core\GatewayInterface;
+use Payum\Paypal\ExpressCheckout\Nvp\Request\Api\DoVoid;
+use Payum\Paypal\ExpressCheckout\Nvp\Request\Api\GetTransactionDetails;
+
+class DoVoidAction extends BaseApiAwareAction implements GatewayAwareInterface
+{
+    /**
+     * @var GatewayInterface
+     */
+    protected $gateway;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setGateway(GatewayInterface $gateway)
+    {
+        $this->gateway = $gateway;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute($request)
+    {
+        /** @var $request DoCapture */
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        $model = ArrayObject::ensureArrayObject($request->getModel());
+        $paymentRequestN = $request->getPaymentRequestN();
+
+        $fields = new ArrayObject([]);
+        $parentTransactionId = $model['PAYMENTREQUEST_'.$paymentRequestN.'_PARENTTRANSACTIONID'];
+        $fields['AUTHORIZATIONID'] = $parentTransactionId
+            ? $parentTransactionId
+            : $model['PAYMENTREQUEST_'.$paymentRequestN.'_TRANSACTIONID']
+        ;
+
+        $fields->validateNotEmpty(['AUTHORIZATIONID']);
+
+        $this->api->doVoid((array) $fields);
+
+        $this->gateway->execute(new GetTransactionDetails($model, $paymentRequestN));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($request)
+    {
+        return
+            $request instanceof DoVoid &&
+            $request->getModel() instanceof \ArrayAccess
+        ;
+    }
+}

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Action/CancelAction.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Action/CancelAction.php
@@ -3,11 +3,13 @@ namespace Payum\Paypal\ExpressCheckout\Nvp\Action;
 
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Request\Cancel;
+use Payum\Core\Request\Sync;
+use Payum\Core\Action\GatewayAwareAction;
 use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Paypal\ExpressCheckout\Nvp\Api;
 use Payum\Paypal\ExpressCheckout\Nvp\Request\Api\DoVoid;
 
-class CancelAction extends PurchaseAction
+class CancelAction extends GatewayAwareAction
 {
     /**
      * {@inheritDoc}
@@ -27,7 +29,7 @@ class CancelAction extends PurchaseAction
             }
         }
 
-        parent::execute($request);
+        $this->gateway->execute(new Sync($request->getModel()));
     }
 
     /**

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Action/CancelAction.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Action/CancelAction.php
@@ -1,11 +1,11 @@
 <?php
 namespace Payum\Paypal\ExpressCheckout\Nvp\Action;
 
+use Payum\Core\Action\GatewayAwareAction;
 use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\Request\Cancel;
 use Payum\Core\Request\Sync;
-use Payum\Core\Action\GatewayAwareAction;
-use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Paypal\ExpressCheckout\Nvp\Api;
 use Payum\Paypal\ExpressCheckout\Nvp\Request\Api\DoVoid;
 
@@ -22,6 +22,9 @@ class CancelAction extends GatewayAwareAction
         $details = ArrayObject::ensureArrayObject($request->getModel());
 
         $details['PAYMENTREQUEST_0_PAYMENTACTION'] = Api::PAYMENTACTION_VOID;
+        if (empty($details['AUTHORIZATIONID']) && !empty($details['TRANSACTIONID'])) {
+            $details['AUTHORIZATIONID'] = $details['TRANSACTIONID'];
+        }
 
         foreach (range(0, 9) as $index) {
             if (Api::PENDINGREASON_AUTHORIZATION == $details['PAYMENTINFO_'.$index.'_PENDINGREASON']) {

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Action/CancelAction.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Action/CancelAction.php
@@ -1,0 +1,43 @@
+<?php
+namespace Payum\Paypal\ExpressCheckout\Nvp\Action;
+
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Request\Cancel;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Paypal\ExpressCheckout\Nvp\Api;
+use Payum\Paypal\ExpressCheckout\Nvp\Request\Api\DoVoid;
+
+class CancelAction extends PurchaseAction
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function execute($request)
+    {
+        /** @var $request Cancel */
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        $details = ArrayObject::ensureArrayObject($request->getModel());
+
+        $details['PAYMENTREQUEST_0_PAYMENTACTION'] = Api::PAYMENTACTION_VOID;
+
+        foreach (range(0, 9) as $index) {
+            if (Api::PENDINGREASON_AUTHORIZATION == $details['PAYMENTINFO_'.$index.'_PENDINGREASON']) {
+                $this->gateway->execute(new DoVoid($details, $index));
+            }
+        }
+
+        parent::execute($request);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports($request)
+    {
+        return
+            $request instanceof Cancel &&
+            $request->getModel() instanceof \ArrayAccess
+        ;
+    }
+}

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Api.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Api.php
@@ -136,6 +136,11 @@ class Api
     const PAYMENTACTION_ORDER = 'Order';
 
     /**
+     * Void – This is the voiding of an authorized order that has not been captured.
+     */
+    const PAYMENTACTION_VOID = 'Void';
+
+    /**
      * Payment has not been authorized by the user.
      */
     const L_ERRORCODE_PAYMENT_NOT_AUTHORIZED = 10485;
@@ -521,6 +526,23 @@ class Api
     public function doCapture(array $fields)
     {
         $fields['METHOD']  = 'DoCapture';
+
+        $this->addVersionField($fields);
+        $this->addAuthorizeFields($fields);
+
+        return $this->doRequest($fields);
+    }
+
+    /**
+     * Require: AUTHORIZATIONID
+     *
+     * @param array $fields
+     *
+     * @return array
+     */
+    public function doVoid(array $fields)
+    {
+        $fields['METHOD']  = 'DoVoid';
 
         $this->addVersionField($fields);
         $this->addAuthorizeFields($fields);

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Api.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Api.php
@@ -534,7 +534,7 @@ class Api
     }
 
     /**
-     * Require: TRANSACTIONID
+     * Require: AUTHORIZATIONID
      *
      * @param array $fields
      *
@@ -543,9 +543,6 @@ class Api
     public function doVoid(array $fields)
     {
         $fields['METHOD']  = 'DoVoid';
-        if (empty($fields['AUTHORIZATIONID'])) {
-            $fields['AUTHORIZATIONID'] = $fields['TRANSACTIONID'];
-        }
 
         $this->addVersionField($fields);
         $this->addAuthorizeFields($fields);

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Api.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Api.php
@@ -534,7 +534,7 @@ class Api
     }
 
     /**
-     * Require: AUTHORIZATIONID
+     * Require: TRANSACTIONID
      *
      * @param array $fields
      *
@@ -543,6 +543,9 @@ class Api
     public function doVoid(array $fields)
     {
         $fields['METHOD']  = 'DoVoid';
+        if (empty($fields['AUTHORIZATIONID'])) {
+            $fields['AUTHORIZATIONID'] = $fields['TRANSACTIONID'];
+        }
 
         $this->addVersionField($fields);
         $this->addAuthorizeFields($fields);

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/PaypalExpressCheckoutGatewayFactory.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/PaypalExpressCheckoutGatewayFactory.php
@@ -17,8 +17,10 @@ use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\ManageRecurringPaymentsProfileSt
 use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\CreateBillingAgreementAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\DoReferenceTransactionAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\UpdateRecurringPaymentProfileAction;
+use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\DoVoidAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\AuthorizeAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\CaptureAction;
+use Payum\Paypal\ExpressCheckout\Nvp\Action\CancelAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\ConvertPaymentAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\NotifyAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\PaymentDetailsStatusAction;
@@ -40,6 +42,7 @@ class PaypalExpressCheckoutGatewayFactory extends GatewayFactory
             'payum.template.confirm_order' => '@PayumPaypalExpressCheckout/confirmOrder.html.twig',
 
             'payum.action.capture' => new CaptureAction(),
+            'payum.action.cancel' => new CancelAction(),
             'payum.action.authorize' => new AuthorizeAction(),
             'payum.action.convert_payment' => new ConvertPaymentAction(),
             'payum.action.notify' => new NotifyAction(),
@@ -61,6 +64,7 @@ class PaypalExpressCheckoutGatewayFactory extends GatewayFactory
             'payum.action.api.do_reference_transaction' => new DoReferenceTransactionAction(),
             'payum.action.api.do_capture' => new DoCaptureAction(),
             'payum.action.api.authorize_token' => new AuthorizeTokenAction(),
+            'payum.action.api.do_void' => new DoVoidAction(),
             'payum.action.api.confirm_order' => function (ArrayObject $config) {
                 return new ConfirmOrderAction($config['payum.template.confirm_order']);
             },

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Request/Api/DoVoid.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Request/Api/DoVoid.php
@@ -5,27 +5,4 @@ use Payum\Core\Request\Generic;
 
 class DoVoid extends Generic
 {
-    /**
-     * @var int
-     */
-    protected $paymentRequestN;
-
-    /**
-     * @param mixed $model
-     * @param int   $paymentRequestN
-     */
-    public function __construct($model, $paymentRequestN)
-    {
-        parent::__construct($model);
-
-        $this->paymentRequestN = $paymentRequestN;
-    }
-
-    /**
-     * @return int
-     */
-    public function getPaymentRequestN()
-    {
-        return $this->paymentRequestN;
-    }
 }

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Request/Api/DoVoid.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Request/Api/DoVoid.php
@@ -1,0 +1,31 @@
+<?php
+namespace Payum\Paypal\ExpressCheckout\Nvp\Request\Api;
+
+use Payum\Core\Request\Generic;
+
+class DoVoid extends Generic
+{
+    /**
+     * @var int
+     */
+    protected $paymentRequestN;
+
+    /**
+     * @param mixed $model
+     * @param int   $paymentRequestN
+     */
+    public function __construct($model, $paymentRequestN)
+    {
+        parent::__construct($model);
+
+        $this->paymentRequestN = $paymentRequestN;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPaymentRequestN()
+    {
+        return $this->paymentRequestN;
+    }
+}

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/Api/DoVoidActionTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/Api/DoVoidActionTest.php
@@ -9,11 +9,51 @@ class DoVoidActionTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function shouldBeSubClassOfBaseApiAwareAction()
+    public function shouldImplementActionInterface()
     {
         $rc = new \ReflectionClass('Payum\Paypal\ExpressCheckout\Nvp\Action\Api\DoVoidAction');
 
-        $this->assertTrue($rc->isSubclassOf('Payum\Paypal\ExpressCheckout\Nvp\Action\Api\BaseApiAwareAction'));
+        $this->assertTrue($rc->implementsInterface('Payum\Core\Action\ActionInterface'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldImplementApiAwareInterface()
+    {
+        $rc = new \ReflectionClass('Payum\Paypal\ExpressCheckout\Nvp\Action\Api\DoVoidAction');
+
+        $this->assertTrue($rc->implementsInterface('Payum\Core\ApiAwareInterface'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldImplementGatewayAwareInterface()
+    {
+        $rc = new \ReflectionClass('Payum\Paypal\ExpressCheckout\Nvp\Action\Api\DoVoidAction');
+
+        $this->assertTrue($rc->implementsInterface('Payum\Core\GatewayAwareInterface'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldUseApiAwareTrait()
+    {
+        $rc = new \ReflectionClass('Payum\Paypal\ExpressCheckout\Nvp\Action\Api\DoVoidAction');
+
+        $this->assertContains('Payum\Core\ApiAwareTrait', $rc->getTraitNames());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldUseGatewayAwareTrait()
+    {
+        $rc = new \ReflectionClass('Payum\Paypal\ExpressCheckout\Nvp\Action\Api\DoVoidAction');
+
+        $this->assertContains('Payum\Core\GatewayAwareTrait', $rc->getTraitNames());
     }
 
     /**
@@ -62,9 +102,9 @@ class DoVoidActionTest extends \PHPUnit_Framework_TestCase
      * @test
      *
      * @expectedException \Payum\Core\Exception\LogicException
-     * @expectedExceptionMessage TRANSACTIONID must be set. Has user not authorized this transaction?
+     * @expectedExceptionMessage AUTHORIZATIONID must be set. Has user not authorized this transaction?
      */
-    public function throwIfTransactionIdNotSetInModel()
+    public function throwIfAuthorizationIdNotSetInModel()
     {
         $action = new DoVoidAction();
 
@@ -85,8 +125,8 @@ class DoVoidActionTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('DoVoid')
             ->will($this->returnCallback(function (array $fields) use ($testCase) {
-                $testCase->assertArrayHasKey('TRANSACTIONID', $fields);
-                $testCase->assertEquals('theTransactionId', $fields['TRANSACTIONID']);
+                $testCase->assertArrayHasKey('AUTHORIZATIONID', $fields);
+                $testCase->assertEquals('theOriginalTransactionId', $fields['AUTHORIZATIONID']);
 
                 return array();
             }))
@@ -96,7 +136,7 @@ class DoVoidActionTest extends \PHPUnit_Framework_TestCase
         $action->setApi($apiMock);
 
         $request = new DoVoid(array(
-            'TRANSACTIONID' => 'theTransactionId',
+            'AUTHORIZATIONID' => 'theOriginalTransactionId',
         ));
 
         $action->execute($request);
@@ -123,7 +163,7 @@ class DoVoidActionTest extends \PHPUnit_Framework_TestCase
         $action->setApi($apiMock);
 
         $request = new DoVoid(array(
-            'TRANSACTIONID' => 'theTransactionId',
+            'AUTHORIZATIONID' => 'theTransactionId',
         ));
 
         $action->execute($request);

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/Api/DoVoidActionTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/Api/DoVoidActionTest.php
@@ -1,0 +1,213 @@
+<?php
+namespace Payum\Paypal\ExpressCheckout\Nvp\Tests\Action\Api;
+
+use Payum\Core\GatewayAwareInterface;
+use Payum\Core\GatewayInterface;
+use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\BaseApiAwareAction;
+use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\DoVoidAction;
+use Payum\Paypal\ExpressCheckout\Nvp\Api;
+use Payum\Paypal\ExpressCheckout\Nvp\Request\Api\DoVoid;
+use Payum\Paypal\ExpressCheckout\Nvp\Request\Api\GetTransactionDetails;
+
+class DoVoidActionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldBeSubClassOfBaseApiAwareAction()
+    {
+        $rc = new \ReflectionClass(DoVoidAction::class);
+
+        $this->assertTrue($rc->isSubclassOf(BaseApiAwareAction::class));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldImplementsGatewayAwareInterface()
+    {
+        $rc = new \ReflectionClass(DoVoidAction::class);
+
+        $this->assertTrue($rc->implementsInterface(GatewayAwareInterface::class));
+    }
+
+    /**
+     * @test
+     */
+    public function couldBeConstructedWithoutAnyArguments()
+    {
+        new DoVoidAction();
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSupportDoVoidRequestAndArrayAccessAsModel()
+    {
+        $action = new DoVoidAction();
+
+        $this->assertTrue($action->supports(new DoVoid(new \ArrayObject(), 0)));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotSupportAnythingNotDoVoidRequest()
+    {
+        $action = new DoVoidAction();
+
+        $this->assertFalse($action->supports(new \stdClass()));
+    }
+
+    /**
+     * @test
+     *
+     * @expectedException \Payum\Core\Exception\RequestNotSupportedException
+     */
+    public function throwIfNotSupportedRequestGivenAsArgumentForExecute()
+    {
+        $action = new DoVoidAction();
+
+        $action->execute(new \stdClass());
+    }
+
+    /**
+     * @test
+     *
+     * @expectedException \Payum\Core\Exception\LogicException
+     * @expectedExceptionMessage The AUTHORIZATIONID fields are required.
+     */
+    public function throwIfTransactionIdNorAuthorizationIdNotSetInModel()
+    {
+        $action = new DoVoidAction();
+
+        $action->execute(new DoVoid([], 0));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCallApiDoVoidMethodWithExpectedRequiredArguments()
+    {
+        $apiMock = $this->createApiMock();
+        $apiMock
+            ->expects($this->once())
+            ->method('DoVoid')
+            ->will($this->returnCallback(function (array $fields) {
+                $this->assertArrayHasKey('AUTHORIZATIONID', $fields);
+                $this->assertEquals('theParentTransactionId', $fields['AUTHORIZATIONID']);
+
+                return array();
+            }))
+        ;
+
+        $action = new DoVoidAction();
+        $action->setApi($apiMock);
+        $action->setGateway($this->createGatewayMock());
+
+        $request = new DoVoid(array(
+            'PAYMENTREQUEST_0_TRANSACTIONID' => 'theTransactionId',
+            'PAYMENTREQUEST_0_PARENTTRANSACTIONID' => 'theParentTransactionId',
+        ), 0);
+
+        $action->execute($request);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCallApiDoVoidMethodWithParentTransactionIdMissing()
+    {
+        $apiMock = $this->createApiMock();
+        $apiMock
+            ->expects($this->once())
+            ->method('DoVoid')
+            ->will($this->returnCallback(function (array $fields) {
+                $this->assertArrayHasKey('AUTHORIZATIONID', $fields);
+                $this->assertEquals('theTransactionId', $fields['AUTHORIZATIONID']);
+
+                return array();
+            }))
+        ;
+
+        $action = new DoVoidAction();
+        $action->setApi($apiMock);
+        $action->setGateway($this->createGatewayMock());
+
+        $request = new DoVoid(array(
+            'PAYMENTREQUEST_0_TRANSACTIONID' => 'theTransactionId',
+        ), 0);
+
+        $action->execute($request);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCallApiDoVoidMethodAndUpdateModelFromResponseOnSuccess()
+    {
+        $apiMock = $this->createApiMock();
+        $apiMock
+            ->expects($this->once())
+            ->method('DoVoid')
+            ->will($this->returnCallback(function () {
+                return array(
+                    'FIRSTNAME' => 'theFirstname',
+                    'EMAIL' => 'the@example.com',
+                );
+            }))
+        ;
+
+        $gatewayMock = $this->createGatewayMock();
+        $gatewayMock
+            ->expects($this->once())
+            ->method('execute')
+            ->with($this->isInstanceOf(GetTransactionDetails::class))
+            ->will($this->returnCallback(function(GetTransactionDetails $request) {
+                $this->assertSame(0, $request->getPaymentRequestN());
+                $this->assertSame(array(
+                    'PAYMENTREQUEST_0_TRANSACTIONID' => 'theTransactionId',
+                ), (array) $request->getModel());
+
+
+                $model = $request->getModel();
+                $model['FIRSTNAME'] = 'theFirstname';
+                $model['EMAIL'] = 'the@example.com';
+            }))
+        ;
+
+        $action = new DoVoidAction();
+        $action->setApi($apiMock);
+        $action->setGateway($gatewayMock);
+
+        $request = new DoVoid(array(
+            'PAYMENTREQUEST_0_TRANSACTIONID' => 'theTransactionId',
+        ), 0);
+
+        $action->execute($request);
+
+        $model = $request->getModel();
+
+        $this->assertArrayHasKey('FIRSTNAME', $model);
+        $this->assertEquals('theFirstname', $model['FIRSTNAME']);
+
+        $this->assertArrayHasKey('EMAIL', $model);
+        $this->assertEquals('the@example.com', $model['EMAIL']);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|Api
+     */
+    protected function createApiMock()
+    {
+        return $this->getMock(Api::class, [], [], '', false);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|GatewayInterface
+     */
+    protected function createGatewayMock()
+    {
+        return $this->getMock(GatewayInterface::class);
+    }
+}

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/CancelActionTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/CancelActionTest.php
@@ -1,0 +1,320 @@
+<?php
+namespace Payum\Paypal\ExpressCheckout\Nvp\Tests\Action;
+
+use Payum\Core\Request\Cancel;
+use Payum\Core\Request\Sync;
+use Payum\Paypal\ExpressCheckout\Nvp\Action\CancelAction;
+use Payum\Paypal\ExpressCheckout\Nvp\Api;
+use Payum\Paypal\ExpressCheckout\Nvp\Request\Api\DoVoid;
+
+class CancelActionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldBeSubClassOfGatewayAwareAction()
+    {
+        $rc = new \ReflectionClass('Payum\Paypal\ExpressCheckout\Nvp\Action\CancelAction');
+
+        $this->assertTrue($rc->isSubclassOf('Payum\Core\Action\GatewayAwareAction'));
+    }
+
+    /**
+     * @test
+     */
+    public function couldBeConstructedWithoutAnyArguments()
+    {
+        new CancelAction();
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSetZeroGatewayActionAsVoid()
+    {
+        $action = new CancelAction();
+        $action->setGateway($this->createGatewayMock());
+
+        $action->execute($request = new Cancel([]));
+
+        $model = $request->getModel();
+        $this->assertArrayHasKey('PAYMENTREQUEST_0_PAYMENTACTION', $model);
+        $this->assertEquals(Api::PAYMENTACTION_VOID, $model['PAYMENTREQUEST_0_PAYMENTACTION']);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldForcePaymentActionVoid()
+    {
+        $action = new CancelAction();
+        $action->setGateway($this->createGatewayMock());
+
+        $action->execute($request = new Cancel([
+            'PAYMENTREQUEST_0_PAYMENTACTION' => 'FooBarBaz',
+        ]));
+
+        $model = $request->getModel();
+        $this->assertArrayHasKey('PAYMENTREQUEST_0_PAYMENTACTION', $model);
+        $this->assertEquals(Api::PAYMENTACTION_VOID, $model['PAYMENTREQUEST_0_PAYMENTACTION']);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSupportEmptyModel()
+    {
+        $action = new CancelAction();
+
+        $request = new Cancel(array());
+
+        $this->assertTrue($action->supports($request));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSupportCancelRequestWithArrayAsModelWhichHasPendingReasonAsAuthorized()
+    {
+        $action = new CancelAction();
+
+        $payment = array(
+           'PAYMENTINFO_0_PENDINGREASON' => Api::PENDINGREASON_AUTHORIZATION,
+        );
+
+        $request = new Cancel($payment);
+
+        $this->assertTrue($action->supports($request));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSupportCancelRequestWithArrayAsModelWhichHasPendingReasonAsOtherThanAuthorized()
+    {
+        $action = new CancelAction();
+
+        $payment = array(
+           'PAYMENTINFO_0_PENDINGREASON' => 'Foo',
+        );
+
+        $request = new Cancel($payment);
+
+        $this->assertTrue($action->supports($request));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotSupportCancelRequestWithNoArrayAccessAsModel()
+    {
+        $action = new CancelAction();
+
+        $request = new Cancel(new \stdClass());
+
+        $this->assertFalse($action->supports($request));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotSupportAnythingNotCancelRequest()
+    {
+        $action = new CancelAction();
+
+        $this->assertFalse($action->supports(new \stdClass()));
+    }
+
+    /**
+     * @test
+     *
+     * @expectedException \Payum\Core\Exception\RequestNotSupportedException
+     */
+    public function throwIfNotSupportedRequestGivenAsArgumentForExecute()
+    {
+        $action = new CancelAction();
+
+        $action->execute(new \stdClass());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotExecuteDoVoidIfPaymentInfoPendingReasonNotSet()
+    {
+        $gatewayMock = $this->createGatewayMock();
+        $gatewayMock
+            ->expects($this->once())
+            ->method('execute')
+            ->with($this->isInstanceOf(Sync::class))
+        ;
+
+        $action = new CancelAction();
+        $action->setGateway($gatewayMock);
+
+        $request = new Cancel(array());
+
+        $action->execute($request);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldExecuteDoVoidIfPaymentInfoPendingReasonSet()
+    {
+        $gatewayMock = $this->createGatewayMock();
+        $gatewayMock
+            ->expects($this->exactly(2))
+            ->method('execute')
+            ->withConsecutive(
+                array($this->isInstanceOf(DoVoid::class)),
+                array($this->isInstanceOf(Sync::class))
+            )
+        ;
+
+        $action = new CancelAction();
+        $action->setGateway($gatewayMock);
+
+        $request = new Cancel(array(
+            'PAYMENTINFO_0_PENDINGREASON' => Api::PENDINGREASON_AUTHORIZATION,
+        ));
+
+        $action->execute($request);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldExecuteDoVoidForEachPaymentInfoPendingReasonSetIndexedToNine()
+    {
+        $gatewayMock = $this->createGatewayMock();
+        $gatewayMock
+            ->expects($this->exactly(4))
+            ->method('execute')
+            ->withConsecutive(
+                array($this->isInstanceOf(DoVoid::class)),
+                array($this->isInstanceOf(DoVoid::class)),
+                array($this->isInstanceOf(DoVoid::class)),
+                array($this->isInstanceOf(Sync::class))
+            )
+        ;
+
+        $action = new CancelAction();
+        $action->setGateway($gatewayMock);
+
+        $request = new Cancel(array(
+            'PAYMENTINFO_0_PENDINGREASON' => Api::PENDINGREASON_AUTHORIZATION,
+            'PAYMENTINFO_1_PENDINGREASON' => Api::PENDINGREASON_AUTHORIZATION,
+            'PAYMENTINFO_9_PENDINGREASON' => Api::PENDINGREASON_AUTHORIZATION,
+        ));
+
+        $action->execute($request);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotExecuteDoVoidForPaymentInfoPendingReasonIndexedOverNine()
+    {
+        $gatewayMock = $this->createGatewayMock();
+        $gatewayMock
+            ->expects($this->once())
+            ->method('execute')
+            ->with($this->isInstanceOf(Sync::class))
+        ;
+
+        $action = new CancelAction();
+        $action->setGateway($gatewayMock);
+
+        $request = new Cancel(array(
+            'PAYMENTINFO_10_PENDINGREASON' => Api::PENDINGREASON_AUTHORIZATION,
+        ));
+
+        $action->execute($request);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotSetAuthorizationIdFromTransactionIdIfBothNotSet()
+    {
+        $gatewayMock = $this->createGatewayMock();
+        $gatewayMock
+            ->expects($this->at(0))
+            ->method('execute')
+            ->with($this->isInstanceOf(Sync::class))
+        ;
+
+        $action = new CancelAction();
+        $action->setGateway($gatewayMock);
+
+        $request = new Cancel(array());
+
+        $action->execute($request);
+
+        $details = $request->getModel();
+
+        $this->assertFalse(isset($details['AUTHORIZATIONID']));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSetAuthorizationIdFromTransactionIdIfNotSet()
+    {
+        $gatewayMock = $this->createGatewayMock();
+        $gatewayMock
+            ->expects($this->at(0))
+            ->method('execute')
+            ->with($this->isInstanceOf(Sync::class))
+        ;
+
+        $action = new CancelAction();
+        $action->setGateway($gatewayMock);
+
+        $request = new Cancel(array(
+            'TRANSACTIONID' => 'theOriginalTransactionId',
+        ));
+
+        $action->execute($request);
+
+        $details = $request->getModel();
+
+        $this->assertEquals($details['AUTHORIZATIONID'], 'theOriginalTransactionId');
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotOverrideAuthorizationIdWithTransactionIdIfSet()
+    {
+        $gatewayMock = $this->createGatewayMock();
+        $gatewayMock
+            ->expects($this->at(0))
+            ->method('execute')
+            ->with($this->isInstanceOf(Sync::class))
+        ;
+
+        $action = new CancelAction();
+        $action->setGateway($gatewayMock);
+
+        $request = new Cancel(array(
+            'TRANSACTIONID' => 'theReauthorizedTransactionId',
+            'AUTHORIZATIONID' => 'theOriginalTransactionId',
+        ));
+
+        $action->execute($request);
+
+        $details = $request->getModel();
+
+        $this->assertEquals($details['AUTHORIZATIONID'], 'theOriginalTransactionId');
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\Payum\Core\GatewayInterface
+     */
+    protected function createGatewayMock()
+    {
+        return $this->getMock('Payum\Core\GatewayInterface');
+    }
+}

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/PaymentDetailsStatusActionTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/PaymentDetailsStatusActionTest.php
@@ -354,6 +354,27 @@ class PaymentDetailsStatusActionTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function shouldMarkCanceledIfAllPaymentStatusVoidedAndReasonAuthorization()
+    {
+        $action = new PaymentDetailsStatusAction();
+
+        $request = new GetHumanStatus(array(
+            'PAYMENTREQUEST_0_AMT' => 12,
+            'CHECKOUTSTATUS' => Api::CHECKOUTSTATUS_PAYMENT_COMPLETED,
+            'PAYMENTREQUEST_0_PAYMENTSTATUS' => Api::PAYMENTSTATUS_VOIDED,
+            'PAYMENTINFO_0_PENDINGREASON' => Api::PENDINGREASON_AUTHORIZATION,
+            'PAYMENTREQUEST_9_PAYMENTSTATUS' => Api::PAYMENTSTATUS_VOIDED,
+            'PAYMENTINFO_9_PENDINGREASON' => Api::PENDINGREASON_AUTHORIZATION,
+        ));
+
+        $action->execute($request);
+
+        $this->assertTrue($request->isCanceled());
+    }
+
+    /**
+     * @test
+     */
     public function shouldMarkAuthorizedIfAllPaymentStatusPendingAndReasonAuthorization()
     {
         $action = new PaymentDetailsStatusAction();

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/DoVoidTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/DoVoidTest.php
@@ -1,0 +1,38 @@
+<?php
+namespace Payum\Paypal\ExpressCheckout\Nvp\Tests\Request\Api;
+
+use Payum\Core\Request\Generic;
+use Payum\Paypal\ExpressCheckout\Nvp\Request\Api\DoVoid;
+
+class DoVoidTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldBeSubClassOfGeneric()
+    {
+        $rc = new \ReflectionClass(DoVoid::class);
+
+        $this->assertTrue($rc->isSubclassOf(Generic::class));
+    }
+
+    /**
+     * @test
+     */
+    public function couldBeConstructedWithModelAndPaymentRequestNAsArguments()
+    {
+        new DoVoid(new \stdClass(), $paymentRequestN = 5);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldAllowGetPaymentRequestNSetInConstructor()
+    {
+        $expectedPaymentRequestN = 7;
+
+        $request = new DoVoid(new \stdClass(), $expectedPaymentRequestN);
+
+        $this->assertSame($expectedPaymentRequestN, $request->getPaymentRequestN());
+    }
+}

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/DoVoidTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Request/Api/DoVoidTest.php
@@ -15,24 +15,4 @@ class DoVoidTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($rc->isSubclassOf(Generic::class));
     }
-
-    /**
-     * @test
-     */
-    public function couldBeConstructedWithModelAndPaymentRequestNAsArguments()
-    {
-        new DoVoid(new \stdClass(), $paymentRequestN = 5);
-    }
-
-    /**
-     * @test
-     */
-    public function shouldAllowGetPaymentRequestNSetInConstructor()
-    {
-        $expectedPaymentRequestN = 7;
-
-        $request = new DoVoid(new \stdClass(), $expectedPaymentRequestN);
-
-        $this->assertSame($expectedPaymentRequestN, $request->getPaymentRequestN());
-    }
 }


### PR DESCRIPTION
Resubmitting the changes mistakenly requested on the read-only [PaypalExpressCheckoutNvp](https://github.com/Payum/PaypalExpressCheckoutNvp/pull/44) subtree split.