### PR TITLE
Set PP_CONFIG_PATH as default config_path and make config_path optional

### DIFF
--- a/src/Payum/Paypal/Rest/PaypalRestGatewayFactory.php
+++ b/src/Payum/Paypal/Rest/PaypalRestGatewayFactory.php
@@ -31,21 +31,30 @@ class PaypalRestGatewayFactory extends GatewayFactory
         ]);
 
         if (false == $config['payum.api']) {
+            $defaultConfigPath = '';
+
+            if (defined('PP_CONFIG_PATH')) {
+                $defaultConfigPath = PP_CONFIG_PATH;
+            }
+
             $config['payum.default_options'] = [
                 'client_id' => '',
                 'client_secret' => '',
-                'config_path' => '',
+                'config_path' => $defaultConfigPath,
             ];
+
             $config->defaults($config['payum.default_options']);
 
-            $config['payum.required_options'] = ['client_id', 'client_secret', 'config_path'];
+            $config['payum.required_options'] = ['client_id', 'client_secret'];
             $config['payum.api'] = function (ArrayObject $config) {
                 $config->validateNotEmpty($config['payum.required_options']);
 
-                if (false == defined('PP_CONFIG_PATH')) {
-                    define('PP_CONFIG_PATH', $config['config_path']);
-                } elseif (PP_CONFIG_PATH !== $config['config_path']) {
-                    throw new InvalidArgumentException(sprintf('Given "config_path" is invalid. Should be equal to the defined "PP_CONFIG_PATH": %s.', PP_CONFIG_PATH));
+                if ($config['config_path']) {
+                    if (false == defined('PP_CONFIG_PATH')) {
+                        define('PP_CONFIG_PATH', $config['config_path']);
+                    } elseif (PP_CONFIG_PATH !== $config['config_path']) {
+                        throw new InvalidArgumentException(sprintf('Given "config_path" is invalid. Should be equal to the defined "PP_CONFIG_PATH": %s.', PP_CONFIG_PATH));
+                    }
                 }
 
                 $credential = new OAuthTokenCredential($config['client_id'], $config['client_secret']);


### PR DESCRIPTION
To make integration easier the default should be read from the PP_CONFIG_PATH so e.g. in a symfony/sylius application you could define this in your over `env` or a `config/bootstrap.php` file and get the client_id and client_secret over the DynamicRegistry from a database.

Also I don't think that the config_path is really a requirement for Paypal Api when looking at there wiki.