### PR TITLE
Added refund and payout actions to offline gateway

### DIFF
--- a/src/Payum/Offline/Action/ConvertPayoutAction.php
+++ b/src/Payum/Offline/Action/ConvertPayoutAction.php
@@ -1,0 +1,50 @@
+<?php
+namespace Payum\Offline\Action;
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Model\PayoutInterface;
+use Payum\Core\Request\Convert;
+use Payum\Offline\Constants;
+
+class ConvertPayoutAction implements ActionInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @param Convert $request
+     */
+    public function execute($request)
+    {
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        /** @var PayoutInterface $payout */
+        $payout = $request->getSource();
+
+        $details = ArrayObject::ensureArrayObject($payout->getDetails());
+        $details['amount'] = $payout->getTotalAmount();
+        $details['currency'] = $payout->getCurrencyCode();
+        $details['description'] = $payout->getDescription();
+        $details['recipient_email'] = $payout->getRecipientEmail();
+        $details['recipient_id'] = $payout->getRecipientId();
+        
+        $details->defaults(array(
+            Constants::FIELD_PAYOUT => true,
+        ));
+
+        $request->setResult((array) $details);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports($request)
+    {
+        return
+            $request instanceof Convert &&
+            $request->getSource() instanceof PayoutInterface &&
+            $request->getTo() == 'array'
+        ;
+    }
+}

--- a/src/Payum/Offline/Action/PayoutAction.php
+++ b/src/Payum/Offline/Action/PayoutAction.php
@@ -1,0 +1,39 @@
+<?php
+namespace Payum\Offline\Action;
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Request\Payout;
+use Payum\Offline\Constants;
+
+class PayoutAction implements ActionInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function execute($request)
+    {
+        /** @var $request Payout */
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        $model = ArrayObject::ensureArrayObject($request->getModel());
+
+        if ($model[Constants::FIELD_PAYOUT]) {
+            $model[Constants::FIELD_STATUS] = Constants::STATUS_PAYEDOUT;
+        } else {
+            $model[Constants::FIELD_STATUS] = Constants::STATUS_PENDING;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports($request)
+    {
+        return
+            $request instanceof Payout &&
+            $request->getModel() instanceof \ArrayAccess
+            ;
+    }
+}

--- a/src/Payum/Offline/Action/RefundAction.php
+++ b/src/Payum/Offline/Action/RefundAction.php
@@ -1,0 +1,37 @@
+<?php
+namespace Payum\Offline\Action;
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Request\Refund;
+use Payum\Offline\Constants;
+
+class RefundAction implements ActionInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function execute($request)
+    {
+        /** @var $request Refund */
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        $model = ArrayObject::ensureArrayObject($request->getModel());
+
+        if ($model[Constants::FIELD_STATUS] == Constants::STATUS_CAPTURED) {
+            $model[Constants::FIELD_STATUS] = Constants::STATUS_REFUNDED;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports($request)
+    {
+        return
+            $request instanceof Refund &&
+            $request->getModel() instanceof \ArrayAccess
+            ;
+    }
+}

--- a/src/Payum/Offline/Action/StatusAction.php
+++ b/src/Payum/Offline/Action/StatusAction.php
@@ -42,7 +42,19 @@ class StatusAction implements ActionInterface
 
             return;
         }
-        
+
+        if (Constants::STATUS_PAYEDOUT == $model[Constants::FIELD_STATUS]) {
+            $request->markPayedout();
+
+            return;
+        }
+
+        if (Constants::STATUS_REFUNDED == $model[Constants::FIELD_STATUS]) {
+            $request->markRefunded();
+
+            return;
+        }
+
         if (Constants::STATUS_CANCELED == $model[Constants::FIELD_STATUS]) {
             $request->markCanceled();
 

--- a/src/Payum/Offline/Constants.php
+++ b/src/Payum/Offline/Constants.php
@@ -5,11 +5,17 @@ abstract class Constants
 {
     const FIELD_PAID = 'paid';
 
+    const FIELD_PAYOUT = 'payout';
+
     const FIELD_STATUS = 'status';
 
     const STATUS_CAPTURED = 'captured';
 
     const STATUS_AUTHORIZED = 'authorized';
+
+    const STATUS_PAYEDOUT = 'payedout';
+
+    const STATUS_REFUNDED = 'refunded';
 
     const STATUS_PENDING = 'pending';
     

--- a/src/Payum/Offline/OfflineGatewayFactory.php
+++ b/src/Payum/Offline/OfflineGatewayFactory.php
@@ -6,6 +6,9 @@ use Payum\Core\GatewayFactory;
 use Payum\Offline\Action\AuthorizeAction;
 use Payum\Offline\Action\CaptureAction;
 use Payum\Offline\Action\ConvertPaymentAction;
+use Payum\Offline\Action\ConvertPayoutAction;
+use Payum\Offline\Action\PayoutAction;
+use Payum\Offline\Action\RefundAction;
 use Payum\Offline\Action\StatusAction;
 
 class OfflineGatewayFactory extends GatewayFactory
@@ -20,8 +23,11 @@ class OfflineGatewayFactory extends GatewayFactory
             'payum.factory_title' => 'Offline',
             'payum.action.capture' => new CaptureAction(),
             'payum.action.authorize' => new AuthorizeAction(),
+            'payum.action.payout' => new PayoutAction(),
+            'payum.action.refund' => new RefundAction(),
             'payum.action.status' => new StatusAction(),
             'payum.action.convert_payment' => new ConvertPaymentAction(),
+            'payum.action.convert_payout' => new ConvertPayoutAction(),
         ]);
     }
 }

--- a/src/Payum/Offline/Tests/Action/ConvertPayoutActionTest.php
+++ b/src/Payum/Offline/Tests/Action/ConvertPayoutActionTest.php
@@ -1,0 +1,124 @@
+<?php
+namespace Payum\Offline\Tests\Action\Api;
+
+use Payum\Core\Model\Payout;
+use Payum\Core\Model\PayoutInterface;
+use Payum\Core\Request\Convert;
+use Payum\Core\Tests\GenericActionTest;
+use Payum\Offline\Action\ConvertPayoutAction;
+use Payum\Offline\Constants;
+
+class ConvertPayoutActionTest extends GenericActionTest
+{
+    protected $actionClass = 'Payum\Offline\Action\ConvertPayoutAction';
+
+    protected $requestClass = 'Payum\Core\Request\Convert';
+
+    public function provideSupportedRequests()
+    {
+        return array(
+            array(new $this->requestClass(new Payout(), 'array')),
+            array(new $this->requestClass($this->getMock(PayoutInterface::class), 'array')),
+            array(new $this->requestClass(new Payout(), 'array', $this->getMock('Payum\Core\Security\TokenInterface'))),
+        );
+    }
+
+    public function provideNotSupportedRequests()
+    {
+        return array(
+            array('foo'),
+            array(array('foo')),
+            array(new \stdClass()),
+            array($this->getMockForAbstractClass('Payum\Core\Request\Generic', array(array()))),
+            array(new $this->requestClass(new \stdClass(), 'array')),
+            array(new $this->requestClass(new Payout(), 'foobar')),
+            array(new $this->requestClass($this->getMock(PayoutInterface::class), 'foobar')),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCorrectlyConvertOrderToDetailsAndSetItBack()
+    {
+        $order = new Payout();
+        $order->setCurrencyCode('USD');
+        $order->setTotalAmount(123);
+        $order->setDescription('the description');
+        $order->setRecipientId('theRecipientId');
+        $order->setRecipientEmail('theRecipientEmail');
+
+        $action = new ConvertPayoutAction();
+
+        $action->execute($convert = new Convert($order, 'array'));
+
+        $details = $convert->getResult();
+
+        $this->assertNotEmpty($details);
+
+        $this->assertArrayHasKey('amount', $details);
+        $this->assertEquals(123, $details['amount']);
+
+        $this->assertArrayHasKey('currency', $details);
+        $this->assertEquals('USD', $details['currency']);
+
+        $this->assertArrayHasKey('description', $details);
+        $this->assertEquals('the description', $details['description']);
+
+        $this->assertArrayHasKey('recipient_id', $details);
+        $this->assertEquals('theRecipientId', $details['recipient_id']);
+
+        $this->assertArrayHasKey('recipient_email', $details);
+        $this->assertEquals('theRecipientEmail', $details['recipient_email']);
+
+        $this->assertArrayHasKey(Constants::FIELD_PAYOUT, $details);
+        $this->assertEquals(true, $details[Constants::FIELD_PAYOUT]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldForcePayedoutFalseIfAlreadySet()
+    {
+        $order = new Payout();
+        $order->setDetails(array(
+            Constants::FIELD_PAYOUT => false,
+        ));
+
+        $action = new ConvertPayoutAction();
+
+        $action->execute($convert = new Convert($order, 'array'));
+
+        $details = $convert->getResult();
+
+        $this->assertNotEmpty($details);
+
+        $this->assertArrayHasKey(Constants::FIELD_PAYOUT, $details);
+        $this->assertEquals(false, $details[Constants::FIELD_PAYOUT]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotOverwriteAlreadySetExtraDetails()
+    {
+        $order = new Payout();
+        $order->setCurrencyCode('USD');
+        $order->setTotalAmount(123);
+        $order->setDescription('the description');
+        $order->setDetails(array(
+            'foo' => 'fooVal',
+        ));
+
+        $action = new ConvertPayoutAction();
+
+        $action->execute($convert = new Convert($order, 'array'));
+
+        $details = $convert->getResult();
+
+        $this->assertNotEmpty($details);
+
+        $this->assertArrayHasKey('foo', $details);
+        $this->assertEquals('fooVal', $details['foo']);
+    }
+}

--- a/src/Payum/Offline/Tests/Action/PayoutActionTest.php
+++ b/src/Payum/Offline/Tests/Action/PayoutActionTest.php
@@ -1,0 +1,138 @@
+<?php
+namespace Payum\Offline\Tests\Action;
+
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Request\Payout;
+use Payum\Offline\Action\PayoutAction;
+use Payum\Offline\Constants;
+
+class PayoutActionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldImplementActionInterface()
+    {
+        $rc = new \ReflectionClass('Payum\Offline\Action\PayoutAction');
+
+        $this->assertTrue($rc->implementsInterface('Payum\Core\Action\ActionInterface'));
+    }
+
+    /**
+     * @test
+     */
+    public function couldBeConstructedWithoutAnyArguments()
+    {
+        new PayoutAction();
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSupportPayoutWithArrayAccessAsModel()
+    {
+        $action = new PayoutAction();
+
+        $request = new Payout($this->getMock('ArrayAccess'));
+
+        $this->assertTrue($action->supports($request));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotSupportNotPayout()
+    {
+        $action = new PayoutAction();
+
+        $request = new \stdClass();
+
+        $this->assertFalse($action->supports($request));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotSupportPayoutAndNotArrayAccessAsModel()
+    {
+        $action = new PayoutAction();
+
+        $request = new Payout(new \stdClass());
+
+        $this->assertFalse($action->supports($request));
+    }
+
+    /**
+     * @test
+     *
+     * @expectedException \Payum\Core\Exception\RequestNotSupportedException
+     */
+    public function throwIfNotSupportedRequestGivenAsArgumentForExecute()
+    {
+        $action = new PayoutAction();
+
+        $action->execute(new \stdClass());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSetStatusPendingIfPayoutNotSet()
+    {
+        $action = new PayoutAction();
+
+        $details = new ArrayObject();
+
+        $request = new Payout($details);
+
+        //guard
+        $this->assertTrue($action->supports($request));
+
+        $action->execute($request);
+
+        $this->assertTrue(isset($details[Constants::FIELD_STATUS]));
+        $this->assertEquals(Constants::STATUS_PENDING, $details[Constants::FIELD_STATUS]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSetStatusPendingIfPayoutSetToFalse()
+    {
+        $action = new PayoutAction();
+
+        $details = new ArrayObject();
+        $details[Constants::FIELD_PAYOUT] = false;
+
+        $request = new Payout($details);
+
+        //guard
+        $this->assertTrue($action->supports($request));
+
+        $action->execute($request);
+
+        $this->assertTrue(isset($details[Constants::FIELD_STATUS]));
+        $this->assertEquals(Constants::STATUS_PENDING, $details[Constants::FIELD_STATUS]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSetStatusPayedoutIfPayoutSetToTrue()
+    {
+        $action = new PayoutAction();
+
+        $details = new ArrayObject();
+        $details[Constants::FIELD_PAYOUT] = true;
+
+        $request = new Payout($details);
+
+        //guard
+        $this->assertTrue($action->supports($request));
+
+        $action->execute($request);
+
+        $this->assertTrue(isset($details[Constants::FIELD_STATUS]));
+        $this->assertEquals(Constants::STATUS_PAYEDOUT, $details[Constants::FIELD_STATUS]);
+    }
+}

--- a/src/Payum/Offline/Tests/Action/RefundActionTest.php
+++ b/src/Payum/Offline/Tests/Action/RefundActionTest.php
@@ -1,0 +1,118 @@
+<?php
+namespace Payum\Offline\Tests\Action;
+
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Request\Refund;
+use Payum\Offline\Action\RefundAction;
+use Payum\Offline\Constants;
+
+class RefundActionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldImplementActionInterface()
+    {
+        $rc = new \ReflectionClass('Payum\Offline\Action\RefundAction');
+
+        $this->assertTrue($rc->implementsInterface('Payum\Core\Action\ActionInterface'));
+    }
+
+    /**
+     * @test
+     */
+    public function couldBeConstructedWithoutAnyArguments()
+    {
+        new RefundAction();
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSupportRefundWithArrayAccessAsModel()
+    {
+        $action = new RefundAction();
+
+        $request = new Refund($this->getMock('ArrayAccess'));
+
+        $this->assertTrue($action->supports($request));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotSupportNotRefund()
+    {
+        $action = new RefundAction();
+
+        $request = new \stdClass();
+
+        $this->assertFalse($action->supports($request));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotSupportRefundAndNotArrayAccessAsModel()
+    {
+        $action = new RefundAction();
+
+        $request = new Refund(new \stdClass());
+
+        $this->assertFalse($action->supports($request));
+    }
+
+    /**
+     * @test
+     *
+     * @expectedException \Payum\Core\Exception\RequestNotSupportedException
+     */
+    public function throwIfNotSupportedRequestGivenAsArgumentForExecute()
+    {
+        $action = new RefundAction();
+
+        $action->execute(new \stdClass());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSetStatusRefundedIfStatusSetToCaptured()
+    {
+        $action = new RefundAction();
+
+        $details = new ArrayObject();
+        $details[Constants::FIELD_STATUS] = Constants::STATUS_CAPTURED;
+
+        $request = new Refund($details);
+
+        //guard
+        $this->assertTrue($action->supports($request));
+
+        $action->execute($request);
+
+        $this->assertTrue(isset($details[Constants::FIELD_STATUS]));
+        $this->assertEquals(Constants::STATUS_REFUNDED, $details[Constants::FIELD_STATUS]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotSetStatusRefundedIfStatusNotSetToCaptured()
+    {
+        $action = new RefundAction();
+
+        $details = new ArrayObject();
+        $details[Constants::FIELD_STATUS] = Constants::STATUS_PENDING;
+
+        $request = new Refund($details);
+
+        //guard
+        $this->assertTrue($action->supports($request));
+
+        $action->execute($request);
+
+        $this->assertTrue(isset($details[Constants::FIELD_STATUS]));
+        $this->assertEquals(Constants::STATUS_PENDING, $details[Constants::FIELD_STATUS]);
+    }
+}

--- a/src/Payum/Offline/Tests/Action/StatusActionTest.php
+++ b/src/Payum/Offline/Tests/Action/StatusActionTest.php
@@ -137,7 +137,41 @@ class StatusActionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($request->isCaptured());
     }
-    
+
+    /**
+     * @test
+     */
+    public function shouldMarkPayedoutIfStatusSetToPayedout()
+    {
+        $request = new GetBinaryStatus(array(
+            Constants::FIELD_STATUS => Constants::STATUS_PAYEDOUT,
+        ));
+        $request->markUnknown();
+
+        $action = new StatusAction();
+
+        $action->execute($request);
+
+        $this->assertTrue($request->isPayedout());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldMarkRefundedIfStatusSetToRefunded()
+    {
+        $request = new GetBinaryStatus(array(
+            Constants::FIELD_STATUS => Constants::STATUS_REFUNDED,
+        ));
+        $request->markUnknown();
+
+        $action = new StatusAction();
+
+        $action->execute($request);
+
+        $this->assertTrue($request->isRefunded());
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
Created as copy of other actions.
Related to #688.

I have no idea what is [FIELD_PAID](https://github.com/Payum/Payum/blob/master/src/Payum/Offline/Action/CaptureAction.php#L22) for. There is no way to change it's value. But I added it into Payout as  FIELD_PAYOUT anyway.

There is [STATUS_CANCELED](https://github.com/Payum/Payum/blob/master/src/Payum/Offline/Action/StatusAction.php#L46) but there is no way to change status to canceled. Should I add CancelAction too?