### PR TITLE
Check that the gateway factory exists

### DIFF
--- a/src/Payum/Core/PayumBuilder.php
+++ b/src/Payum/Core/PayumBuilder.php
@@ -605,7 +605,7 @@ class PayumBuilder
     protected function buildOmnipayGatewayFactories(GatewayFactoryInterface $coreGatewayFactory)
     {
         $gatewayFactories = [];
-        if (false == class_exists(\Omnipay\Omnipay::class)) {
+        if (false == class_exists(\Omnipay\Omnipay::class) || false == class_exists(OmnipayGatewayFactory::class)) {
             return $gatewayFactories;
         }
 


### PR DESCRIPTION
The PayumBuilder will fatally error out if you have Omnipay installed without the OmnipayBridge package.  This adds a check to ensure the bridge is present as well.