### PR TITLE
Deprecate Propel storage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "php-http/client-implementation": "^1.0",
         "league/uri": "^6.4",
         "league/uri-components": "^2.2",
-        "twig/twig": "^1.34 || ^2.4 || ^3.0"
+        "twig/twig": "^1.34 || ^2.4 || ^3.0",
+        "symfony/deprecation-contracts": "^2.5"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/docs/frameworks-and-e-commerce-integration.md
+++ b/docs/frameworks-and-e-commerce-integration.md
@@ -20,8 +20,8 @@ Payum is an MIT-licensed open source project with its ongoing development made p
 ## Storages.
 
 * Doctrine ORM\MongoODM
-* Propel1
-* Propel2
+* Propel1 (Deprecated, will be removed in V2)
+* Propel2 (Deprecated, will be removed in V2)
 * Laminas Db Gateway
 * Elouqent
 * Filesystem

--- a/docs/storages.md
+++ b/docs/storages.md
@@ -271,7 +271,7 @@ $storage = new FilesystemStorage(
 );
 ```
 
-## Propel 2
+## Propel 2 (Deprecated, will be removed in V2)
 
 First, you have to generate the model base classes.
 

--- a/docs/symfony/storages.md
+++ b/docs/symfony/storages.md
@@ -158,7 +158,7 @@ payum:
 _**Note**: You should use commented path if you install payum/payum package._
 
 
-## Propel.
+## Propel (Deprecated, will be removed in V2)
 
 Firstly, you will need to build your schema schema. You can either use your own schema or you can copy the schema into your resources\config file from Payum\Core\Bridge\Propel\Resources\config\schema.xml
 Once this has been done you will need to implement the required classes

--- a/src/Payum/Core/Bridge/Propel/Model/Payment.php
+++ b/src/Payum/Core/Bridge/Propel/Model/Payment.php
@@ -4,7 +4,9 @@ namespace Payum\Core\Bridge\Propel\Model;
 
 use om\BasePayment;
 use Payum\Core\Model\PaymentInterface;
+use function trigger_error;
 
+@trigger_error('Propel storage is deprecated and will be removed in V2', \E_USER_DEPRECATED);
 class Payment extends BasePayment implements PaymentInterface
 {
 }

--- a/src/Payum/Core/Bridge/Propel/Model/Token.php
+++ b/src/Payum/Core/Bridge/Propel/Model/Token.php
@@ -5,7 +5,9 @@ namespace Payum\Core\Bridge\Propel\Model;
 use om\BaseToken;
 use Payum\Core\Security\TokenInterface;
 use Payum\Core\Security\Util\Random;
+use function trigger_error;
 
+@trigger_error('Propel storage is deprecated and will be removed in V2', \E_USER_DEPRECATED);
 class Token extends BaseToken implements TokenInterface
 {
     public function __construct()

--- a/src/Payum/Core/Bridge/Propel/Storage/Propel1Storage.php
+++ b/src/Payum/Core/Bridge/Propel/Storage/Propel1Storage.php
@@ -6,7 +6,9 @@ use \Criteria;
 use Payum\Core\Storage\AbstractStorage;
 use Payum\Core\Exception\LogicException;
 use Payum\Core\Model\Identity;
+use function trigger_error;
 
+@trigger_error('Propel storage is deprecated and will be removed in V2', \E_USER_DEPRECATED);
 class Propel1Storage extends AbstractStorage
 {
     /**

--- a/src/Payum/Core/Bridge/Propel2/Model/Payment.php
+++ b/src/Payum/Core/Bridge/Propel2/Model/Payment.php
@@ -2,7 +2,9 @@
 namespace Payum\Core\Bridge\Propel2\Model;
 
 use Payum\Core\Bridge\Propel2\Model\Base\Payment as BasePayment;
+use function trigger_error;
 
+@trigger_error('Propel storage is deprecated and will be removed in V2', \E_USER_DEPRECATED);
 class Payment extends BasePayment
 {
 }

--- a/src/Payum/Core/Bridge/Propel2/Model/PaymentQuery.php
+++ b/src/Payum/Core/Bridge/Propel2/Model/PaymentQuery.php
@@ -2,7 +2,9 @@
 namespace Payum\Core\Bridge\Propel2\Model;
 
 use Payum\Core\Bridge\Propel2\Model\Base\PaymentQuery as BasePaymentQuery;
+use function trigger_error;
 
+@trigger_error('Propel storage is deprecated and will be removed in V2', \E_USER_DEPRECATED);
 class PaymentQuery extends BasePaymentQuery
 {
 }

--- a/src/Payum/Core/Bridge/Propel2/Model/Token.php
+++ b/src/Payum/Core/Bridge/Propel2/Model/Token.php
@@ -2,7 +2,9 @@
 namespace Payum\Core\Bridge\Propel2\Model;
 
 use Payum\Core\Bridge\Propel2\Model\Base\Token as BaseToken;
+use function trigger_error;
 
+@trigger_error('Propel storage is deprecated and will be removed in V2', \E_USER_DEPRECATED);
 class Token extends BaseToken
 {
 }

--- a/src/Payum/Core/Bridge/Propel2/Model/TokenQuery.php
+++ b/src/Payum/Core/Bridge/Propel2/Model/TokenQuery.php
@@ -2,7 +2,9 @@
 namespace Payum\Core\Bridge\Propel2\Model;
 
 use Payum\Core\Bridge\Propel2\Model\Base\TokenQuery as BaseTokenQuery;
+use function trigger_error;
 
+@trigger_error('Propel storage is deprecated and will be removed in V2', \E_USER_DEPRECATED);
 class TokenQuery extends BaseTokenQuery
 {
 }

--- a/src/Payum/Core/Bridge/Propel2/Storage/Propel2Storage.php
+++ b/src/Payum/Core/Bridge/Propel2/Storage/Propel2Storage.php
@@ -3,7 +3,10 @@ namespace Payum\Core\Bridge\Propel2\Storage;
 
 use Payum\Core\Model\Identity;
 use Payum\Core\Storage\AbstractStorage;
+use function trigger_error;
+use function vsprintf;
 
+@trigger_error('Propel storage is deprecated and will be removed in V2', \E_USER_DEPRECATED);
 class Propel2Storage extends AbstractStorage
 {
     /**


### PR DESCRIPTION
Propel hasn't been updated for a long time, so I think we should drop support for it in V2.
See #938