### PR TITLE
Add info for Symfony 4 & 5

### DIFF
--- a/docs/symfony/get-it-started.md
+++ b/docs/symfony/get-it-started.md
@@ -40,7 +40,7 @@ public function registerBundles()
 So now after you registered the bundle let's import routing.
 
 ```yaml
-# app/config/routing.yml
+# app/config/routing.yml (In Symfony 4 & 5 config/routes.yaml )
 
 payum_all:
     resource: "@PayumBundle/Resources/config/routing/all.xml"


### PR DESCRIPTION
Add info, that the path in Symfony 4 & 5 is config/routes.yaml and not routing.yml anymore