### PR TITLE
PHP 8.2: Creation of dynamic property is deprecated

### DIFF
--- a/src/Payum/Core/Request/GetHttpRequest.php
+++ b/src/Payum/Core/Request/GetHttpRequest.php
@@ -39,6 +39,11 @@ class GetHttpRequest
      */
     public $content;
 
+    /**
+     * @var array
+     */
+    public $headers;
+
     public function __construct()
     {
         $this->query = [];
@@ -48,5 +53,6 @@ class GetHttpRequest
         $this->clientIp = '';
         $this->userAgent = '';
         $this->content = '';
+        $this->headers = [];
     }
 }


### PR DESCRIPTION
Fixes 8.2 warning: "Creation of dynamic property Payum\Core\Request\GetHttpRequest::$headers is deprecated"