### PR TITLE
Added helpful comments to get-it-started.md

### DIFF
--- a/docs/paypal/rest/get-it-started.md
+++ b/docs/paypal/rest/get-it-started.md
@@ -36,9 +36,9 @@ $payum = (new PayumBuilder())
     ->addDefaultStorages()
     ->addGateway('gatewayName', [
         'factory' => 'paypal_rest',
-        'client_id' => 'REPLACE IT',
-        'client_secret' => 'REPLACE IT',
-        'config_path' => 'REPLACE IT',
+        'client_id' => 'REPLACE IT', // Your PayPal REST API cliend ID.
+        'client_secret' => 'REPLACE IT', // Your PayPal REST API client secret.
+        'config_path' => 'REPLACE IT', // Point to the directory where your skd_config.ini is located.
     ])
 
     ->getPayum()


### PR DESCRIPTION
I've seen multiple examples where developers point to the skd_config.ini full path instead of its directory (me included). This should fix that misconception.