### PR TITLE
Upgrade Doctrine mongodb-odm to 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,12 @@ matrix:
     - php: 7.2
       env:
         - COMPOSER_FLAGS="--prefer-lowest --prefer-stable"
+    - php: 7.2
+      before_install:
+        - pecl install mongodb
+        - composer require doctrine/mongodb-odm
+      services:
+        - mongodb
 
 before_install:
     - composer global require --no-progress --no-scripts --no-plugins symfony/flex

--- a/docs/php7.md
+++ b/docs/php7.md
@@ -11,7 +11,6 @@ Payum is an MIT-licensed open source project with its ongoing development made p
 
 Payum works on PHP7 though some features are not working yet:
 
-* Doctrine MongoODM storage is not supported because it rely on legacy php extension mongo. The extension is planned to be released for PHP7.
 * Authorize.NET AIM official library does not support PHP7 yet.
 * KlarnaInvoice uses XMLRPC library. It does not compatible with PHP7 yet.
 

--- a/docs/storages.md
+++ b/docs/storages.md
@@ -166,7 +166,7 @@ $tokenStorage = new DoctrineStorage(
 ### Doctrine MongoODM.
 
 ```
-php composer.phar install "doctrine/mongodb": "1.0.*@dev" "doctrine/mongodb-odm": "1.0.*@dev"
+php composer.phar install "doctrine/mongodb-odm": "^2.0"
 ```
 
 ```php
@@ -218,7 +218,6 @@ use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Configuration;
-use Doctrine\MongoDB\Connection;
 use Payum\Core\Bridge\Doctrine\Storage\DoctrineStorage;
 
 Type::addType('object', 'Payum\Core\Bridge\Doctrine\Types\ObjectType');
@@ -254,17 +253,9 @@ $config->setMetadataDriverImpl($driver);
 $config->setMetadataCacheImpl(new ArrayCache());
 $config->setDefaultDB('payum_tests');
 
-$connection = new Connection(null, array(), $config);
-
-$orderStorage = new DoctrineStorage(
-    DocumentManager::create($connection, $config),
-    'Acme\Document\Payment'
-);
-
-$tokenStorage = new DoctrineStorage(
-    DocumentManager::create($connection, $config),
-    'Acme\Document\SecurityToken'
-);
+$documentManager = DocumentManager::create(null, $config);
+$orderStorage = new DoctrineStorage($documentManager, 'Acme\Document\Payment');
+$tokenStorage = new DoctrineStorage($documentManager, 'Acme\Document\SecurityToken');
 ```        
 
 ## Filesystem.

--- a/docs/storages.md
+++ b/docs/storages.md
@@ -166,7 +166,7 @@ $tokenStorage = new DoctrineStorage(
 ### Doctrine MongoODM.
 
 ```
-php composer.phar install "doctrine/mongodb-odm": "^2.0"
+php composer.phar require "doctrine/mongodb-odm:^2.1"
 ```
 
 ```php
@@ -211,8 +211,8 @@ next, you have to create an entity manager and Payum's storage:
 <?php
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Cache\ArrayCache;
-use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
-use Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
+use Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
@@ -236,7 +236,6 @@ $driver->addDriver(
 );
 
 // your models
-AnnotationDriver::registerAnnotationClasses();
 $driver->addDriver(
     new AnnotationDriver(new AnnotationReader(), array(
         'path/to/Acme/Document',
@@ -254,6 +253,7 @@ $config->setMetadataCacheImpl(new ArrayCache());
 $config->setDefaultDB('payum_tests');
 
 $documentManager = DocumentManager::create(null, $config);
+
 $orderStorage = new DoctrineStorage($documentManager, 'Acme\Document\Payment');
 $tokenStorage = new DoctrineStorage($documentManager, 'Acme\Document\SecurityToken');
 ```        

--- a/src/Payum/Core/Bridge/Doctrine/Resources/mapping/Token.mongodb.xml
+++ b/src/Payum/Core/Bridge/Doctrine/Resources/mapping/Token.mongodb.xml
@@ -2,7 +2,7 @@
 <doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
     <mapped-superclass name="Payum\Core\Model\Token">
 
-      <field name="hash" type="string" id="true" strategy="NONE" />
+      <id field-name="hash" type="string" strategy="NONE"/>
 
       <field name="details" type="object" />
 

--- a/src/Payum/Core/Bridge/Doctrine/Types/ObjectType.php
+++ b/src/Payum/Core/Bridge/Doctrine/Types/ObjectType.php
@@ -41,12 +41,12 @@ class ObjectType extends Type
         return $val;
     }
 
-    public function closureToMongo()
+    public function closureToMongo(): string
     {
         return '$return = serialize($value);';
     }
 
-    public function closureToPHP()
+    public function closureToPHP(): string
     {
         return '$return = unserialize($value);';
     }

--- a/src/Payum/Core/composer.json
+++ b/src/Payum/Core/composer.json
@@ -71,7 +71,7 @@
         "payum/payex": "self.version If you want to use payex payment gateway",
         "payum/omnipay-v3-bridge": "^1 If you want to use omnipay's gateways",
         "doctrine/orm": "~2.3 If you want to store models to database using doctrin2 ORM",
-        "doctrine/mongodb-odm": "~1.1 If you want to store models to mongo doctrin2 ODM",
+        "doctrine/mongodb-odm": "~1.3|~2.0 If you want to store models to mongo doctrin2 ODM",
         "zendframework/zend-db": "~2.0 If you want to store models to Zend Db ORM",
         "propel/propel1": "~1.7 If you want to store models to Propel1 ORM",
         "propel/propel": "If you want to store models to Propel2 ORM",

--- a/src/Payum/Core/composer.json
+++ b/src/Payum/Core/composer.json
@@ -71,7 +71,7 @@
         "payum/payex": "self.version If you want to use payex payment gateway",
         "payum/omnipay-v3-bridge": "^1 If you want to use omnipay's gateways",
         "doctrine/orm": "~2.3 If you want to store models to database using doctrin2 ORM",
-        "doctrine/mongodb-odm": "~1.3|~2.0 If you want to store models to mongo doctrin2 ODM",
+        "doctrine/mongodb-odm": "~2.0 If you want to store models to mongo doctrin2 ODM",
         "zendframework/zend-db": "~2.0 If you want to store models to Zend Db ORM",
         "propel/propel1": "~1.7 If you want to store models to Propel1 ORM",
         "propel/propel": "If you want to store models to Propel2 ORM",


### PR DESCRIPTION
This replaces #853 (and includes the original commit).
Additional changes in this PR is to run the unit tests on Travis with Mongodb.