### PR TITLE
Extend throwable on exception interface

### DIFF
--- a/src/Payum/Core/Exception/ExceptionInterface.php
+++ b/src/Payum/Core/Exception/ExceptionInterface.php
@@ -1,6 +1,6 @@
 <?php
 namespace Payum\Core\Exception;
 
-interface ExceptionInterface
+interface ExceptionInterface extends \Throwable
 {
 }


### PR DESCRIPTION
The `Throwable` interface was introduced in php 7.0.
This does meant hat the exception interface can only be implemented by classes that extend either `Exception` or `Error`