### PR TITLE
Suppress warning on PHP ^7.2

### DIFF
--- a/src/Payum/Sofort/Api.php
+++ b/src/Payum/Sofort/Api.php
@@ -126,7 +126,7 @@ class Api
             $varName = $method;
             $varName = strtolower(preg_replace('/([^A-Z])([A-Z])/', '$1_$2', substr($varName, 3)));
 
-            if (count($params) == 2) {
+            if (is_array($params) && count($params) == 2) {
                 $fields[$varName] = $transactionData->$method($params[0], $params[1]);
             } elseif ($params !== '') {
                 $fields[$varName] = $transactionData->$method($params);


### PR DESCRIPTION
Since PHP 7.2 ```count()``` yields a warning on invalid countable types [warning on invalid countable types](https://www.php.net/manual/en/function.count.php#refsect1-function.count-changelog). Added an ```is_array``` check before calling count on $params.