### PR TITLE
Remove guzzle.client from the gateway factory config

### DIFF
--- a/src/Payum/Core/CoreGatewayFactory.php
+++ b/src/Payum/Core/CoreGatewayFactory.php
@@ -132,8 +132,6 @@ class CoreGatewayFactory implements GatewayFactoryInterface
             },
             'payum.template.layout' => '@PayumCore/layout.html.twig',
 
-            // deprecated
-            'guzzle.client' => HttpClientFactory::createGuzzle(),
             'twig.env' => function() {
                 return new \Twig_Environment(new \Twig_Loader_Chain());
             },


### PR DESCRIPTION
See issue https://github.com/Payum/Payum/issues/591

Nothing was added to the UPGRADE.md because it was already there:
https://github.com/gpou/Payum/blob/master/UPGRADE.md#130
> [gateway-factory] Option 'guzzle.client' was removed.
