### PR TITLE
Checkout: Automatically choose language

### DIFF
--- a/src/Payum/Stripe/Resources/views/Action/obtain_checkout_token.html.twig
+++ b/src/Payum/Stripe/Resources/views/Action/obtain_checkout_token.html.twig
@@ -11,7 +11,8 @@
             data-name="{{ model.name|default("") }}"
             data-description="{{ model.description|default("") }}"
             data-amount="{{ model.amount }}"
-            data-currency="{{ model.currency|default("USD") }}">
+            data-currency="{{ model.currency|default("USD") }}"
+            data-locale="auto">
         </script>
     </form>
 {% endblock %}


### PR DESCRIPTION
Let Stripe set the language automatically by passing `data-locale="auto"` to the script.
See https://stripe.com/blog/checkout-in-more-languages for details.