### PR TITLE
 [Stripe][FIX] LogicException when card is declined

### DIFF
--- a/src/Payum/Stripe/Extension/CreateCustomerExtension.php
+++ b/src/Payum/Stripe/Extension/CreateCustomerExtension.php
@@ -80,14 +80,11 @@ class CreateCustomerExtension implements ExtensionInterface
 
         $gateway->execute(new CreateCustomer($customer));
 
-        $local['customer'] = $customer->toUnsafeArray();
-        $model['local'] = $local->toUnsafeArray();
-        unset($model['card']);
-
         if ($customer['id']) {
+            $local['customer'] = $customer->toUnsafeArray();
+            $model['local'] = $local->toUnsafeArray();
             $model['customer'] = $customer['id'];
-        } else {
-            $model['status'] = Constants::STATUS_FAILED;
+            unset($model['card']);
         }
     }
 }

--- a/src/Payum/Stripe/Tests/Extension/CreateCustomerExtensionTest.php
+++ b/src/Payum/Stripe/Tests/Extension/CreateCustomerExtensionTest.php
@@ -393,7 +393,7 @@ class CreateCustomerExtensionTest extends \PHPUnit\Framework\TestCase
         ], (array) $request->getModel());
     }
 
-    public function testShouldSetStatusFailedIfCreateCustomerRequestFailedOnPostObtainToken()
+    public function testShouldDoNothingIfCreateCustomerRequestFailedOnPostObtainToken()
     {
         $model = new \ArrayObject([
             'card' => 'theCardToken',
@@ -426,13 +426,9 @@ class CreateCustomerExtensionTest extends \PHPUnit\Framework\TestCase
         $extension->onPostExecute($context);
 
         $this->assertEquals([
-            'status' => Constants::STATUS_FAILED,
+            'card' => ['theCardToken'],
             'local' => [
                 'save_card' => true,
-                'customer' => [
-                    'id' => null,
-                    'card' => 'theCardToken',
-                ]
             ],
         ], (array) $request->getModel());
     }

--- a/src/Payum/Stripe/Tests/Extension/CreateCustomerExtensionTest.php
+++ b/src/Payum/Stripe/Tests/Extension/CreateCustomerExtensionTest.php
@@ -117,7 +117,7 @@ class CreateCustomerExtensionTest extends \PHPUnit\Framework\TestCase
         ], (array) $request->getModel());
     }
 
-    public function testShouldSetStatusFailedIfCreateCustomerRequestFailedOnPreCapture()
+    public function testShouldDoNothingIfCreateCustomerRequestFailedOnPreCapture()
     {
         $model = new \ArrayObject([
             'card' => 'theCardToken',
@@ -150,13 +150,9 @@ class CreateCustomerExtensionTest extends \PHPUnit\Framework\TestCase
         $extension->onPreExecute($context);
 
         $this->assertEquals([
-            'status' => Constants::STATUS_FAILED,
+            'card' => 'theCardToken',
             'local' => [
                 'save_card' => true,
-                'customer' => [
-                    'id' => null,
-                    'card' => 'theCardToken',
-                ]
             ],
         ], (array) $request->getModel());
     }
@@ -426,9 +422,12 @@ class CreateCustomerExtensionTest extends \PHPUnit\Framework\TestCase
         $extension->onPostExecute($context);
 
         $this->assertEquals([
-            'card' => ['theCardToken'],
             'local' => [
                 'save_card' => true,
+                'customer' => [
+                    'id' => null,
+                    'card' => 'theCardToken',
+                ]
             ],
         ], (array) $request->getModel());
     }

--- a/src/Payum/Stripe/Tests/Extension/CreateCustomerExtensionTest.php
+++ b/src/Payum/Stripe/Tests/Extension/CreateCustomerExtensionTest.php
@@ -422,12 +422,9 @@ class CreateCustomerExtensionTest extends \PHPUnit\Framework\TestCase
         $extension->onPostExecute($context);
 
         $this->assertEquals([
+            'card' => 'theCardToken',
             'local' => [
                 'save_card' => true,
-                'customer' => [
-                    'id' => null,
-                    'card' => 'theCardToken',
-                ]
             ],
         ], (array) $request->getModel());
     }


### PR DESCRIPTION
With Stripe, if "save_card" is requested but card is declined, CreateCustomer fails and both $model['card'] && $model['customer'] are unset. 
Fix => keep card unchanged if CreateCustomer fails and move forward