### PR TITLE
[security] Add ability to crypt data stored to database

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,7 @@
         "fp/klarna-invoice": "0.1.*",
         "stripe/stripe-php": "~2.0|~3.0",
         "php-http/guzzle6-adapter": "^1.1.1",
+        "defuse/php-encryption": "^2",
         "ext-soap": "*"
     },
     "replace": {
@@ -94,7 +95,8 @@
         "paypal/rest-api-sdk-php" : "0.5.* If you want to use PayPal REST API install paypal/rest-api-sdk-php:0.5.* library",
         "klarna/checkout": "~1.0|~2.0 If you want to use Klarna Checkout install klarna/checkout:~1|~2.0 library",
         "fp/klarna-invoice": "0.1.* If you want to use Klarna Invoice install fp/klarna-invoice:0.1.* library",
-        "stripe/stripe-php": "~2.0|~3.0 If you want to use Stripe install stripe/stripe-php:~2.0|~3.0 library"
+        "stripe/stripe-php": "~2.0|~3.0 If you want to use Stripe install stripe/stripe-php:~2.0|~3.0 library",
+        "defuse/php-encryption": "^2 If you want to encrypt gateways credentials in database"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Payum/Core/Bridge/Defuse/Security/DefuseCypher.php
+++ b/src/Payum/Core/Bridge/Defuse/Security/DefuseCypher.php
@@ -23,16 +23,16 @@ class DefuseCypher implements CypherInterface
     /**
      * {@inheritdoc}
      */
-    public function decrypt($encryptedValue)
+    public function decrypt($value)
     {
-        return Crypto::decrypt($encryptedValue, $this->key);
+        return Crypto::decrypt($value, $this->key);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function encrypt($rawValue)
+    public function encrypt($value)
     {
-        return Crypto::encrypt($rawValue, $this->key);
+        return Crypto::encrypt($value, $this->key);
     }
 }

--- a/src/Payum/Core/Bridge/Defuse/Security/DefuseCypher.php
+++ b/src/Payum/Core/Bridge/Defuse/Security/DefuseCypher.php
@@ -1,0 +1,38 @@
+<?php
+namespace Payum\Core\Bridge\Defuse\Security;
+
+use Defuse\Crypto\Crypto;
+use Defuse\Crypto\Key;
+use Payum\Core\Security\CypherInterface;
+
+class DefuseCypher implements CypherInterface
+{
+    /**
+     * @var string
+     */
+    private $key;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($secret)
+    {
+        $this->key = Key::loadFromAsciiSafeString($secret);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function decrypt($encryptedValue)
+    {
+        return Crypto::decrypt($encryptedValue, $this->key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function encrypt($rawValue)
+    {
+        return Crypto::encrypt($rawValue, $this->key);
+    }
+}

--- a/src/Payum/Core/Model/GatewayConfig.php
+++ b/src/Payum/Core/Model/GatewayConfig.php
@@ -92,11 +92,17 @@ class GatewayConfig implements GatewayConfigInterface, CryptedInterface
      */
     public function decrypt(CypherInterface $cypher)
     {
-        if (false == isset($this->config['encrypted'])) {
+        if (empty($this->config['encrypted'])) {
             return;
         }
 
         foreach ($this->config as $name => $value) {
+            if ('encrypted' == $name || is_bool($value)) {
+                $this->decryptedConfig[$name] = $value;
+
+                continue;
+            }
+
             $this->decryptedConfig[$name] = $cypher->decrypt($value);
         }
     }
@@ -106,9 +112,15 @@ class GatewayConfig implements GatewayConfigInterface, CryptedInterface
      */
     public function encrypt(CypherInterface $cypher)
     {
-        $this->config['encrypted'] = true;
+        $this->decryptedConfig['encrypted'] = true;
 
         foreach ($this->decryptedConfig as $name => $value) {
+            if ('encrypted' == $name || is_bool($value)) {
+                $this->config[$name] = $value;
+
+                continue;
+            }
+
             $this->config[$name] = $cypher->encrypt($value);
         }
     }

--- a/src/Payum/Core/Security/CryptedInterface.php
+++ b/src/Payum/Core/Security/CryptedInterface.php
@@ -4,12 +4,16 @@ namespace Payum\Core\Security;
 interface CryptedInterface
 {
     /**
-     * {@inheritdoc}
+     * @param CypherInterface $cypher
+     *
+     * @return void
      */
     public function decrypt(CypherInterface $cypher);
 
     /**
-     * {@inheritdoc}
+     * @param CypherInterface $cypher
+     *
+     * @return void
      */
     public function encrypt(CypherInterface $cypher);
 }

--- a/src/Payum/Core/Security/CryptedInterface.php
+++ b/src/Payum/Core/Security/CryptedInterface.php
@@ -1,0 +1,15 @@
+<?php
+namespace Payum\Core\Security;
+
+interface CryptedInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function decrypt(CypherInterface $cypher);
+
+    /**
+     * {@inheritdoc}
+     */
+    public function encrypt(CypherInterface $cypher);
+}

--- a/src/Payum/Core/Security/CypherInterface.php
+++ b/src/Payum/Core/Security/CypherInterface.php
@@ -1,0 +1,23 @@
+<?php
+namespace Payum\Core\Security;
+
+interface CypherInterface
+{
+    /**
+     * This method decrypts the passed value.
+     *
+     * @param string $value
+     *
+     * @return string
+     */
+    public function decrypt($value);
+
+    /**
+     * This method encrypts the passed value.
+     *
+     * Binary data may be base64-encoded.
+     *
+     * @param string $value
+     */
+    public function encrypt($value);
+}

--- a/src/Payum/Core/Security/CypherInterface.php
+++ b/src/Payum/Core/Security/CypherInterface.php
@@ -18,6 +18,8 @@ interface CypherInterface
      * Binary data may be base64-encoded.
      *
      * @param string $value
+     *
+     * @return string
      */
     public function encrypt($value);
 }

--- a/src/Payum/Core/Storage/CryptoStorageDecorator.php
+++ b/src/Payum/Core/Storage/CryptoStorageDecorator.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Payum\Core\Storage;
+
+use Payum\Core\Security\CryptedInterface;
+use Payum\Core\Security\CypherInterface;
+
+final class CryptoStorageDecorator implements StorageInterface
+{
+    /**
+     * @var StorageInterface
+     */
+    private $realStorage;
+
+    /**
+     * @var CypherInterface
+     */
+    private $crypto;
+
+    /**
+     * @param StorageInterface $realStorage
+     * @param CypherInterface $crypto
+     */
+    public function __construct(StorageInterface $realStorage, CypherInterface $crypto)
+    {
+        $this->realStorage = $realStorage;
+        $this->crypto = $crypto;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create()
+    {
+        return $this->realStorage->create();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function support($model)
+    {
+        return $this->realStorage->support($model);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function update($model)
+    {
+        if ($model instanceof CryptedInterface) {
+            $model->encrypt($this->crypto);
+        }
+
+        $this->realStorage->update($model);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete($model)
+    {
+        $this->realStorage->delete($model);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function find($id)
+    {
+        $model = $this->realStorage->find($id);
+
+        if ($model instanceof CryptedInterface) {
+            $model->decrypt($this->crypto);
+        }
+
+        return $model;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findBy(array $criteria)
+    {
+        $models = $this->realStorage->findBy($criteria);
+
+        foreach ($models as $model) {
+            if ($model instanceof CryptedInterface) {
+                $model->decrypt($this->crypto);
+            }
+        }
+
+        return $models;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function identify($model)
+    {
+        return $this->realStorage->identify($model);
+    }
+}

--- a/src/Payum/Core/Storage/CryptoStorageDecorator.php
+++ b/src/Payum/Core/Storage/CryptoStorageDecorator.php
@@ -10,7 +10,7 @@ final class CryptoStorageDecorator implements StorageInterface
     /**
      * @var StorageInterface
      */
-    private $realStorage;
+    private $decoratedStorage;
 
     /**
      * @var CypherInterface
@@ -18,12 +18,12 @@ final class CryptoStorageDecorator implements StorageInterface
     private $crypto;
 
     /**
-     * @param StorageInterface $realStorage
+     * @param StorageInterface $decoratedStorage
      * @param CypherInterface $crypto
      */
-    public function __construct(StorageInterface $realStorage, CypherInterface $crypto)
+    public function __construct(StorageInterface $decoratedStorage, CypherInterface $crypto)
     {
-        $this->realStorage = $realStorage;
+        $this->decoratedStorage = $decoratedStorage;
         $this->crypto = $crypto;
     }
 
@@ -32,7 +32,7 @@ final class CryptoStorageDecorator implements StorageInterface
      */
     public function create()
     {
-        return $this->realStorage->create();
+        return $this->decoratedStorage->create();
     }
 
     /**
@@ -40,7 +40,7 @@ final class CryptoStorageDecorator implements StorageInterface
      */
     public function support($model)
     {
-        return $this->realStorage->support($model);
+        return $this->decoratedStorage->support($model);
     }
 
     /**
@@ -52,7 +52,7 @@ final class CryptoStorageDecorator implements StorageInterface
             $model->encrypt($this->crypto);
         }
 
-        $this->realStorage->update($model);
+        $this->decoratedStorage->update($model);
     }
 
     /**
@@ -60,7 +60,7 @@ final class CryptoStorageDecorator implements StorageInterface
      */
     public function delete($model)
     {
-        $this->realStorage->delete($model);
+        $this->decoratedStorage->delete($model);
     }
 
     /**
@@ -68,7 +68,7 @@ final class CryptoStorageDecorator implements StorageInterface
      */
     public function find($id)
     {
-        $model = $this->realStorage->find($id);
+        $model = $this->decoratedStorage->find($id);
 
         if ($model instanceof CryptedInterface) {
             $model->decrypt($this->crypto);
@@ -82,7 +82,7 @@ final class CryptoStorageDecorator implements StorageInterface
      */
     public function findBy(array $criteria)
     {
-        $models = $this->realStorage->findBy($criteria);
+        $models = $this->decoratedStorage->findBy($criteria);
 
         foreach ($models as $model) {
             if ($model instanceof CryptedInterface) {
@@ -98,6 +98,6 @@ final class CryptoStorageDecorator implements StorageInterface
      */
     public function identify($model)
     {
-        return $this->realStorage->identify($model);
+        return $this->decoratedStorage->identify($model);
     }
 }

--- a/src/Payum/Core/Tests/Bridge/Defuse/Security/DefuseCypherTest.php
+++ b/src/Payum/Core/Tests/Bridge/Defuse/Security/DefuseCypherTest.php
@@ -1,0 +1,31 @@
+<?php
+namespace Payum\Core\Tests\Bridge\Defuse\Security;
+
+use Defuse\Crypto\Key;
+use Payum\Core\Bridge\Defuse\Security\DefuseCypher;
+use Payum\Core\Security\CypherInterface;
+
+class DefuseCypherTest extends \PHPUnit_Framework_TestCase
+{
+    public function testShouldImplementCypherInterface()
+    {
+        $rc = new \ReflectionClass(DefuseCypher::class);
+
+        $this->assertTrue($rc->implementsInterface(CypherInterface::class));
+    }
+
+    public function testShouldEncryptAndDecryptValue()
+    {
+        $secret = Key::createNewRandomKey()->saveToAsciiSafeString();
+
+        $cypher = new DefuseCypher($secret);
+
+        $cryptedValue = $cypher->encrypt('theValue');
+
+        $this->assertNotSame('theValue', $cryptedValue);
+
+        $decryptedValue = $cypher->decrypt($cryptedValue);
+
+        $this->assertSame('theValue', $decryptedValue);
+    }
+}

--- a/src/Payum/Core/Tests/Model/GatewayConfigTest.php
+++ b/src/Payum/Core/Tests/Model/GatewayConfigTest.php
@@ -3,6 +3,8 @@ namespace Payum\Core\Tests\Model;
 
 use Payum\Core\Model\GatewayConfig;
 use Payum\Core\Model\GatewayConfigInterface;
+use Payum\Core\Security\CryptedInterface;
+use Payum\Core\Security\CypherInterface;
 
 class GatewayConfigTest extends \PHPUnit_Framework_TestCase
 {
@@ -14,6 +16,16 @@ class GatewayConfigTest extends \PHPUnit_Framework_TestCase
         $rc = new \ReflectionClass(GatewayConfig::class);
 
         $this->assertTrue($rc->implementsInterface(GatewayConfigInterface::class));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldImplementCryptedInterface()
+    {
+        $rc = new \ReflectionClass(GatewayConfig::class);
+
+        $this->assertTrue($rc->implementsInterface(CryptedInterface::class));
     }
 
     /**
@@ -55,7 +67,7 @@ class GatewayConfigTest extends \PHPUnit_Framework_TestCase
     {
         $config = new GatewayConfig();
 
-        $this->assertEquals(array(), $config->getConfig());
+        $this->assertEquals([], $config->getConfig());
     }
 
     /**
@@ -68,5 +80,116 @@ class GatewayConfigTest extends \PHPUnit_Framework_TestCase
         $config->setConfig(array('foo' => 'fooVal'));
 
         $this->assertEquals(array('foo' => 'fooVal'), $config->getConfig());
+    }
+
+    public function testShouldDecryptConfigValuesOnDecrypt()
+    {
+        $encryptedConfig = [
+            'encrypted' => true,
+            'foo' => 'encryptedFooVal',
+            'bar' => 'encryptedBarVal',
+        ];
+        $expectedDecryptedConfig = [
+            'encrypted' => true,
+            'foo' => 'decrypted-encryptedFooVal',
+            'bar' => 'decrypted-encryptedBarVal',
+        ];
+
+        $config = new GatewayConfig();
+        $config->setConfig($encryptedConfig);
+
+        $this->assertAttributeSame($encryptedConfig, 'config', $config);
+        $this->assertAttributeSame($encryptedConfig, 'decryptedConfig', $config);
+
+        $config->decrypt($this->createDummyCypher());
+
+        $this->assertAttributeSame($encryptedConfig, 'config', $config);
+        $this->assertAttributeSame($expectedDecryptedConfig, 'decryptedConfig', $config);
+
+        $this->assertSame($expectedDecryptedConfig, $config->getConfig());
+    }
+
+    public function testShouldDoNothingOnDecryptIfConfigIsNotEncrypted()
+    {
+        $plainConfig = [
+            'encrypted' => false,
+            'foo' => 'encryptedFooVal',
+            'bar' => 'encryptedBarVal',
+        ];
+
+        $config = new GatewayConfig();
+        $config->setConfig($plainConfig);
+
+        $this->assertAttributeSame($plainConfig, 'config', $config);
+        $this->assertAttributeSame($plainConfig, 'decryptedConfig', $config);
+
+        $config->decrypt($this->createDummyCypher());
+
+        $this->assertAttributeSame($plainConfig, 'config', $config);
+        $this->assertAttributeSame($plainConfig, 'decryptedConfig', $config);
+
+        $this->assertSame($plainConfig, $config->getConfig());
+    }
+
+    public function testShouldEncryptConfigValuesOnEncrypt()
+    {
+        $plainConfig = [
+            'foo' => 'plainFooVal',
+            'bar' => 'plainBarVal',
+        ];
+
+        $expectedDecryptedConfig = [
+            'foo' => 'plainFooVal',
+            'bar' => 'plainBarVal',
+            'encrypted' => true,
+        ];
+
+        $expectedEncryptedConfig = [
+            'foo' => 'encrypted-plainFooVal',
+            'bar' => 'encrypted-plainBarVal',
+            'encrypted' => true,
+        ];
+
+
+        $config = new GatewayConfig();
+        $config->setConfig($plainConfig);
+
+        $this->assertAttributeSame($plainConfig, 'config', $config);
+        $this->assertAttributeSame($plainConfig, 'decryptedConfig', $config);
+
+        $config->encrypt($this->createDummyCypher());
+
+        $this->assertAttributeSame($expectedEncryptedConfig, 'config', $config);
+        $this->assertAttributeSame($expectedDecryptedConfig, 'decryptedConfig', $config);
+
+        $this->assertSame($expectedDecryptedConfig, $config->getConfig());
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|CypherInterface
+     */
+    private function createDummyCypher()
+    {
+        $mock = $this->getMock(CypherInterface::class);
+
+        $mock
+            ->expects($this->any())
+            ->method('encrypt')
+            ->with($this->anything())
+            ->willReturnCallback(function($value) {
+                return 'encrypted-'.$value;
+            })
+        ;
+
+        $mock
+            ->expects($this->any())
+            ->method('decrypt')
+            ->with($this->anything())
+            ->willReturnCallback(function($value) {
+                return 'decrypted-'.$value;
+            })
+        ;
+
+        return $mock;
     }
 }

--- a/src/Payum/Core/Tests/Storage/CryptoStorageDecoratorTest.php
+++ b/src/Payum/Core/Tests/Storage/CryptoStorageDecoratorTest.php
@@ -1,0 +1,234 @@
+<?php
+namespace Payum\Core\Tests\Storage;
+
+use Payum\Core\Security\CryptedInterface;
+use Payum\Core\Security\CypherInterface;
+use Payum\Core\Storage\CryptoStorageDecorator;
+use Payum\Core\Storage\StorageInterface;
+
+class CryptoStorageDecoratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testShouldImplementStorageInterface()
+    {
+        $rc = new \ReflectionClass(CryptoStorageDecorator::class);
+
+        $this->assertTrue($rc->implementsInterface(StorageInterface::class));
+    }
+
+    public function testCouldBeConstructedWithDecoratedStorageAndCypherAsArguments()
+    {
+        new CryptoStorageDecorator($this->createStorageMock(), $this->createCypherMock());
+    }
+
+    public function testShouldProxyCallToDecoratedStorageAndDoNothingWithCypherOnCreate()
+    {
+        $decoratedStorage = $this->createStorageMock();
+        $decoratedStorage
+            ->expects($this->once())
+            ->method('create')
+        ;
+
+        $cypherMock = $this->createCypherMock();
+        $cypherMock
+            ->expects($this->never())
+            ->method('encrypt')
+        ;
+        $cypherMock
+            ->expects($this->never())
+            ->method('decrypt')
+        ;
+
+        $storage = new CryptoStorageDecorator($decoratedStorage, $cypherMock);
+
+        $storage->create();
+    }
+
+    public function testShouldProxyCallToDecoratedStorageAndDoNothingWithCypherOnSupport()
+    {
+        $model = new CryptedModel();
+
+        $decoratedStorage = $this->createStorageMock();
+        $decoratedStorage
+            ->expects($this->once())
+            ->method('support')
+            ->with($this->identicalTo($model))
+        ;
+
+        $cypherMock = $this->createCypherMock();
+        $cypherMock
+            ->expects($this->never())
+            ->method('encrypt')
+        ;
+        $cypherMock
+            ->expects($this->never())
+            ->method('decrypt')
+        ;
+
+        $storage = new CryptoStorageDecorator($decoratedStorage, $cypherMock);
+
+        $storage->support($model);
+    }
+
+    public function testShouldProxyCallToDecoratedStorageAndDoNothingWithCypherOnDelete()
+    {
+        $model = new CryptedModel();
+
+        $decoratedStorage = $this->createStorageMock();
+        $decoratedStorage
+            ->expects($this->once())
+            ->method('delete')
+            ->with($this->identicalTo($model))
+        ;
+
+        $cypherMock = $this->createCypherMock();
+        $cypherMock
+            ->expects($this->never())
+            ->method('encrypt')
+        ;
+        $cypherMock
+            ->expects($this->never())
+            ->method('decrypt')
+        ;
+
+        $storage = new CryptoStorageDecorator($decoratedStorage, $cypherMock);
+
+        $storage->delete($model);
+    }
+
+    public function testShouldProxyCallToDecoratedStorageAndDoNothingWithCypherOnIdentify()
+    {
+        $model = new CryptedModel();
+
+        $decoratedStorage = $this->createStorageMock();
+        $decoratedStorage
+            ->expects($this->once())
+            ->method('identify')
+            ->with($this->identicalTo($model))
+        ;
+
+        $cypherMock = $this->createCypherMock();
+        $cypherMock
+            ->expects($this->never())
+            ->method('encrypt')
+        ;
+        $cypherMock
+            ->expects($this->never())
+            ->method('decrypt')
+        ;
+
+        $storage = new CryptoStorageDecorator($decoratedStorage, $cypherMock);
+
+        $storage->identify($model);
+    }
+
+    public function testShouldProxyCallToDecoratedStorageAndPassCypherToModelEncryptOnUpdate()
+    {
+        $model = new CryptedModel();
+
+        $decoratedStorage = $this->createStorageMock();
+        $decoratedStorage
+            ->expects($this->once())
+            ->method('update')
+            ->willReturn($model)
+        ;
+
+        $cypherMock = $this->createCypherMock();
+        $cypherMock
+            ->expects($this->once())
+            ->method('encrypt')
+            ->with('theVal');
+        ;
+        $cypherMock
+            ->expects($this->never())
+            ->method('decrypt')
+        ;
+
+        $storage = new CryptoStorageDecorator($decoratedStorage, $cypherMock);
+
+        $storage->update($model);
+    }
+
+    public function testShouldProxyCallToDecoratedStorageAndPassCypherToModelDecryptOnFind()
+    {
+        $model = new CryptedModel();
+
+        $decoratedStorage = $this->createStorageMock();
+        $decoratedStorage
+            ->expects($this->once())
+            ->method('find')
+            ->willReturn($model)
+        ;
+
+        $cypherMock = $this->createCypherMock();
+        $cypherMock
+            ->expects($this->never())
+            ->method('encrypt')
+        ;
+        $cypherMock
+            ->expects($this->once())
+            ->method('decrypt')
+            ->with('theEncryptedVal');
+        ;
+
+        $storage = new CryptoStorageDecorator($decoratedStorage, $cypherMock);
+
+        $storage->find('anId');
+    }
+
+    public function testShouldProxyCallToDecoratedStorageAndPassCypherToEveryModelDecryptOnFindBy()
+    {
+        $decoratedStorage = $this->createStorageMock();
+        $decoratedStorage
+            ->expects($this->once())
+            ->method('findBy')
+            ->willReturn([new CryptedModel(), new CryptedModel(), new \stdClass()])
+        ;
+
+        $cypherMock = $this->createCypherMock();
+        $cypherMock
+            ->expects($this->never())
+            ->method('encrypt')
+        ;
+        $cypherMock
+            ->expects($this->exactly(2))
+            ->method('decrypt')
+            ->with('theEncryptedVal');
+        ;
+
+        $storage = new CryptoStorageDecorator($decoratedStorage, $cypherMock);
+
+        $storage->findBy([]);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|StorageInterface
+     */
+    private function createStorageMock()
+    {
+        return $this->getMock(StorageInterface::class);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|CypherInterface
+     */
+    private function createCypherMock()
+    {
+        return $this->getMock(CypherInterface::class);
+    }
+}
+
+class CryptedModel implements CryptedInterface
+{
+    public function decrypt(CypherInterface $cypher)
+    {
+        $cypher->decrypt('theEncryptedVal');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function encrypt(CypherInterface $cypher)
+    {
+        $cypher->encrypt('theVal');
+    }
+}

--- a/src/Payum/Core/Tests/Storage/CryptoStorageDecoratorTest.php
+++ b/src/Payum/Core/Tests/Storage/CryptoStorageDecoratorTest.php
@@ -22,10 +22,13 @@ class CryptoStorageDecoratorTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldProxyCallToDecoratedStorageAndDoNothingWithCypherOnCreate()
     {
+        $model = new CryptedModel();
+
         $decoratedStorage = $this->createStorageMock();
         $decoratedStorage
             ->expects($this->once())
             ->method('create')
+            ->willReturn($model)
         ;
 
         $cypherMock = $this->createCypherMock();
@@ -40,6 +43,23 @@ class CryptoStorageDecoratorTest extends \PHPUnit_Framework_TestCase
 
         $storage = new CryptoStorageDecorator($decoratedStorage, $cypherMock);
 
+        $createdModel = $storage->create();
+
+        $this->assertSame($model, $createdModel);
+    }
+
+    public function testThrowsIfModelDoesImplementCryptedInterfaceOnCreate()
+    {
+        $decoratedStorage = $this->createStorageMock();
+        $decoratedStorage
+            ->expects($this->once())
+            ->method('create')
+            ->willReturn(new \stdClass())
+        ;
+
+        $storage = new CryptoStorageDecorator($decoratedStorage, $this->createCypherMock());
+
+        $this->setExpectedException(\LogicException::class, 'The model stdClass must implement Payum\Core\Security\CryptedInterface interface.');
         $storage->create();
     }
 
@@ -148,6 +168,14 @@ class CryptoStorageDecoratorTest extends \PHPUnit_Framework_TestCase
         $storage->update($model);
     }
 
+    public function testThrowsIfModelDoesImplementCryptedInterfaceOnUpdate()
+    {
+        $storage = new CryptoStorageDecorator($this->createStorageMock(), $this->createCypherMock());
+
+        $this->setExpectedException(\LogicException::class, 'The model stdClass must implement Payum\Core\Security\CryptedInterface interface.');
+        $storage->update(new \stdClass());
+    }
+
     public function testShouldProxyCallToDecoratedStorageAndPassCypherToModelDecryptOnFind()
     {
         $model = new CryptedModel();
@@ -172,16 +200,35 @@ class CryptoStorageDecoratorTest extends \PHPUnit_Framework_TestCase
 
         $storage = new CryptoStorageDecorator($decoratedStorage, $cypherMock);
 
+        $foundModel = $storage->find('anId');
+
+        $this->assertSame($model, $foundModel);
+    }
+
+    public function testThrowsIfModelDoesImplementCryptedInterfaceOnFind()
+    {
+        $decoratedStorage = $this->createStorageMock();
+        $decoratedStorage
+            ->expects($this->once())
+            ->method('find')
+            ->willReturn(new \stdClass())
+        ;
+
+        $storage = new CryptoStorageDecorator($decoratedStorage, $this->createCypherMock());
+
+        $this->setExpectedException(\LogicException::class, 'The model stdClass must implement Payum\Core\Security\CryptedInterface interface.');
         $storage->find('anId');
     }
 
     public function testShouldProxyCallToDecoratedStorageAndPassCypherToEveryModelDecryptOnFindBy()
     {
+        $models = [new CryptedModel(), new CryptedModel()];
+
         $decoratedStorage = $this->createStorageMock();
         $decoratedStorage
             ->expects($this->once())
             ->method('findBy')
-            ->willReturn([new CryptedModel(), new CryptedModel(), new \stdClass()])
+            ->willReturn($models)
         ;
 
         $cypherMock = $this->createCypherMock();
@@ -197,6 +244,23 @@ class CryptoStorageDecoratorTest extends \PHPUnit_Framework_TestCase
 
         $storage = new CryptoStorageDecorator($decoratedStorage, $cypherMock);
 
+        $foundModels = $storage->findBy([]);
+
+        $this->assertSame($models, $foundModels);
+    }
+
+    public function testThrowsIfModelDoesImplementCryptedInterfaceOnFindBy()
+    {
+        $decoratedStorage = $this->createStorageMock();
+        $decoratedStorage
+            ->expects($this->once())
+            ->method('findBy')
+            ->willReturn([new \stdClass()])
+        ;
+
+        $storage = new CryptoStorageDecorator($decoratedStorage, $this->createCypherMock());
+
+        $this->setExpectedException(\LogicException::class, 'The model stdClass must implement Payum\Core\Security\CryptedInterface interface.');
         $storage->findBy([]);
     }
 

--- a/src/Payum/Core/composer.json
+++ b/src/Payum/Core/composer.json
@@ -55,7 +55,8 @@
         "symfony/form": "~2.8|~3.0",
         "symfony/validator": "~2.8|~3.0",
         "symfony/dependency-injection": "~2.8|~3.0",
-        "symfony/phpunit-bridge": "~2.8|~3.0"
+        "symfony/phpunit-bridge": "~2.8|~3.0",
+        "defuse/php-encryption": "^2"
     },
     "suggest": {
         "payum/paypal-express-checkout-nvp": "self.version If you want to use paypal express checkout, digital goods or recurring payments",
@@ -77,6 +78,7 @@
         "symfony/form": "~2.8|~3.0 If you want to use forms",
         "symfony/dependency-injection": "~2.8|~3.0 If you want to use container aware stuff",
         "monolog/monolog": "~1.0 If you want to use PSR-3 logger"
+        "defuse/php-encryption": "^2 If you want to encrypt gateways credentials in database"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Payum/Core/composer.json
+++ b/src/Payum/Core/composer.json
@@ -77,7 +77,7 @@
         "symfony/http-foundation": "~2.8|~3.0 If you want to use HttpRequestVerifier or HttpResponse reply from symfony's bridge",
         "symfony/form": "~2.8|~3.0 If you want to use forms",
         "symfony/dependency-injection": "~2.8|~3.0 If you want to use container aware stuff",
-        "monolog/monolog": "~1.0 If you want to use PSR-3 logger"
+        "monolog/monolog": "~1.0 If you want to use PSR-3 logger",
         "defuse/php-encryption": "^2 If you want to encrypt gateways credentials in database"
     },
     "config": {


### PR DESCRIPTION
This is an alternative approach to this PR https://github.com/Payum/Payum/pull/635

Here's some benefits with my approach:

* The algo is not limited to openssl. One can use another one by implementing Cypher interface.
* Rely on `defuse/php-encryption` library. 
* Not only gateway configs could be secured but payment data or any other model (model has to implement CryptedInterface)
* No need for doctrine listener and manipulations with change sets. 
* It would work with previously not encrypted data, it will be encrypted while using. 