### PR TITLE
Fix Stripe's CreateCustomerExtension and ConvertPaymentAction

### DIFF
--- a/src/Payum/Core/Action/CapturePaymentAction.php
+++ b/src/Payum/Core/Action/CapturePaymentAction.php
@@ -21,8 +21,8 @@ class CapturePaymentAction extends GatewayAwareAction
 
         /** @var $payment PaymentInterface */
         $payment = $request->getModel();
-
         $this->gateway->execute($status = new GetHumanStatus($payment));
+
         if ($status->isNew()) {
             $this->gateway->execute($convert = new Convert($payment, 'array', $request->getToken()));
 

--- a/src/Payum/Core/Action/RefundAction.php
+++ b/src/Payum/Core/Action/RefundAction.php
@@ -1,0 +1,52 @@
+<?php
+namespace Payum\Core\Action;
+
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Model\RefundInterface;
+use Payum\Core\Request\Refund;
+use Payum\Core\Request\Convert;
+use Payum\Core\Request\GetHumanStatus;
+
+class RefundAction extends GatewayAwareAction
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @param Refund $request
+     */
+    public function execute($request)
+    {
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        /** @var $refund RefundInterface */
+        $refund = $request->getModel();
+
+        $this->gateway->execute($status = new GetHumanStatus($refund));
+        if ($status->isNew()) {
+            $this->gateway->execute($convert = new Convert($refund, 'array', $request->getToken()));
+
+            $refund->setDetails($convert->getResult());
+        }
+
+        $details = ArrayObject::ensureArrayObject($refund->getDetails());
+
+        $request->setModel($details);
+        try {
+            $this->gateway->execute($request);
+        } finally {
+            $refund->setDetails($details);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports($request)
+    {
+        return
+            $request instanceof Refund &&
+            $request->getModel() instanceof RefundInterface
+        ;
+    }
+}

--- a/src/Payum/Stripe/Action/Api/CreateRefundAction.php
+++ b/src/Payum/Stripe/Action/Api/CreateRefundAction.php
@@ -1,0 +1,75 @@
+<?php
+namespace Payum\Stripe\Action\Api;
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\ApiAwareInterface;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\LogicException;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Exception\UnsupportedApiException;
+use Payum\Stripe\Keys;
+use Payum\Core\Request\Refund;
+use Stripe\Refund as StripeRefund;
+use Stripe\Error;
+use Stripe\Stripe;
+use Payum\Stripe\Constants;
+
+class CreateRefundAction implements ActionInterface, ApiAwareInterface
+{
+    /**
+     * @var Keys
+     */
+    protected $keys;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setApi($api)
+    {
+        if (false == $api instanceof Keys) {
+            throw new UnsupportedApiException('Not supported.');
+        }
+
+        $this->keys = $api;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function execute($request)
+    {
+        /** @var $request Refund */
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        $model = ArrayObject::ensureArrayObject($request->getModel());
+
+        if (!@$model['charge']) {
+            throw new LogicException('The charge id has to be set.');
+        }
+
+        if (isset($model['amount'])
+            && (!is_numeric($model['amount']) || $model['amount'] <= 0)
+        ) {
+            throw new LogicException('The amount is invalid.');
+        }
+
+        try {
+            Stripe::setApiKey($this->keys->getSecretKey());
+            $refund = StripeRefund::create($model->toUnsafeArrayWithoutLocal());
+            $model->replace($refund->__toArray(true));
+        } catch (Error\Base $e) {
+            $model->replace($e->getJsonBody());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports($request)
+    {
+        return
+            $request instanceof Refund &&
+            $request->getModel() instanceof \ArrayAccess
+        ;
+    }
+}

--- a/src/Payum/Stripe/Action/ConvertPaymentAction.php
+++ b/src/Payum/Stripe/Action/ConvertPaymentAction.php
@@ -29,7 +29,7 @@ class ConvertPaymentAction implements ActionInterface
 
         if ($card = $payment->getCreditCard()) {
             if ($card->getToken()) {
-                $details["customer"] = $card->getToken();
+                $details["card"] = $card->getToken();
             } else {
                 $details["card"] = SensitiveValue::ensureSensitive([
                     'number' => $card->getNumber(),

--- a/src/Payum/Stripe/Action/ConvertPaymentAction.php
+++ b/src/Payum/Stripe/Action/ConvertPaymentAction.php
@@ -29,9 +29,9 @@ class ConvertPaymentAction implements ActionInterface
 
         if ($card = $payment->getCreditCard()) {
             if ($card->getToken()) {
-                $details["card"] = $card->getToken();
+                $details["source"] = $card->getToken();
             } else {
-                $details["card"] = SensitiveValue::ensureSensitive([
+                $details["source"] = SensitiveValue::ensureSensitive([
                     'number' => $card->getNumber(),
                     'exp_month' => $card->getExpireAt()->format('m'),
                     'exp_year' => $card->getExpireAt()->format('Y'),

--- a/src/Payum/Stripe/Action/ConvertRefundAction.php
+++ b/src/Payum/Stripe/Action/ConvertRefundAction.php
@@ -1,0 +1,43 @@
+<?php
+namespace Payum\Stripe\Action;
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Model\RefundInterface;
+use Payum\Core\Request\Convert;
+
+class ConvertPaymentAction implements ActionInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @param Convert $request
+     */
+    public function execute($request)
+    {
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        /** @var RefundInterface $refund */
+        $refund = $request->getSource();
+
+        $details = ArrayObject::ensureArrayObject($refund->getDetails());
+        $details["amount"] = $refund->getRefundedAmount();
+        $details["charge"] = $refund->getCurrencyCode();
+        $details["reason"] = $refund->getReason();
+
+        $request->setResult((array) $details);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports($request)
+    {
+        return
+            $request instanceof Convert &&
+            $request->getSource() instanceof RefundInterface &&
+            $request->getTo() == 'array'
+        ;
+    }
+}

--- a/src/Payum/Stripe/Extension/CreateCustomerExtension.php
+++ b/src/Payum/Stripe/Extension/CreateCustomerExtension.php
@@ -9,6 +9,7 @@ use Payum\Core\Request\Capture;
 use Payum\Stripe\Constants;
 use Payum\Stripe\Request\Api\CreateCustomer;
 use Payum\Stripe\Request\Api\ObtainToken;
+use Payum\Core\Security\SensitiveValue;
 
 class CreateCustomerExtension implements ExtensionInterface
 {
@@ -66,7 +67,11 @@ class CreateCustomerExtension implements ExtensionInterface
         if ($model['customer']) {
             return;
         }
-        if (false == ($model['card'] && is_string($model['card']))) {
+
+        if (!@$model['card']
+            || (!is_string($model['card'])
+            && !$model['card'] instanceof SensitiveValue)
+        ) {
             return;
         }
 

--- a/src/Payum/Stripe/Tests/Action/ConvertPaymentActionTest.php
+++ b/src/Payum/Stripe/Tests/Action/ConvertPaymentActionTest.php
@@ -57,7 +57,7 @@ class ConvertPaymentActionTest extends GenericActionTest
 
         $this->assertNotEmpty($details);
 
-        $this->assertArrayNotHasKey('card', $details);
+        $this->assertArrayNotHasKey('source', $details);
 
         $this->assertArrayHasKey('amount', $details);
         $this->assertEquals(123, $details['amount']);
@@ -116,10 +116,10 @@ class ConvertPaymentActionTest extends GenericActionTest
 
         $this->assertNotEmpty($details);
 
-        $this->assertArrayHasKey('card', $details);
-        $this->assertInstanceOf(SensitiveValue::class, $details['card']);
+        $this->assertArrayHasKey('source', $details);
+        $this->assertInstanceOf(SensitiveValue::class, $details['source']);
 
-        $card = $details['card']->peek();
+        $card = $details['source']->peek();
         $this->assertInternalType('array', $card);
 
         $this->assertArrayHasKey('number', $card);
@@ -141,7 +141,7 @@ class ConvertPaymentActionTest extends GenericActionTest
     public function shouldCorrectlyConvertCreditCardToken()
     {
         $creditCard = new CreditCard();
-        $creditCard->setToken('theCustomerId');
+        $creditCard->setToken('theSourceId');
 
         $order = new Payment();
         $order->setCreditCard($creditCard);
@@ -154,7 +154,7 @@ class ConvertPaymentActionTest extends GenericActionTest
 
         $this->assertNotEmpty($details);
 
-        $this->assertArrayHasKey('customer', $details);
-        $this->assertEquals('theCustomerId', $details['customer']);
+        $this->assertArrayHasKey('source', $details);
+        $this->assertEquals('theSourceId', $details['source']);
     }
 }


### PR DESCRIPTION
CreateCustomerExtension should accept credit card information as an array in order to create the customer:

```
[
    'number' => '',
    'exp_month' => '',
    'exp_year' => '',
    'cvc' => '',
]
```

This will allow the creation of a customer if the credit card was passed with its details instead of as a token.

Also, ConvertPaymentAction, when receiving a tokenized Credit card,
should set the token into `$details["card"]` instead of
`$details["customer"]` in order to let CreateCustomerExtension
create a Customer from a tokenized card.

Note:
I have no previous experience with Stripe but I think that `customer` and `card` have both been replaced by the `source` parameter. The source should accept anything that is tokenized (customer, credit card) or plain credit card information.
`card` and `customer` still seems to work but we might also consider refactoring this at some point. 
