### PR TITLE
Add support for PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
     - php: 7.2
     - php: 7.3
     - php: 7.4
+    - php: 8.0
     - php: 7.2
       env:
         - COMPOSER_FLAGS="--prefer-lowest --prefer-stable"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
     - php: 7.3
     - php: 7.4
     - php: 8.0
+      before_install:
+        - composer req --dev league/uri-components:2.x-dev omnipay/common:3.0.x-dev
     - php: 7.2
       env:
         - COMPOSER_FLAGS="--prefer-lowest --prefer-stable"

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "payum/iso4217": "~1.0",
         "php-http/message": "^1.0",
         "php-http/client-implementation": "^1.0",
@@ -52,7 +52,7 @@
         "ext-pdo_sqlite": "*",
         "payum/omnipay-v3-bridge": "^1.0",
         "omnipay/dummy": "^3.0",
-        "omnipay/common": "^3.0",
+        "omnipay/common": "3.0.x-dev",
         "doctrine/orm": "^2.5",
         "doctrine/persistence": "^1.3.3|^2.0",
         "phpunit/phpunit": "^7.5 || ^8.5",

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "ext-pdo_sqlite": "*",
         "payum/omnipay-v3-bridge": "^1.0",
         "omnipay/dummy": "^3.0",
-        "omnipay/common": "3.0.x-dev",
+        "omnipay/common": "^3.0",
         "doctrine/orm": "^2.5",
         "doctrine/persistence": "^1.3.3|^2.0",
         "phpunit/phpunit": "^7.5 || ^8.5",


### PR DESCRIPTION
Allow PHP 8 in composer, and run unit tests Travis against PHP 8.

~Edit: Seems there are some failures related to league/uri, will have a look at them and get the tests to pass~

Tests pass with no code changes necessary