### PR TITLE
[stripe] by providing the amount, stripe will validate CVC code

### DIFF
--- a/src/Payum/Stripe/Resources/views/Action/obtain_js_token.html.twig
+++ b/src/Payum/Stripe/Resources/views/Action/obtain_js_token.html.twig
@@ -59,7 +59,7 @@
                 // This identifies your website in the createToken call below
                 Stripe.setPublishableKey({{ publishable_key|json_encode|raw }});
 
-                Stripe.card.createToken($form, stripeResponseHandler);
+                Stripe.card.createToken($form, {{ model.amount }}, stripeResponseHandler);
 
                 // Prevent the form from submitting with the default action
                 return false;


### PR DESCRIPTION
Stripe does not validate CVC code in front.

This PR adds the amount as a param of the createToken function call since Stripe Checkout has built-in behavior that runs CVD checks if you've provided an amount.

This way stripe will return an error message like "Your card's security code is incorrect." and the form would print it