### PR TITLE
Support PHP 8.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
           - php: 7.3
           - php: 7.4
           - php: 8.0
+          - php: 8.1
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.6-dev"
+            "dev-master": "1.7-dev"
         }
     }
 }


### PR DESCRIPTION
So far, no errors has been picked up on PHP 8.1. So this PR only adds PHP 8.1 to GH actions, so that all tests runs against PHP 8.1.