### PR TITLE
doc(symfony): improve documentation for Gateway configuration in backend

### DIFF
--- a/docs/symfony/configure-payment-in-backend.md
+++ b/docs/symfony/configure-payment-in-backend.md
@@ -12,9 +12,9 @@ Payum is an MIT-licensed open source project with its ongoing development made p
 In [get it started](get-it-started.md) we showed you how to configure gateways in the Symfony config.yml file. 
 Though it covers most of the cases sometimes you may want to configure gateways in the backend. 
 For example you will be able to change a gateway credentials, add or delete a gateway.
-As a backend we use [Sonata Admin](http://sonata-project.org/bundles/admin/2-3/doc/index.html) bundle. 
-Follow its doc to configure it properly 
-   
+
+PayumBundle comes with [Sonata Admin](http://sonata-project.org/bundles/admin/2-3/doc/index.html) bundle support out of the box, but you can totally do it manually.
+
 ## Configure
 
 First we have to create an entity where we store information about a gateway. 
@@ -46,7 +46,9 @@ class GatewayConfig extends BaseGatewayConfig
 }
 ```
 
-next, you have to add mapping of the basic entity you've just extended, and configure payum's extension:
+### With Sonata Admin
+
+Next, you have to add mapping of the basic entity you've just extended, and configure payum's extension:
 
 ```yml
 #app/config/config.yml
@@ -58,10 +60,102 @@ payum:
             Acme\PaymentBundle\Entity\GatewayConfig: { doctrine: orm }
 ```
 
-## Backend
+#### Backend
 
 Once you have configured everything doctrine, payum and sonata admin go to `/admin/dashboard`. 
 There you have to see a `Gateways` section. Try to add a gateway there.
+
+### The manual way
+
+```yml
+#app/config/config.yml
+
+payum:
+    dynamic_gateways:
+        config_storage: 
+            Acme\PaymentBundle\Entity\GatewayConfig: { doctrine: orm }
+```
+
+#### Backend
+
+The following code is a basic example for configuring a [Paypal Express Checkout](https://github.com/Payum/Payum/blob/master/docs/paypal/express-checkout/get-it-started.md) gateway.
+
+We first need to create a FormType with three fields:
+  1. `factoryName`, the name of a factory, in our case it will always be `paypal_express_checkout`
+  2. `gatewayName`, the name you want to give to your gateway
+  3. `config`, the gateway configuration
+
+```php
+<?php
+// src/Acme/PaymentBundle/Form/Type/GatewayConfigType.php
+
+namespace Acme\PaymentBundle\Form\Type;
+
+use Acme\PaymentBundle\Entity\GatewayConfig;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class PaypalGatewayConfigType extends AbstractType
+{   
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {        
+        $builder
+            ->add('factoryName', TextType::class, [
+                'disabled' => true,
+                'data' => 'paypal_express_checkout',
+            ])
+            ->add('gatewayName', TextType::class)
+            ->add('config', ConfigPaypalGatewayConfigType::class, [
+                'label' => false,
+                'auto_initialize' => false,
+            ])
+        ;
+    }
+    
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => GatewayConfig::class,
+        ]);
+    }
+}
+```
+
+Then, we should implement a new FormType that will configure your PayPal gateway's config.
+
+By reading [the doc](https://github.com/Payum/Payum/blob/master/docs/paypal/express-checkout/get-it-started.md), we should create four fields:
+  1. `sandbox`
+  2. `username`
+  3. `password`
+  4. `signature`
+  
+
+```php
+<?php
+// src/Acme/PaymentBundle/Form/Type/PaypalGatewayConfigType.php
+
+namespace Acme\PaymentBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+final class ConfigPaypalGatewayConfigType extends AbstractType
+{   
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    { 
+        $builder
+            ->add('sandbox', CheckboxType::class)
+            ->add('username', TextType::class)
+            ->add('password', TextType::class)
+            ->add('signature', TextType::class)
+        ;
+    }
+}
+```
+
+For a more advanced example, you can check how Sylius implemented [Paypal and Stripe gateways form types](https://github.com/Sylius/Sylius/tree/master/src/Sylius/Bundle/PayumBundle/Form/Type).
 
 ## Use gateway
 
@@ -77,7 +171,8 @@ class PaymentController extends Controller
 {
     public function prepareAction() 
     {
-        $gatewayName = 'paypal';
+        // If you have linked a gateway config to your user, you can simply use:
+        $gatewayName = $this->getUser()->getGatewayConfig()->getGatewayName();
         
         $storage = $this->get('payum')->getStorage('Acme\PaymentBundle\Entity\Payment');
         


### PR DESCRIPTION
This PR actually improve documentation for Gateway configuration in backend with Symfony.

I had to setup gateways configuration in background with Symfony, but I thought it was only compatible with Sonata (with `sonata_admin: true`). 
I didn't know that we can use `config_storage` alone. :sweat_smile:

Because of that, I did some really dirty weird things to implement gateways dynamic 
configuration from database (a `kernel.controller` listener that register gateways by updating `gateways` private property from registry, with & tons of reflection :nauseated_face: )

Also, I added an example of how we can implement FormType for configuring gateways configs.

Thanks