### PR TITLE
Add support for Doctrine DBAL 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "payum/omnipay-v3-bridge": "^1.0",
         "omnipay/dummy": "^3.0",
         "omnipay/common": "^3.0",
-        "doctrine/dbal": "^2",
+        "doctrine/dbal": "^2.7 || ^3.0",
         "doctrine/orm": "^2.5",
         "doctrine/persistence": "^1.3.3 || ^2.0",
         "phpunit/phpunit": "^7.5 || ^8.5",

--- a/src/Payum/Core/Bridge/Doctrine/Resources/mapping/ArrayObject.orm.xml
+++ b/src/Payum/Core/Bridge/Doctrine/Resources/mapping/ArrayObject.orm.xml
@@ -2,7 +2,7 @@
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <mapped-superclass name="Payum\Core\Model\ArrayObject">
 
-        <field name="details" column="details" type="json_array" />
+        <field name="details" column="details" type="json" />
 
     </mapped-superclass>
 </doctrine-mapping>

--- a/src/Payum/Core/Bridge/Doctrine/Resources/mapping/GatewayConfig.orm.xml
+++ b/src/Payum/Core/Bridge/Doctrine/Resources/mapping/GatewayConfig.orm.xml
@@ -6,7 +6,7 @@
 
         <field name="factoryName" column="factory_name" type="string" />
 
-        <field name="config" column="config" type="json_array" />
+        <field name="config" column="config" type="json" />
 
     </mapped-superclass>
 </doctrine-mapping>

--- a/src/Payum/Core/Bridge/Doctrine/Resources/mapping/Payment.orm.xml
+++ b/src/Payum/Core/Bridge/Doctrine/Resources/mapping/Payment.orm.xml
@@ -14,7 +14,7 @@
 
         <field name="currencyCode" column="currency_code" type="string" nullable="true" />
 
-        <field name="details" column="details" type="json_array" />
+        <field name="details" column="details" type="json" />
 
     </mapped-superclass>
 </doctrine-mapping>

--- a/src/Payum/Core/Bridge/Doctrine/Resources/mapping/Payout.orm.xml
+++ b/src/Payum/Core/Bridge/Doctrine/Resources/mapping/Payout.orm.xml
@@ -12,7 +12,7 @@
 
         <field name="currencyCode" type="string" nullable="true" />
 
-        <field name="details" type="json_array" />
+        <field name="details" type="json" />
 
     </mapped-superclass>
 </doctrine-mapping>

--- a/src/Payum/Core/Tests/Functional/Bridge/Doctrine/BaseMongoTest.php
+++ b/src/Payum/Core/Tests/Functional/Bridge/Doctrine/BaseMongoTest.php
@@ -7,6 +7,7 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\Types\Type;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 abstract class BaseMongoTest extends TestCase
 {
@@ -32,7 +33,13 @@ abstract class BaseMongoTest extends TestCase
         $config->setHydratorDir(\sys_get_temp_dir());
         $config->setHydratorNamespace('PayumTestsHydrators');
         $config->setMetadataDriverImpl($this->getMetadataDriverImpl());
-        $config->setMetadataCacheImpl(new ArrayCache());
+
+        if (method_exists($config, 'setMetadataCache')) {
+            $config->setMetadataCache(new ArrayAdapter());
+        } else {
+            $config->setMetadataCacheImpl(new ArrayCache());
+        }
+
         $config->setDefaultDB('payum_tests');
 
         $this->dm = DocumentManager::create(null, $config);


### PR DESCRIPTION
As pointed out by @Prometee in https://github.com/Payum/Payum/issues/922#issuecomment-984156298, switching `json_array` to `json` shouldn't be a BC break because we don't store `null` values in the DB.

Fixes #922