### PR TITLE
Add support for Subject authorization

### DIFF
--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Api.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Api.php
@@ -302,6 +302,7 @@ class Api
         'username' => null,
         'password' => null,
         'signature' => null,
+        'subject' => null,
         'return_url' => null,
         'cancel_url' => null,
         'sandbox' => null,
@@ -634,6 +635,10 @@ class Api
         $fields['PWD'] = $this->options['password'];
         $fields['USER'] = $this->options['username'];
         $fields['SIGNATURE'] = $this->options['signature'];
+
+        if ($this->options['subject']) {
+            $fields['SUBJECT'] = $this->options['subject'];
+        }
     }
 
     /**


### PR DESCRIPTION
If you're calling the API on behalf of a third-party merchant, you must specify the email address on file with PayPal of the third-party merchant or the merchant's account ID (sometimes called Payer ID).

`SUBJECT=Authorizing-Merchant-Email Or Authorizing-Merchant-Account-ID`

https://developer.paypal.com/docs/classic/api/NVPAPIOverview/