### PR TITLE
Doctrine storage example invalid path

### DIFF
--- a/src/Payum/Core/Resources/docs/storages.md
+++ b/src/Payum/Core/Resources/docs/storages.md
@@ -125,7 +125,7 @@ $driver = new MappingDriverChain;
 
 // payum's basic models
 $driver->addDriver(
-    new SimplifiedXmlDriver(array('path/to/Payum/Core/Model' => 'Payum\Core\Model')), 
+    new SimplifiedXmlDriver(array('path/to/Payum/Core/Bridge/Doctrine/Resources/mapping' => 'Payum\Core\Model')), 
     'Payum\Core\Model'
 );
 


### PR DESCRIPTION
Doctrine storage example uses 'SimplifiedXmlDriver' and pointing to the wrong directory, which produces unexpected errors during database migration. Changing the path to '/Payum/Core/Bridge/Doctrine/Resources/mapping' fixes the problem.