### PR TITLE
Fix travis ci test by upgrading doctrine/orm and allow deprecations

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,7 +28,7 @@
 
         <ini name="soap.wsdl_cache_enabled" value="0" />
 
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="regex=/Twig_/"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors"/>
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,6 +27,8 @@
         <var name="__PAYUM_PAYPAL_PRO_CHECKOUT_NVP_API_VENDOR" value="palexanderpayflowtest"/>
 
         <ini name="soap.wsdl_cache_enabled" value="0" />
+
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="regex=/Twig_/"/>
     </php>
 
     <testsuites>
@@ -108,4 +110,8 @@
             </exclude>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
 </phpunit>


### PR DESCRIPTION
doctrine/orm 2.6 is needed for php 7.3 tests and currently there are some vendor deprecations which will fail the CI which are now ignored as it looks like the library is not very active maintained so I would ignore them at current state.