### PR TITLE
Upgrade league/uri to version 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ cache:
 
 matrix:
   include:
-    - php: 7.1
-      env:
-        - COMPOSER_FLAGS="--prefer-lowest --prefer-stable"
     - php: 7.2
     - php: 7.3
     - php: 7.4

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "payum/iso4217": "~1.0",
         "php-http/message": "^1.0",
         "php-http/client-implementation": "^1.0",
-        "league/uri": "^5.1",
+        "league/uri": "^6.4",
+        "league/uri-components": "^2.2",
         "twig/twig": "^1.34|^2.4|^3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "payum/iso4217": "~1.0",
         "php-http/message": "^1.0",
         "php-http/client-implementation": "^1.0",

--- a/src/Payum/Core/Security/AbstractTokenFactory.php
+++ b/src/Payum/Core/Security/AbstractTokenFactory.php
@@ -3,7 +3,7 @@ namespace Payum\Core\Security;
 
 use League\Uri\Http as HttpUri;
 use League\Uri\Components\Query;
-use League\Uri\QueryParser;
+use League\Uri\QueryString;
 use Payum\Core\Registry\StorageRegistryInterface;
 use Payum\Core\Security\Util\Random;
 use Payum\Core\Storage\IdentityInterface;
@@ -81,12 +81,11 @@ abstract class AbstractTokenFactory implements TokenFactoryInterface
      */
     protected function addQueryToUri(HttpUri $uri, array $query)
     {
-        $query = array_replace((new QueryParser())->parse($uri->getQuery()), $query);
-        $query = array_filter($query, function ($value) {
-            return null !== $value;
-        });
+        $uriQuery = Query::createFromUri($uri)->withoutEmptyPairs();
 
-        return $uri->withQuery((string) Query::createFromPairs($query));
+        $query = array_replace($uriQuery->params(), $query);
+
+        return $uri->withQuery((string) Query::createFromParams($query));
     }
 
     /**

--- a/src/Payum/Core/Security/Util/RequestTokenVerifier.php
+++ b/src/Payum/Core/Security/Util/RequestTokenVerifier.php
@@ -2,8 +2,8 @@
 
 namespace Payum\Core\Security\Util;
 
+use League\Uri\Components\Path;
 use League\Uri\Http;
-use League\Uri\Modifiers\Normalize;
 
 class RequestTokenVerifier
 {
@@ -16,11 +16,10 @@ class RequestTokenVerifier
     {
         $uri = Http::createFromString($requestUri);
         $altUri = Http::createFromString($tokenUri);
-        $modifier = new Normalize();
 
-        $newUri = $modifier->process($uri);
-        $newAltUri = $modifier->process($altUri);
+        $uriPath = Path::createFromUri($uri);
+        $altUriPath = Path::createFromUri($altUri);
 
-        return $newUri->getPath() === $newAltUri->getPath();
+        return rawurldecode((string) $uriPath) === rawurldecode((string) $altUriPath);
     }
 }

--- a/src/Payum/Core/composer.json
+++ b/src/Payum/Core/composer.json
@@ -31,7 +31,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.2",
         "payum/iso4217": "^1.0",
         "php-http/message": "^1.0",
         "php-http/client-implementation": "^1.0",

--- a/src/Payum/Core/composer.json
+++ b/src/Payum/Core/composer.json
@@ -35,7 +35,8 @@
         "payum/iso4217": "^1.0",
         "php-http/message": "^1.0",
         "php-http/client-implementation": "^1.0",
-        "league/uri": "^5.1",
+        "league/uri": "^6.4",
+        "league/uri-components": "^2.2",
         "twig/twig": "^1.34|^2.4|^3.0"
     },
     "require-dev": {

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Action/PurchaseAction.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Action/PurchaseAction.php
@@ -2,7 +2,7 @@
 namespace Payum\Paypal\ExpressCheckout\Nvp\Action;
 
 use League\Uri\Http as HttpUri;
-use League\Uri\Modifiers\MergeQuery;
+use League\Uri\UriModifier;
 use Payum\Core\Action\ActionInterface;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\GatewayAwareInterface;
@@ -67,8 +67,7 @@ abstract class PurchaseAction implements ActionInterface, GatewayAwareInterface,
 
             if ($details['CANCELURL']) {
                 $cancelUri = HttpUri::createFromString($details['CANCELURL']);
-                $modifier = new MergeQuery('cancelled=1');
-                $cancelUri = $modifier->process($cancelUri);
+                $cancelUri = UriModifier::mergeQuery($cancelUri, 'cancelled=1');
 
                 $details['CANCELURL'] = (string) $cancelUri;
             }

--- a/src/Payum/Paypal/ProHosted/Nvp/Action/CaptureAction.php
+++ b/src/Payum/Paypal/ProHosted/Nvp/Action/CaptureAction.php
@@ -2,7 +2,7 @@
 namespace Payum\Paypal\ProHosted\Nvp\Action;
 
 use League\Uri\Http as HttpUri;
-use League\Uri\Modifiers\MergeQuery;
+use League\Uri\UriModifier;
 use Payum\Core\Action\ActionInterface;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Exception\RequestNotSupportedException;
@@ -53,8 +53,7 @@ class CaptureAction implements ActionInterface, GatewayAwareInterface
         } else {
             if ($model['cancel_return']) {
                 $cancelUri = HttpUri::createFromString($model['cancel_return']);
-                $modifier  = new MergeQuery('cancelled=1');
-                $cancelUri = $modifier->process($cancelUri);
+                $cancelUri  = UriModifier::mergeQuery($cancelUri, 'cancelled=1');
 
                 $model['cancel_return'] = (string) $cancelUri;
             }


### PR DESCRIPTION
Upgrading league/uri to version 6 fixes some deprecations and is a step closer to PHP 8 compatibility (required for tests in #873 to pass).

This requires dropping support for PHP 7.1, which is EOL for a year now and isn't supported by league/uri 6.