### PR TITLE
Missing variables

### DIFF
--- a/docs/get-it-started.md
+++ b/docs/get-it-started.md
@@ -116,6 +116,10 @@ use Payum\Core\Reply\HttpRedirect;
 
 include __DIR__.'/config.php';
 
+/** @var \Payum\Core\Payum $payum */
+$token = $payum->getHttpRequestVerifier()->verify($_REQUEST);
+$gateway = $payum->getGateway($token->getGatewayName());
+
 /** @var \Payum\Core\GatewayInterface $gateway */
 if ($reply = $gateway->execute(new Capture($token), true)) {
     if ($reply instanceof HttpRedirect) {


### PR DESCRIPTION
I noticed in documentation that in capture.php is missing initializate two variables which are used bellow.