### PR TITLE
Add STATUS_REVERSED

### DIFF
--- a/src/Payum/Core/Request/GetBinaryStatus.php
+++ b/src/Payum/Core/Request/GetBinaryStatus.php
@@ -15,6 +15,8 @@ class GetBinaryStatus extends BaseGetStatus
 
     const STATUS_PENDING = 1024; // 2^10
 
+    const STATUS_REVERSED = 64; //2^6
+
     const STATUS_CANCELED = 32; //2^5
 
     const STATUS_REFUNDED = 16; // 2^4
@@ -135,6 +137,22 @@ class GetBinaryStatus extends BaseGetStatus
     public function isCanceled()
     {
         return $this->isCurrentStatusEqualTo(static::STATUS_CANCELED);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function markReversed()
+    {
+        $this->status = static::STATUS_REVERSED;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isReversed()
+    {
+        return $this->isCurrentStatusEqualTo(static::STATUS_REVERSED);
     }
 
     /**

--- a/src/Payum/Core/Request/GetHumanStatus.php
+++ b/src/Payum/Core/Request/GetHumanStatus.php
@@ -23,6 +23,8 @@ class GetHumanStatus extends BaseGetStatus
 
     const STATUS_CANCELED = 'canceled';
 
+    const STATUS_REVERSED = 'reversed';
+
     const STATUS_NEW = 'new';
 
     /**
@@ -135,6 +137,22 @@ class GetHumanStatus extends BaseGetStatus
     public function isCanceled()
     {
         return $this->isCurrentStatusEqualTo(static::STATUS_CANCELED);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function markReversed()
+    {
+        $this->status = static::STATUS_REVERSED;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isReversed()
+    {
+        return $this->isCurrentStatusEqualTo(static::STATUS_REVERSED);
     }
 
     /**

--- a/src/Payum/Core/Request/GetStatusInterface.php
+++ b/src/Payum/Core/Request/GetStatusInterface.php
@@ -94,6 +94,16 @@ interface GetStatusInterface extends ModelAwareInterface, ModelAggregateInterfac
     /**
      * @return boolean
      */
+    public function isReversed();
+
+    /**
+     * @return void
+     */
+    public function markReversed();
+
+    /**
+     * @return boolean
+     */
     public function isPending();
 
     /**

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Action/PaymentDetailsStatusAction.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Action/PaymentDetailsStatusAction.php
@@ -109,6 +109,15 @@ class PaymentDetailsStatusAction implements ActionInterface
                     return;
                 }
 
+                $reversedStatuses = array(
+                    Api::PAYMENTSTATUS_REVERSED,
+                );
+                if (in_array($paymentStatus, $reversedStatuses)) {
+                    $request->markReversed();
+
+                    return;
+                }
+
                 $pendingStatuses = array(
                     Api::PAYMENTSTATUS_IN_PROGRESS,
                     Api::PAYMENTSTATUS_PENDING,

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/PaymentDetailsStatusActionTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/PaymentDetailsStatusActionTest.php
@@ -335,6 +335,25 @@ class PaymentDetailsStatusActionTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function shouldMarkReversedIfAtLeastOnePaymentStatusReversed()
+    {
+        $action = new PaymentDetailsStatusAction();
+
+        $request = new GetHumanStatus(array(
+            'PAYMENTREQUEST_0_AMT' => 12,
+            'CHECKOUTSTATUS' => Api::CHECKOUTSTATUS_PAYMENT_COMPLETED,
+            'PAYMENTREQUEST_0_PAYMENTSTATUS' => Api::PAYMENTSTATUS_COMPLETED,
+            'PAYMENTREQUEST_9_PAYMENTSTATUS' => Api::PAYMENTSTATUS_REVERSED,
+        ));
+
+        $action->execute($request);
+
+        $this->assertTrue($request->isReversed());
+    }
+
+    /**
+     * @test
+     */
     public function shouldMarkCapturedIfAllPaymentStatusCompletedOrProcessed()
     {
         $action = new PaymentDetailsStatusAction();


### PR DESCRIPTION
Added for handling payment reverses (chargebacks) by handling `NotifyAction` executing

_P.S. Not sure about constant value of `GetBinaryStatus::STATUS_REVERSED`_