### PR TITLE
Deprecate usage of payum/iso4217 and use alcohol/iso4217

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - php: 7.4
     - php: 8.0
       before_install:
-        - composer req --dev league/uri-components:2.x-dev omnipay/common:3.0.x-dev
+        - composer req --dev league/uri-components:2.x-dev omnipay/common:3.0.x-dev alcohol/iso4217:4.x-dev
     - php: 7.2
       env:
         - COMPOSER_FLAGS="--prefer-lowest --prefer-stable"

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
+        "alcohol/iso4217": "^3.1",
         "payum/iso4217": "~1.0",
         "php-http/message": "^1.0",
         "php-http/client-implementation": "^1.0",

--- a/src/Payum/Core/Action/GetCurrencyAction.php
+++ b/src/Payum/Core/Action/GetCurrencyAction.php
@@ -3,20 +3,29 @@ namespace Payum\Core\Action;
 
 use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\Request\GetCurrency;
+use Payum\Core\ISO4217\Currency;
 use Payum\ISO4217\ISO4217;
 
 class GetCurrencyAction implements ActionInterface
 {
     /**
      * @var ISO4217
+     * @deprecated The iso4217 property is deprecated and will be removed in v2
      */
     protected $iso4217;
+
+    private $usePayumIso4217 = false;
 
     /**
      * @param ISO4217 $iso4217
      */
     public function __construct(ISO4217 $iso4217 = null)
     {
+        if ($iso4217 instanceof ISO4217) {
+            @trigger_error(sprintf('Passing an instance of %s in %s is deprecated and won\'t be supported in version 2.', ISO4217::class, __METHOD__), E_USER_DEPRECATED);
+            $this->usePayumIso4217 = true;
+        }
+
         $this->iso4217 = $iso4217 ?: new ISO4217();
     }
 
@@ -29,10 +38,18 @@ class GetCurrencyAction implements ActionInterface
     {
         RequestNotSupportedException::assertSupports($this, $request);
 
-        $currency = is_numeric($request->code) ?
-            $this->iso4217->findByNumeric($request->code) :
-            $this->iso4217->findByAlpha3($request->code)
-        ;
+        if ($this->usePayumIso4217) {
+            $currency = is_numeric($request->code) ?
+                $this->iso4217->findByNumeric($request->code) :
+                $this->iso4217->findByAlpha3($request->code)
+            ;
+        } else {
+            $currency = is_numeric($request->code) ?
+                Currency::createFromIso4217Numeric($request->code) :
+                Currency::createFromIso4217Alpha3($request->code)
+            ;
+        }
+
 
         $request->alpha3 = $currency->getAlpha3();
         $request->country = $currency->getCountry();

--- a/src/Payum/Core/ISO4217/Currency.php
+++ b/src/Payum/Core/ISO4217/Currency.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\ISO4217;
+
+use Alcohol\ISO4217;
+
+final class Currency {
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $alpha3;
+
+    /**
+     * @var string
+     */
+    private $numeric;
+
+    /**
+     * @var int
+     */
+    private $exp;
+
+    /**
+     * @var string|string[]
+     */
+    private $country;
+
+    /**
+     * @param string $name
+     * @param string $alpha3
+     * @param string $numeric
+     * @param int $exp
+     * @param string|string[] $country
+     */
+    public function __construct(string $name, string $alpha3, string $numeric, int $exp, $country)
+    {
+        $this->name = $name;
+        $this->alpha3 = $alpha3;
+        $this->numeric = $numeric;
+        $this->exp = $exp;
+        $this->country = $country;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getAlpha3(): string
+    {
+        return $this->alpha3;
+    }
+
+    public function getNumeric(): string
+    {
+        return $this->numeric;
+    }
+
+    public function getExp(): int
+    {
+        return $this->exp;
+    }
+
+    /**
+     * @return string|\string[]
+     */
+    public function getCountry()
+    {
+        return $this->country;
+    }
+
+    public static function createFromIso4217Numeric(string $numeric): self
+    {
+        $currency = (new ISO4217())->getByNumeric($numeric);
+
+        return new self(
+            $currency['name'],
+            $currency['alpha3'],
+            $currency['numeric'],
+            $currency['exp'],
+            $currency['country']
+        );
+    }
+
+    public static function createFromIso4217Alpha3(string $alpha3): self
+    {
+        $currency = (new ISO4217())->getByAlpha3($alpha3);
+
+        return new self(
+            $currency['name'],
+            $currency['alpha3'],
+            $currency['numeric'],
+            $currency['exp'],
+            $currency['country']
+        );
+    }
+}

--- a/src/Payum/Core/Tests/Action/GetCurrencyActionTest.php
+++ b/src/Payum/Core/Tests/Action/GetCurrencyActionTest.php
@@ -4,6 +4,8 @@ namespace Payum\Core\Tests\Action;
 use Payum\Core\Action\GetCurrencyAction;
 use Payum\Core\Request\GetCurrency;
 use Payum\Core\Tests\GenericActionTest;
+use Payum\ISO4217\Currency;
+use Payum\ISO4217\ISO4217;
 
 class GetCurrencyActionTest extends GenericActionTest
 {
@@ -59,5 +61,55 @@ class GetCurrencyActionTest extends GenericActionTest
         $action = new GetCurrencyAction();
 
         $action->execute($getCurrency = new GetCurrency('000'));
+    }
+
+    /**
+     * @legacy
+     */
+    public function testPassingPayumIso4217IsDeprecated()
+    {
+        set_error_handler(function ($errorCode, $errorString) {
+            $this->assertSame(E_USER_DEPRECATED, $errorCode);
+            $this->assertSame('Passing an instance of Payum\ISO4217\ISO4217 in Payum\Core\Action\GetCurrencyAction::__construct is deprecated and won\'t be supported in version 2.', $errorString);
+
+            restore_error_handler();
+        });
+
+        new GetCurrencyAction(new ISO4217());
+    }
+
+    /**
+     * @legacy
+     */
+    public function testItUsesPayumIso4217WhenItIsPassedThrough()
+    {
+        $mock = $this->createMock(ISO4217::class);
+        $mock->expects($this->once())
+            ->method('findByNumeric')
+            ->with(978)
+            ->willReturn(new Currency('Euro', 'EUR', 978, 2, []));
+
+        $action = new GetCurrencyAction($mock);
+        $action->execute($getCurrency = new GetCurrency($euro = 978));
+
+        $this->assertEquals('EUR', $getCurrency->alpha3);
+    }
+
+    public function testItDoesNotUsePayumIso4217ByDefault()
+    {
+        $mock = $this->createMock(ISO4217::class);
+
+        $action = new GetCurrencyAction();
+
+        $iso4217 = (new \ReflectionProperty($action, 'iso4217'));
+        $iso4217->setAccessible(true);
+        $iso4217->setValue($action, $mock);
+
+        $mock->expects($this->never())
+            ->method('findByNumeric');
+
+        $action->execute($getCurrency = new GetCurrency($euro = 978));
+
+        $this->assertEquals('EUR', $getCurrency->alpha3);
     }
 }

--- a/src/Payum/Core/Tests/ISO4217/CurrencyTest.php
+++ b/src/Payum/Core/Tests/ISO4217/CurrencyTest.php
@@ -1,0 +1,43 @@
+<?php
+namespace Payum\Core\Tests\ISO4217;
+
+use Payum\Core\ISO4217\Currency;
+use PHPUnit\Framework\TestCase;
+
+class CurrencyTest extends TestCase
+{
+    public function testShouldAllowGetInfoSetInConstructor()
+    {
+        $currency = new Currency('theName', 'theAlpha3', 'theNumeric', 2, 'theCountry');
+
+        $this->assertSame('theName', $currency->getName());
+        $this->assertSame('theAlpha3', $currency->getAlpha3());
+        $this->assertSame('theNumeric', $currency->getNumeric());
+        $this->assertSame(2, $currency->getExp());
+        $this->assertSame('theCountry', $currency->getCountry());
+    }
+
+    public function testItShouldCreateCurrencyByAlpha3Code()
+    {
+        $currency = Currency::createFromIso4217Alpha3('USD');
+
+        $this->assertInstanceOf(Currency::class, $currency);
+        $this->assertSame('US Dollar', $currency->getName());
+        $this->assertSame('USD', $currency->getAlpha3());
+        $this->assertSame('840', $currency->getNumeric());
+        $this->assertSame(2, $currency->getExp());
+        $this->assertSame(['AS', 'BQ', 'EC', 'FM', 'GU', 'MF', 'MH', 'MP', 'PR', 'PW', 'SV', 'TC', 'TL', 'UM', 'US', 'VG', 'VI', 'ZW',], $currency->getCountry());
+    }
+
+    public function testItShouldCreateCurrencyByNumeric()
+    {
+        $currency = Currency::createFromIso4217Numeric('840');
+
+        $this->assertInstanceOf(Currency::class, $currency);
+        $this->assertSame('US Dollar', $currency->getName());
+        $this->assertSame('USD', $currency->getAlpha3());
+        $this->assertSame('840', $currency->getNumeric());
+        $this->assertSame(2, $currency->getExp());
+        $this->assertSame(['AS', 'BQ', 'EC', 'FM', 'GU', 'MF', 'MH', 'MP', 'PR', 'PW', 'SV', 'TC', 'TL', 'UM', 'US', 'VG', 'VI', 'ZW',], $currency->getCountry());
+    }
+}

--- a/src/Payum/Core/composer.json
+++ b/src/Payum/Core/composer.json
@@ -32,6 +32,7 @@
     ],
     "require": {
         "php": "^7.2",
+        "alcohol/iso4217": "^3.1",
         "payum/iso4217": "^1.0",
         "php-http/message": "^1.0",
         "php-http/client-implementation": "^1.0",


### PR DESCRIPTION
This PR replaces the usage of the `payum/iso4217` fork with the original repo `alcohol/iso4217`, while still keeping the OOP functionality.

This means there is one less repo for the Payum team to maintain while getting an up to date version of ISO4217 currencies.

This also means the https://github.com/Payum/iso4217 repository can be deprecated