### PR TITLE
Fix PayPal express checkout NVP Cancel action support scope

### DIFF
--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Action/Api/CancelRecurringPaymentsProfileAction.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Action/Api/CancelRecurringPaymentsProfileAction.php
@@ -1,7 +1,10 @@
 <?php
 namespace Payum\Paypal\ExpressCheckout\Nvp\Action\Api;
 
+use Payum\Core\ApiAwareInterface;
+use Payum\Core\ApiAwareTrait;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\CancelRecurringPaymentsProfileAction as NewCancelAction;
+use Payum\Paypal\ExpressCheckout\Nvp\Api;
 
 @trigger_error('The ' . CancelRecurringPaymentsProfileAction::class . ' class is deprecated since version 1.4 and will be removed in 2.0. Use ' . NewCancelAction::class . ' class instead.', E_USER_DEPRECATED);
 
@@ -11,6 +14,12 @@ use Payum\Paypal\ExpressCheckout\Nvp\Action\CancelRecurringPaymentsProfileAction
  * @deprecated since version 1.4, to be removed in 2.0.
  *             Use {@link Payum\Paypal\ExpressCheckout\Nvp\Action\CancelRecurringPaymentsProfileAction} instead.
  */
-class CancelRecurringPaymentsProfileAction extends NewCancelAction
+class CancelRecurringPaymentsProfileAction extends NewCancelAction implements ApiAwareInterface
 {
+    use ApiAwareTrait;
+
+    public function __construct()
+    {
+        $this->apiClass = Api::class;
+    }
 }

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Action/Api/CancelRecurringPaymentsProfileAction.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Action/Api/CancelRecurringPaymentsProfileAction.php
@@ -1,52 +1,16 @@
 <?php
 namespace Payum\Paypal\ExpressCheckout\Nvp\Action\Api;
 
-use Payum\Core\Action\ActionInterface;
-use Payum\Core\ApiAwareInterface;
-use Payum\Core\ApiAwareTrait;
-use Payum\Core\Request\Cancel;
-use Payum\Paypal\ExpressCheckout\Nvp\Api;
-use Payum\Core\Bridge\Spl\ArrayObject;
-use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Paypal\ExpressCheckout\Nvp\Action\CancelRecurringPaymentsProfileAction as NewCancelAction;
 
-class CancelRecurringPaymentsProfileAction implements ActionInterface, ApiAwareInterface
+@trigger_error('The ' . CancelRecurringPaymentsProfileAction::class . ' class is deprecated since version 1.4 and will be removed in 2.0. Use ' . NewCancelAction::class . ' class instead.', E_USER_DEPRECATED);
+
+/**
+ * Class CancelRecurringPaymentsProfileAction.
+ *
+ * @deprecated since version 1.4, to be removed in 2.0.
+ *             Use {@link Payum\Paypal\ExpressCheckout\Nvp\Action\CancelRecurringPaymentsProfileAction} instead.
+ */
+class CancelRecurringPaymentsProfileAction extends NewCancelAction
 {
-    use ApiAwareTrait;
-
-    public function __construct()
-    {
-        $this->apiClass = Api::class;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function execute($request)
-    {
-        /** @var $request Cancel */
-        RequestNotSupportedException::assertSupports($this, $request);
-
-        $model = ArrayObject::ensureArrayObject($request->getModel());
-        $model->validateNotEmpty(array('PROFILEID', 'BILLINGPERIOD'));
-
-        $model['ACTION'] = Api::RECURRINGPAYMENTACTION_CANCEL;
-
-        $model->replace(
-            $this->api->manageRecurringPaymentsProfileStatus((array) $model)
-        );
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function supports($request)
-    {
-        if (false == ($request instanceof Cancel && $request->getModel() instanceof \ArrayAccess)) {
-            return false;
-        }
-
-        // it must take into account only recurring payments, common payments must be cancelled by another action.
-        $model = $request->getModel();
-        return isset($model['BILLINGPERIOD']);
-    }
 }

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Action/CancelAction.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Action/CancelAction.php
@@ -24,10 +24,6 @@ class CancelAction implements ActionInterface, GatewayAwareInterface
 
         $details = ArrayObject::ensureArrayObject($request->getModel());
 
-        if (!$details['TRANSACTIONID']) {
-            return;
-        }
-
         $voidDetails = new ArrayObject([
             'AUTHORIZATIONID' => $details['TRANSACTIONID'],
         ]);
@@ -41,9 +37,12 @@ class CancelAction implements ActionInterface, GatewayAwareInterface
      */
     public function supports($request)
     {
-        return
-            $request instanceof Cancel &&
-            $request->getModel() instanceof \ArrayAccess
-        ;
+        if (false == ($request instanceof Cancel && $request->getModel() instanceof \ArrayAccess)) {
+            return false;
+        }
+
+        // it must take into account only common payments, recurring payments must be cancelled by another action.
+        $model = $request->getModel();
+        return isset($model['TRANSACTIONID']);
     }
 }

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Action/CancelAction.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Action/CancelAction.php
@@ -24,6 +24,10 @@ class CancelAction implements ActionInterface, GatewayAwareInterface
 
         $details = ArrayObject::ensureArrayObject($request->getModel());
 
+        if (!$details['TRANSACTIONID']) {
+            return;
+        }
+
         $voidDetails = new ArrayObject([
             'AUTHORIZATIONID' => $details['TRANSACTIONID'],
         ]);
@@ -43,6 +47,6 @@ class CancelAction implements ActionInterface, GatewayAwareInterface
 
         // it must take into account only common payments, recurring payments must be cancelled by another action.
         $model = $request->getModel();
-        return isset($model['TRANSACTIONID']);
+        return empty($model['BILLINGPERIOD']);
     }
 }

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Action/CancelRecurringPaymentsProfileAction.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Action/CancelRecurringPaymentsProfileAction.php
@@ -1,0 +1,52 @@
+<?php
+namespace Payum\Paypal\ExpressCheckout\Nvp\Action;
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\ApiAwareInterface;
+use Payum\Core\ApiAwareTrait;
+use Payum\Core\Request\Cancel;
+use Payum\Paypal\ExpressCheckout\Nvp\Api;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
+
+class CancelRecurringPaymentsProfileAction implements ActionInterface, ApiAwareInterface
+{
+    use ApiAwareTrait;
+
+    public function __construct()
+    {
+        $this->apiClass = Api::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function execute($request)
+    {
+        /** @var $request Cancel */
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        $model = ArrayObject::ensureArrayObject($request->getModel());
+        $model->validateNotEmpty(array('PROFILEID', 'BILLINGPERIOD'));
+
+        $model['ACTION'] = Api::RECURRINGPAYMENTACTION_CANCEL;
+
+        $model->replace(
+            $this->api->manageRecurringPaymentsProfileStatus((array) $model)
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports($request)
+    {
+        if (false == ($request instanceof Cancel && $request->getModel() instanceof \ArrayAccess)) {
+            return false;
+        }
+
+        // it must take into account only recurring payments, common payments must be cancelled by another action.
+        $model = $request->getModel();
+        return isset($model['BILLINGPERIOD']);
+    }
+}

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/PaypalExpressCheckoutGatewayFactory.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/PaypalExpressCheckoutGatewayFactory.php
@@ -12,7 +12,6 @@ use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\GetRecurringPaymentsProfileDetai
 use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\GetTransactionDetailsAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\SetExpressCheckoutAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\AuthorizeTokenAction;
-use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\CancelRecurringPaymentsProfileAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\ManageRecurringPaymentsProfileStatusAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\CreateBillingAgreementAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\DoReferenceTransactionAction;
@@ -21,6 +20,7 @@ use Payum\Paypal\ExpressCheckout\Nvp\Action\Api\DoVoidAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\AuthorizeAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\CaptureAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\CancelAction;
+use Payum\Paypal\ExpressCheckout\Nvp\Action\CancelRecurringPaymentsProfileAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\ConvertPaymentAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\NotifyAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\PaymentDetailsStatusAction;

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/CancelActionTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/CancelActionTest.php
@@ -43,11 +43,15 @@ class CancelActionTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function shouldSupportEmptyModel()
+    public function shouldSupportModelWithTransactionId()
     {
         $action = new CancelAction();
 
-        $request = new Cancel([]);
+        $payment = array(
+            'TRANSACTIONID' => 123,
+        );
+
+        $request = new Cancel($payment);
 
         $this->assertTrue($action->supports($request));
     }
@@ -60,7 +64,8 @@ class CancelActionTest extends \PHPUnit_Framework_TestCase
         $action = new CancelAction();
 
         $payment = array(
-           'PAYMENTINFO_0_PENDINGREASON' => Api::PENDINGREASON_AUTHORIZATION,
+            'TRANSACTIONID' => 123,
+            'PAYMENTINFO_0_PENDINGREASON' => Api::PENDINGREASON_AUTHORIZATION,
         );
 
         $request = new Cancel($payment);
@@ -76,12 +81,25 @@ class CancelActionTest extends \PHPUnit_Framework_TestCase
         $action = new CancelAction();
 
         $payment = array(
-           'PAYMENTINFO_0_PENDINGREASON' => 'Foo',
+            'TRANSACTIONID' => 123,
+            'PAYMENTINFO_0_PENDINGREASON' => 'Foo',
         );
 
         $request = new Cancel($payment);
 
         $this->assertTrue($action->supports($request));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotSupportModelWithoutTransactionId()
+    {
+        $action = new CancelAction();
+
+        $request = new Cancel([]);
+
+        $this->assertFalse($action->supports($request));
     }
 
     /**
@@ -120,17 +138,12 @@ class CancelActionTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     *
+     * @expectedException \Payum\Core\Exception\RequestNotSupportedException
      */
-    public function shouldNotExecuteDoVoidIfTransactionIdNotSet()
+    public function throwIfNotSupportedModelGivenAsArgumentForExecute()
     {
-        $gatewayMock = $this->createGatewayMock();
-        $gatewayMock
-            ->expects($this->never())
-            ->method('execute')
-        ;
-
         $action = new CancelAction();
-        $action->setGateway($gatewayMock);
 
         $request = new Cancel([]);
 

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/CancelActionTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/CancelActionTest.php
@@ -43,15 +43,11 @@ class CancelActionTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function shouldSupportModelWithTransactionId()
+    public function shouldSupportEmptyModel()
     {
         $action = new CancelAction();
 
-        $payment = array(
-            'TRANSACTIONID' => 123,
-        );
-
-        $request = new Cancel($payment);
+        $request = new Cancel([]);
 
         $this->assertTrue($action->supports($request));
     }
@@ -64,8 +60,7 @@ class CancelActionTest extends \PHPUnit_Framework_TestCase
         $action = new CancelAction();
 
         $payment = array(
-            'TRANSACTIONID' => 123,
-            'PAYMENTINFO_0_PENDINGREASON' => Api::PENDINGREASON_AUTHORIZATION,
+           'PAYMENTINFO_0_PENDINGREASON' => Api::PENDINGREASON_AUTHORIZATION,
         );
 
         $request = new Cancel($payment);
@@ -81,8 +76,7 @@ class CancelActionTest extends \PHPUnit_Framework_TestCase
         $action = new CancelAction();
 
         $payment = array(
-            'TRANSACTIONID' => 123,
-            'PAYMENTINFO_0_PENDINGREASON' => 'Foo',
+           'PAYMENTINFO_0_PENDINGREASON' => 'Foo',
         );
 
         $request = new Cancel($payment);
@@ -93,11 +87,15 @@ class CancelActionTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function shouldNotSupportModelWithoutTransactionId()
+    public function shouldNotSupportModelWithBillingPeriod()
     {
         $action = new CancelAction();
 
-        $request = new Cancel([]);
+        $payment = array(
+           'BILLINGPERIOD' => 'Month',
+        );
+
+        $request = new Cancel($payment);
 
         $this->assertFalse($action->supports($request));
     }
@@ -138,12 +136,17 @@ class CancelActionTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     *
-     * @expectedException \Payum\Core\Exception\RequestNotSupportedException
      */
-    public function throwIfNotSupportedModelGivenAsArgumentForExecute()
+    public function shouldNotExecuteDoVoidIfTransactionIdNotSet()
     {
+        $gatewayMock = $this->createGatewayMock();
+        $gatewayMock
+            ->expects($this->never())
+            ->method('execute')
+        ;
+
         $action = new CancelAction();
+        $action->setGateway($gatewayMock);
 
         $request = new Cancel([]);
 

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/CancelRecurringPaymentsProfileActionTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/CancelRecurringPaymentsProfileActionTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Payum\Paypal\ExpressCheckout\Nvp\Tests\Action\Api;
+namespace Payum\Paypal\ExpressCheckout\Nvp\Tests\Action;
 
 use Payum\Core\Action\ActionInterface;
 use Payum\Core\ApiAwareInterface;
@@ -18,7 +18,7 @@ class CancelRecurringPaymentsProfileActionTest extends GenericActionTest
     /**
      * @var ActionInterface
      */
-    protected $actionClass = 'Payum\Paypal\ExpressCheckout\Nvp\Action\Api\CancelRecurringPaymentsProfileAction';
+    protected $actionClass = 'Payum\Paypal\ExpressCheckout\Nvp\Action\CancelRecurringPaymentsProfileAction';
 
     public function provideSupportedRequests()
     {


### PR DESCRIPTION
Because of very wide scope of support method, this action was preventing execution of other actions that handle Cancel request like CancelRecurringPaymentsProfileAction

fix #660