### PR TITLE
Make Payum compatible with OmnipayBridge 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.0 (2017-08-21)
+* [bridge][omnipay] make it compatible with ominpay/common:^3.0, since Omnipay removed getSupportedGateways() function, you now need add 'type' property to your gateway-config or pass it to the gateway factory.
+
 ## 1.4.2 (2017-06-21)
 
 * [paypal-ec] Re-factor CancelRecurringPaymentsProfileAction as actions proxy

--- a/composer.json
+++ b/composer.json
@@ -49,8 +49,8 @@
     "require-dev": {
         "ext-curl": "*",
         "ext-pdo_sqlite": "*",
-        "payum/omnipay-bridge": "^1",
-        "omnipay/dummy": "~2.0",
+        "payum/omnipay-bridge": "^2.0",
+        "omnipay/dummy": "~3.0",
         "doctrine/orm": "2.5.*",
         "phpunit/phpunit": "~4.0",
         "propel/propel1": "~1.7",

--- a/src/Payum/Core/PayumBuilder.php
+++ b/src/Payum/Core/PayumBuilder.php
@@ -611,19 +611,9 @@ class PayumBuilder
 
         $factory = \Omnipay\Omnipay::getFactory();
 
-        $gatewayFactories['omnipay'] = new OmnipayGatewayFactory('', $factory, [], $coreGatewayFactory);
-        $gatewayFactories['omnipay_direct'] = new OmnipayGatewayFactory('', $factory, [], $coreGatewayFactory);
-        $gatewayFactories['omnipay_offsite'] = new OmnipayGatewayFactory('', $factory, [], $coreGatewayFactory);
-
-        foreach ($factory->getSupportedGateways() as $type) {
-            // omnipay throws exception on these gateways https://github.com/thephpleague/omnipay/issues/312
-            // skip them for now
-            if (in_array($type, ['Buckaroo', 'Alipay Bank', 'AliPay Dual Func', 'Alipay Express', 'Alipay Mobile Express', 'Alipay Secured', 'Alipay Wap Express', 'Cybersource', 'DataCash', 'Ecopayz', 'Neteller', 'Pacnet', 'PaymentSense', 'Realex Remote', 'SecPay (PayPoint.net)', 'Sisow', 'Skrill', 'YandexMoney', 'YandexMoneyIndividual'])) {
-                continue;
-            }
-
-            $gatewayFactories[strtolower('omnipay_'.$type)] = new OmnipayGatewayFactory($type, $factory, [], $coreGatewayFactory);
-        }
+        $gatewayFactories['omnipay'] = new OmnipayGatewayFactory($factory, [], $coreGatewayFactory);
+        $gatewayFactories['omnipay_direct'] = new OmnipayGatewayFactory($factory, [], $coreGatewayFactory);
+        $gatewayFactories['omnipay_offsite'] = new OmnipayGatewayFactory($factory, [], $coreGatewayFactory);
 
         return $gatewayFactories;
     }

--- a/src/Payum/Core/Tests/PayumBuilderTest.php
+++ b/src/Payum/Core/Tests/PayumBuilderTest.php
@@ -659,19 +659,19 @@ class PayumBuilderTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Either omnipay or\and omnipay bridge are not installed. Skip');
         }
 
-        $expectedCoreGatewayFactory = $this->getMock(GatewayFactoryInterface::class);
-
         $payum = (new PayumBuilder())
             ->addDefaultStorages()
-            ->setCoreGatewayFactory($expectedCoreGatewayFactory)
+            ->setCoreGatewayFactory(new CoreGatewayFactory())
             ->getPayum()
         ;
 
         $gatewayFactories = $payum->getGatewayFactories();
 
-        $this->assertArrayHasKey('omnipay_dummy', $gatewayFactories);
-        $this->assertArrayHasKey('omnipay_stripe', $gatewayFactories);
-        $this->assertArrayHasKey('omnipay_paypal_express', $gatewayFactories);
+        $this->assertArrayHasKey('omnipay', $gatewayFactories);
+
+        $dummyType = $gatewayFactories['omnipay']->create(['type' => 'dummy']);
+
+        $this->assertNotNull($dummyType);
     }
 
     /**
@@ -691,7 +691,7 @@ class PayumBuilderTest extends \PHPUnit_Framework_TestCase
             ->getPayum()
         ;
 
-        $gatewayFactory = $payum->getGatewayFactory('omnipay_dummy');
+        $gatewayFactory = $payum->getGatewayFactory('omnipay');
 
         $this->assertInstanceOf(OmnipayGatewayFactory::class, $gatewayFactory);
 
@@ -712,11 +712,11 @@ class PayumBuilderTest extends \PHPUnit_Framework_TestCase
             ->getPayum()
         ;
 
-        $gatewayFactory = $payum->getGatewayFactory('omnipay_dummy');
+        $gatewayFactory = $payum->getGatewayFactory('omnipay');
 
         $this->assertInstanceOf(OmnipayGatewayFactory::class, $gatewayFactory);
 
-        $gateway = $gatewayFactory->create();
+        $gateway = $gatewayFactory->create(['type' => 'Dummy']);
 
         $apis = $this->readAttribute($gateway, 'apis');
 


### PR DESCRIPTION
This PR makes Payum compatible with not yet released OmnipayBridge 2.0 (https://github.com/Payum/OmnipayBridge/pull/32).

It looks like a BC break, but since it affects only OmnipayBridge, I wouldn't consider it a BC break at all.

related to https://github.com/Payum/Payum/issues/675