### PR TITLE
feat: add return hint for setLogger() to void

### DIFF
--- a/src/Payum/Core/Bridge/Psr/Log/LogExecutedActionsExtension.php
+++ b/src/Payum/Core/Bridge/Psr/Log/LogExecutedActionsExtension.php
@@ -26,7 +26,7 @@ class LogExecutedActionsExtension implements ExtensionInterface, LoggerAwareInte
     /**
      * {@inheritDoc}
      */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }

--- a/src/Payum/Core/Bridge/Psr/Log/LoggerExtension.php
+++ b/src/Payum/Core/Bridge/Psr/Log/LoggerExtension.php
@@ -31,7 +31,7 @@ class LoggerExtension implements ExtensionInterface, LoggerAwareInterface
     /**
      * {@inheritDoc}
      */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }

--- a/src/Payum/Core/Tests/Bridge/Psr/Log/LoggerExtensionTest.php
+++ b/src/Payum/Core/Tests/Bridge/Psr/Log/LoggerExtensionTest.php
@@ -176,7 +176,7 @@ class LoggerAwareAction implements ActionInterface, LoggerAwareInterface
 {
     public $logger;
 
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }

--- a/src/Payum/Core/Tests/Mocks/Action/LoggerAwareAction.php
+++ b/src/Payum/Core/Tests/Mocks/Action/LoggerAwareAction.php
@@ -12,7 +12,7 @@ class LoggerAwareAction implements ActionInterface, LoggerAwareInterface
     /**
      * {@inheritDoc}
      */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }


### PR DESCRIPTION
Hi. This will fix this error i got with symfony 6 (and Upgrading psr/log (2.0.0 => 3.0.0))

`PHP Fatal error:  Declaration of Payum\Core\Bridge\Psr\Log\LoggerExtension::setLogger(Psr\Log\LoggerInterface $logger) must be compatible with Psr\Log\LoggerAwareInterface::setLogger(Psr\Log\LoggerInterface $logger): void in /vendor/payum/core/Payum/Core/Bridge/Psr/Log/LoggerExtension.php on line 34
`

There are probably more, but these are the first that i get.