### PR TITLE
Don't execute global functions when used as gateway config

### DIFF
--- a/src/Payum/Core/CoreGatewayFactory.php
+++ b/src/Payum/Core/CoreGatewayFactory.php
@@ -202,7 +202,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface
         }
 
         foreach ($config as $name => $value) {
-            if (is_callable($value)) {
+            if (is_callable($value) && !(is_string($value) && function_exists('\\'.$value))) {
                 $config[$name] = call_user_func($value, $config);
             }
         }

--- a/src/Payum/Core/Tests/CoreGatewayFactoryTest.php
+++ b/src/Payum/Core/Tests/CoreGatewayFactoryTest.php
@@ -397,4 +397,19 @@ class CoreGatewayFactoryTest extends TestCase
         $this->assertSame($secondExtension, $extensions[0]);
         $this->assertSame($firstExtension, $extensions[1]);
     }
+
+    /**
+     * @test
+     */
+    public function shouldNotAllowGlobalFunctionsAsGatewayConfig()
+    {
+        $factory = new CoreGatewayFactory();
+
+        $factory->create(array(
+            'hash' => 'sha1',
+            'verify' => function ($config) {
+                $this->assertSame('sha1', $config['hash']);
+            },
+        ));
+    }
 }


### PR DESCRIPTION
When you use a function name as config, currently the function is executed and results in an error since the parameters don't match. This PR prevents such scenarios by skipping the execution of such functions when building the gateway config.

Fixes #692 