### PR TITLE
Remove deprecation notices

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,8 +46,7 @@
         "league/uri": "^6.4",
         "league/uri-components": "^2.2",
         "twig/twig": "^2.4 || ^3.0",
-        "symfony/deprecation-contracts": "^2.5",
-        "doctrine/mongodb-odm": "^2.5"
+        "symfony/deprecation-contracts": "^2.5"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "league/uri": "^6.4",
         "league/uri-components": "^2.2",
         "twig/twig": "^2.4 || ^3.0",
-        "symfony/deprecation-contracts": "^2.5"
+        "symfony/deprecation-contracts": "^2.5",
+        "doctrine/mongodb-odm": "^2.5"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -211,116 +211,6 @@ parameters:
 			path: src/Payum/Core/Bridge/PlainPhp/Security/TokenFactory.php
 
 		-
-			message: "#^Class Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject extends generic class ArrayObject but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
-			count: 2
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:__construct\\(\\) has parameter \\$flags with no type specified\\.$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:__construct\\(\\) has parameter \\$input with no type specified\\.$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:__construct\\(\\) has parameter \\$iterator_class with no type specified\\.$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:defaults\\(\\) has parameter \\$input with no value type specified in iterable type Traversable\\.$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:defaults\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:defaults\\(\\) has parameter \\$input with no value type specified in iterable type array\\|Traversable\\.$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:getArray\\(\\) should return static\\(Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\) but returns Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\.$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:offsetSet\\(\\) with return type void returns void but should not return anything\\.$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:offsetUnset\\(\\) with return type void returns void but should not return anything\\.$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:replace\\(\\) has parameter \\$input with no value type specified in iterable type Traversable\\.$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:replace\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:replace\\(\\) has parameter \\$input with no value type specified in iterable type array\\|Traversable\\.$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:toUnsafeArray\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:toUnsafeArrayWithoutLocal\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:validateNotEmpty\\(\\) has parameter \\$required with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:validatedKeysSet\\(\\) has parameter \\$required with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Property Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:\\$input has no type specified\\.$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Result of method ArrayObject\\<\\(int\\|string\\),mixed\\>\\:\\:offsetSet\\(\\) \\(void\\) is used\\.$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Result of method ArrayObject\\<\\(int\\|string\\),mixed\\>\\:\\:offsetUnset\\(\\) \\(void\\) is used\\.$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 1
-			path: src/Payum/Core/Bridge/Spl/ArrayObject.php
-
-		-
 			message: "#^Elseif branch is unreachable because previous condition is always true\\.$#"
 			count: 1
 			path: src/Payum/Core/Bridge/Symfony/Action/GetHttpRequestAction.php
@@ -589,21 +479,6 @@ parameters:
 			message: "#^Method Payum\\\\Core\\\\ISO4217\\\\Currency\\:\\:getCountry\\(\\) has invalid return type string\\.$#"
 			count: 1
 			path: src/Payum/Core/ISO4217/Currency.php
-
-		-
-			message: "#^Class Payum\\\\Core\\\\Model\\\\ArrayObject implements generic interface ArrayAccess but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Payum/Core/Model/ArrayObject.php
-
-		-
-			message: "#^Class Payum\\\\Core\\\\Model\\\\ArrayObject implements generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Payum/Core/Model/ArrayObject.php
-
-		-
-			message: "#^Property Payum\\\\Core\\\\Model\\\\ArrayObject\\:\\:\\$details type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Payum/Core/Model/ArrayObject.php
 
 		-
 			message: "#^Method Payum\\\\Core\\\\Model\\\\BankAccountInterface\\:\\:setBankCode\\(\\) has no return type specified\\.$#"
@@ -1291,19 +1166,9 @@ parameters:
 			path: src/Payum/Core/Tests/AbstractGatewayFactoryTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$iterator of function iterator_to_array expects Traversable, ArrayAccess given\\.$#"
-			count: 1
-			path: src/Payum/Core/Tests/Action/AuthorizePaymentActionTest.php
-
-		-
 			message: "#^Property Payum\\\\Core\\\\Tests\\\\Action\\\\AuthorizePaymentActionTest\\:\\:\\$requestClass \\(Payum\\\\Core\\\\Request\\\\Generic\\) does not accept default value of type string\\.$#"
 			count: 1
 			path: src/Payum/Core/Tests/Action/AuthorizePaymentActionTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$iterator of function iterator_to_array expects Traversable, ArrayAccess given\\.$#"
-			count: 1
-			path: src/Payum/Core/Tests/Action/CapturePaymentActionTest.php
 
 		-
 			message: "#^Property Payum\\\\Core\\\\Tests\\\\Action\\\\CapturePaymentActionTest\\:\\:\\$requestClass \\(Payum\\\\Core\\\\Request\\\\Generic\\) does not accept default value of type string\\.$#"
@@ -1313,11 +1178,6 @@ parameters:
 		-
 			message: "#^Method Payum\\\\Core\\\\Tests\\\\Action\\\\ModelAggregateAwareRequest\\:\\:__construct\\(\\) has parameter \\$model with no type specified\\.$#"
 			count: 1
-			path: src/Payum/Core/Tests/Action/ExecuteSameRequestWithModelDetailsActionTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$iterator of function iterator_to_array expects Traversable, ArrayAccess given\\.$#"
-			count: 5
 			path: src/Payum/Core/Tests/Action/ExecuteSameRequestWithModelDetailsActionTest.php
 
 		-
@@ -1349,11 +1209,6 @@ parameters:
 			message: "#^Property Payum\\\\Core\\\\Tests\\\\Action\\\\GetTokenActionTest\\:\\:\\$requestClass \\(Payum\\\\Core\\\\Request\\\\Generic\\) does not accept default value of type string\\.$#"
 			count: 1
 			path: src/Payum/Core/Tests/Action/GetTokenActionTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$iterator of function iterator_to_array expects Traversable, ArrayAccess given\\.$#"
-			count: 1
-			path: src/Payum/Core/Tests/Action/PayoutPayoutActionTest.php
 
 		-
 			message: "#^Property Payum\\\\Core\\\\Tests\\\\Action\\\\PayoutPayoutActionTest\\:\\:\\$requestClass \\(Payum\\\\Core\\\\Request\\\\Generic\\) does not accept default value of type string\\.$#"
@@ -1432,21 +1287,6 @@ parameters:
 
 		-
 			message: "#^Class Payum\\\\Core\\\\Tests\\\\Bridge\\\\Spl\\\\CustomArrayObject implements generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Payum/Core/Tests/Bridge/Spl/ArrayObjectTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$input of method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:replace\\(\\) expects array\\|Traversable, string given\\.$#"
-			count: 1
-			path: src/Payum/Core/Tests/Bridge/Spl/ArrayObjectTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$required of method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:validateNotEmpty\\(\\) expects array, string given\\.$#"
-			count: 1
-			path: src/Payum/Core/Tests/Bridge/Spl/ArrayObjectTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$required of method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:validatedKeysSet\\(\\) expects array, string given\\.$#"
 			count: 1
 			path: src/Payum/Core/Tests/Bridge/Spl/ArrayObjectTest.php
 
@@ -2042,11 +1882,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$country of method KlarnaAddr\\:\\:setCountry\\(\\) expects int, string given\\.$#"
-			count: 1
-			path: src/Payum/Klarna/Invoice/Action/Api/GetAddressesAction.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function utf8_encode expects string, int given\\.$#"
 			count: 1
 			path: src/Payum/Klarna/Invoice/Action/Api/GetAddressesAction.php
 
@@ -2726,19 +2561,9 @@ parameters:
 			path: src/Payum/Paypal/ExpressCheckout/Nvp/Action/Api/DoCaptureAction.php
 
 		-
-			message: "#^Parameter \\#1 \\$required of method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:validateNotEmpty\\(\\) expects array, string given\\.$#"
-			count: 1
-			path: src/Payum/Paypal/ExpressCheckout/Nvp/Action/Api/GetRecurringPaymentsProfileDetailsAction.php
-
-		-
 			message: "#^Method Payum\\\\Paypal\\\\ExpressCheckout\\\\Nvp\\\\Action\\\\Api\\\\GetTransactionDetailsAction\\:\\:getPaymentRequestNFields\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Payum/Paypal/ExpressCheckout/Nvp/Action/Api/GetTransactionDetailsAction.php
-
-		-
-			message: "#^Parameter \\#1 \\$required of method Payum\\\\Core\\\\Bridge\\\\Spl\\\\ArrayObject\\:\\:validateNotEmpty\\(\\) expects array, string given\\.$#"
-			count: 1
-			path: src/Payum/Paypal/ExpressCheckout/Nvp/Action/PurchaseAction.php
 
 		-
 			message: "#^Right side of && is always true\\.$#"

--- a/rector.php
+++ b/rector.php
@@ -14,11 +14,16 @@ use Rector\Config\RectorConfig;
 use Rector\Core\ValueObject\PhpVersion;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Php80\Rector\FunctionLike\MixedTypeRector;
+use Rector\Php81\Rector\Array_\FirstClassCallableRector;
+use Rector\Php81\Rector\ClassConst\FinalizePublicClassConstantRector;
+use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
+use Rector\Php82\Rector\FuncCall\Utf8DecodeEncodeToMbConvertEncodingRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddSeeTestAnnotationRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
@@ -27,10 +32,10 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->importNames();
     $rectorConfig->importShortClasses();
-    $rectorConfig->phpVersion(PhpVersion::PHP_80);
+    $rectorConfig->phpVersion(PhpVersion::PHP_82);
 
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_80,
+        LevelSetList::UP_TO_PHP_82,
 
         // PHP
         SetList::PHP_72,
@@ -61,12 +66,17 @@ return static function (RectorConfig $rectorConfig): void {
         FlipTypeControlToUseExclusiveTypeRector::class,
         InlineConstructorDefaultToPropertyRector::class,
         AddVoidReturnTypeWhereNoReturnRector::class,
+        Utf8DecodeEncodeToMbConvertEncodingRector::class,
     ]);
 
     $rectorConfig->skip([
         AddSeeTestAnnotationRector::class,
         ClassPropertyAssignToConstructorPromotionRector::class,
         MixedTypeRector::class,
+        FinalizePublicClassConstantRector::class,
+        ReadOnlyPropertyRector::class,
+        FirstClassCallableRector::class,
+        ReturnNeverTypeRector::class,
 
         AddVoidReturnTypeWhereNoReturnRector::class => [
             __DIR__ . '/src/Payum/Core/GatewayFactory.php',

--- a/src/Payum/Be2Bill/Action/CaptureAction.php
+++ b/src/Payum/Be2Bill/Action/CaptureAction.php
@@ -38,7 +38,7 @@ class CaptureAction implements ActionInterface, ApiAwareInterface, GatewayAwareI
         $model = new ArrayObject($request->getModel());
 
         if (Api::EXECCODE_3DSECURE_IDENTIFICATION_REQUIRED === $model['EXECCODE']) {
-            throw new HttpResponse(base64_decode($model['3DSECUREHTML']), 302);
+            throw new HttpResponse(base64_decode((string) $model['3DSECUREHTML']), 302);
         }
 
         if (null !== $model['EXECCODE']) {

--- a/src/Payum/Be2Bill/Action/CaptureOffsiteAction.php
+++ b/src/Payum/Be2Bill/Action/CaptureOffsiteAction.php
@@ -47,7 +47,7 @@ class CaptureOffsiteAction implements ActionInterface, ApiAwareInterface, Gatewa
         if (isset($httpRequest->query['EXECCODE'])) {
             $model->replace($httpRequest->query);
         } else {
-            $extradata = $model['EXTRADATA'] ? json_decode($model['EXTRADATA'], true, 512, JSON_THROW_ON_ERROR) : [];
+            $extradata = $model['EXTRADATA'] ? json_decode((string) $model['EXTRADATA'], true, 512, JSON_THROW_ON_ERROR) : [];
 
             if (! isset($extradata['capture_token']) && $request->getToken()) {
                 $extradata['capture_token'] = $request->getToken()->getHash();

--- a/src/Payum/Be2Bill/Action/CaptureOffsiteNullAction.php
+++ b/src/Payum/Be2Bill/Action/CaptureOffsiteNullAction.php
@@ -33,7 +33,7 @@ class CaptureOffsiteNullAction implements ActionInterface, GatewayAwareInterface
         }
 
         $extraDataJson = $httpRequest->query['EXTRADATA'];
-        if (! $extraData = json_decode($extraDataJson, true, 512, JSON_THROW_ON_ERROR)) {
+        if (! $extraData = json_decode((string) $extraDataJson, true, 512, JSON_THROW_ON_ERROR)) {
             throw new HttpResponse('The capture is invalid. Code Be2Bell2', 400);
         }
 

--- a/src/Payum/Be2Bill/Action/NotifyNullAction.php
+++ b/src/Payum/Be2Bill/Action/NotifyNullAction.php
@@ -30,7 +30,7 @@ class NotifyNullAction implements ActionInterface, GatewayAwareInterface
         }
 
         $extraDataJson = $httpRequest->query['EXTRADATA'];
-        if (! $extraData = json_decode($extraDataJson, true, 512, JSON_THROW_ON_ERROR)) {
+        if (! $extraData = json_decode((string) $extraDataJson, true, 512, JSON_THROW_ON_ERROR)) {
             throw new HttpResponse('The notification is invalid. Code Be2Bell2', 400);
         }
 

--- a/src/Payum/Be2Bill/Api.php
+++ b/src/Payum/Be2Bill/Api.php
@@ -236,7 +236,7 @@ class Api
             $clearString .= $key . '=' . $value . $this->options['password'];
         }
 
-        return hash('sha256', $clearString);
+        return hash('sha256', (string) $clearString);
     }
 
     /**

--- a/src/Payum/Core/Bridge/Symfony/Form/Type/GatewayConfigType.php
+++ b/src/Payum/Core/Bridge/Symfony/Form/Type/GatewayConfigType.php
@@ -58,7 +58,7 @@ class GatewayConfigType extends AbstractType
         $propertyPath = is_array($data) ? '[config]' : 'config';
         $firstTime = ! PropertyAccess::createPropertyAccessor()->getValue($data, $propertyPath);
         foreach ($config['payum.default_options'] as $name => $value) {
-            $propertyPath = is_array($data) ? "[config][${name}]" : "config[${name}]";
+            $propertyPath = is_array($data) ? "[config][{$name}]" : "config[{$name}]";
             if ($firstTime) {
                 PropertyAccess::createPropertyAccessor()->setValue($data, $propertyPath, $value);
             }

--- a/src/Payum/Core/Model/ArrayObject.php
+++ b/src/Payum/Core/Model/ArrayObject.php
@@ -5,41 +5,42 @@ namespace Payum\Core\Model;
 use ArrayAccess;
 use ArrayIterator;
 use IteratorAggregate;
-use ReturnTypeWillChange;
+use Traversable;
 
+/**
+ * @template TKey of array-key
+ * @template TValue
+ * @implements ArrayAccess<TKey, TValue>
+ * @implements IteratorAggregate<TKey, TValue>
+ */
 class ArrayObject implements ArrayAccess, IteratorAggregate
 {
     /**
-     * @var array
+     * @var array<TKey, TValue>
      */
-    protected $details = [];
+    protected array $details = [];
 
-    #[ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return array_key_exists($offset, $this->details);
     }
 
-    #[ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->details[$offset];
     }
 
-    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value): void
     {
         $this->details[$offset] = $value;
     }
 
-    #[ReturnTypeWillChange]
     public function offsetUnset($offset): void
     {
         unset($this->details[$offset]);
     }
 
-    #[ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->details);
     }

--- a/src/Payum/Core/Reply/HttpPostRedirect.php
+++ b/src/Payum/Core/Reply/HttpPostRedirect.php
@@ -54,8 +54,8 @@ class HttpPostRedirect extends HttpResponse
         foreach ($fields as $name => $value) {
             $formInputs .= sprintf(
                 '<input type="hidden" name="%1$s" value="%2$s" />',
-                htmlspecialchars($name, ENT_QUOTES, 'UTF-8'),
-                htmlspecialchars($value, ENT_QUOTES, 'UTF-8')
+                htmlspecialchars((string) $name, ENT_QUOTES, 'UTF-8'),
+                htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8')
             ) . "\n";
         }
 
@@ -74,6 +74,6 @@ class HttpPostRedirect extends HttpResponse
 </html>
 HTML;
 
-        return sprintf($content, htmlspecialchars($url, ENT_QUOTES, 'UTF-8'), $formInputs);
+        return sprintf($content, htmlspecialchars((string) $url, ENT_QUOTES, 'UTF-8'), $formInputs);
     }
 }

--- a/src/Payum/Core/Reply/HttpRedirect.php
+++ b/src/Payum/Core/Reply/HttpRedirect.php
@@ -53,6 +53,6 @@ class HttpRedirect extends HttpResponse
     <body>
         Redirecting to %1$s.
     </body>
-</html>', htmlspecialchars($url, ENT_QUOTES, 'UTF-8'));
+</html>', htmlspecialchars((string) $url, ENT_QUOTES, 'UTF-8'));
     }
 }

--- a/src/Payum/Core/Security/Util/Mask.php
+++ b/src/Payum/Core/Security/Util/Mask.php
@@ -19,9 +19,9 @@ class Mask
         if (mb_strlen($value) <= ($showLast + 1) * 2 || ! $showLast) {
             $showRegExpPart = '';
         } else {
-            $showRegExpPart = "(?!(.){0,${showLast}}$)";
+            $showRegExpPart = "(?!(.){0,{$showLast}}$)";
         }
 
-        return preg_replace("/(?!^.?)[^-_\s]${showRegExpPart}/u", $maskSymbol, $value);
+        return preg_replace("/(?!^.?)[^-_\s]{$showRegExpPart}/u", $maskSymbol, $value);
     }
 }

--- a/src/Payum/Core/Security/Util/Random.php
+++ b/src/Payum/Core/Security/Util/Random.php
@@ -20,7 +20,7 @@ class Random
 {
     public static function generateToken()
     {
-        return rtrim(strtr(base64_encode(self::getRandomNumber()), '+/', '-_'), '=');
+        return rtrim(strtr(base64_encode((string) self::getRandomNumber()), '+/', '-_'), '=');
     }
 
     private static function getRandomNumber()

--- a/src/Payum/Core/Tests/Action/AuthorizePaymentActionTest.php
+++ b/src/Payum/Core/Tests/Action/AuthorizePaymentActionTest.php
@@ -15,7 +15,6 @@ use Payum\Core\Request\GetHumanStatus;
 use Payum\Core\Security\TokenInterface;
 use Payum\Core\Tests\GenericActionTest;
 use ReflectionClass;
-use function iterator_to_array;
 
 class AuthorizePaymentActionTest extends GenericActionTest
 {
@@ -171,7 +170,7 @@ class AuthorizePaymentActionTest extends GenericActionTest
                     $details = $request->getModel();
 
                     $testCase->assertInstanceOf(ArrayAccess::class, $details);
-                    $testCase->assertSame($expectedDetails, iterator_to_array($details));
+                    $testCase->assertSame($expectedDetails, (array) $details);
 
                     $details['bar'] = 'barVal';
                 })

--- a/src/Payum/Core/Tests/Action/CapturePaymentActionTest.php
+++ b/src/Payum/Core/Tests/Action/CapturePaymentActionTest.php
@@ -15,7 +15,6 @@ use Payum\Core\Request\GetHumanStatus;
 use Payum\Core\Security\TokenInterface;
 use Payum\Core\Tests\GenericActionTest;
 use ReflectionClass;
-use function iterator_to_array;
 
 class CapturePaymentActionTest extends GenericActionTest
 {
@@ -171,7 +170,7 @@ class CapturePaymentActionTest extends GenericActionTest
                     $details = $request->getModel();
 
                     $testCase->assertInstanceOf(ArrayAccess::class, $details);
-                    $testCase->assertSame($expectedDetails, iterator_to_array($details));
+                    $testCase->assertSame($expectedDetails, (array) $details);
 
                     $details['bar'] = 'barVal';
                 })

--- a/src/Payum/Core/Tests/Action/ExecuteSameRequestWithModelDetailsActionTest.php
+++ b/src/Payum/Core/Tests/Action/ExecuteSameRequestWithModelDetailsActionTest.php
@@ -20,7 +20,7 @@ class ExecuteSameRequestWithModelDetailsActionTest extends GenericActionTest
 {
     protected $actionClass = ExecuteSameRequestWithModelDetailsAction::class;
 
-    protected $requestClass = \Payum\Core\Tests\Action\ModelAggregateAwareRequest::class;
+    protected $requestClass = ModelAggregateAwareRequest::class;
 
     public function provideSupportedRequests(): Iterator
     {
@@ -87,7 +87,7 @@ class ExecuteSameRequestWithModelDetailsActionTest extends GenericActionTest
                 $details = $request->getModel();
 
                 $testCase->assertInstanceOf(ArrayAccess::class, $details);
-                $testCase->assertSame($expectedDetails, iterator_to_array($details));
+                $testCase->assertSame($expectedDetails, (array) $details);
 
                 $details['baz'] = 'bazVal';
             })
@@ -125,7 +125,7 @@ class ExecuteSameRequestWithModelDetailsActionTest extends GenericActionTest
                 $details = $request->getModel();
 
                 $testCase->assertInstanceOf(ArrayAccess::class, $details);
-                $testCase->assertSame($expectedDetails, iterator_to_array($details));
+                $testCase->assertSame($expectedDetails, (array) $details);
 
                 $details['baz'] = 'bazVal';
             })
@@ -144,7 +144,7 @@ class ExecuteSameRequestWithModelDetailsActionTest extends GenericActionTest
                 'bar' => 'barVal',
                 'baz' => 'bazVal',
             ],
-            iterator_to_array($details)
+            (array) $details
         );
     }
 
@@ -171,7 +171,7 @@ class ExecuteSameRequestWithModelDetailsActionTest extends GenericActionTest
                 $details = $request->getModel();
 
                 $testCase->assertInstanceOf(ArrayAccess::class, $details);
-                $testCase->assertSame($expectedDetails, iterator_to_array($details));
+                $testCase->assertSame($expectedDetails, (array) $details);
 
                 $details['baz'] = 'bazVal';
 
@@ -193,7 +193,7 @@ class ExecuteSameRequestWithModelDetailsActionTest extends GenericActionTest
                     'bar' => 'barVal',
                     'baz' => 'bazVal',
                 ],
-                iterator_to_array($details)
+                (array) $details
             );
 
             return;

--- a/src/Payum/Core/Tests/Action/PayoutPayoutActionTest.php
+++ b/src/Payum/Core/Tests/Action/PayoutPayoutActionTest.php
@@ -15,7 +15,6 @@ use Payum\Core\Request\Payout;
 use Payum\Core\Security\TokenInterface;
 use Payum\Core\Tests\GenericActionTest;
 use ReflectionClass;
-use function iterator_to_array;
 
 class PayoutPayoutActionTest extends GenericActionTest
 {
@@ -174,7 +173,7 @@ class PayoutPayoutActionTest extends GenericActionTest
                     $details = $request->getModel();
 
                     $testCase->assertInstanceOf(ArrayAccess::class, $details);
-                    $testCase->assertSame($expectedDetails, iterator_to_array($details));
+                    $testCase->assertSame($expectedDetails, (array) $details);
 
                     $details['bar'] = 'barVal';
                 })

--- a/src/Payum/Core/Tests/Bridge/Spl/ArrayObjectTest.php
+++ b/src/Payum/Core/Tests/Bridge/Spl/ArrayObjectTest.php
@@ -6,7 +6,6 @@ use ArrayAccess;
 use ArrayIterator;
 use IteratorAggregate;
 use Payum\Core\Bridge\Spl\ArrayObject;
-use Payum\Core\Exception\InvalidArgumentException;
 use Payum\Core\Exception\LogicException;
 use Payum\Core\Security\SensitiveValue;
 use PHPUnit\Framework\TestCase;
@@ -96,15 +95,6 @@ class ArrayObjectTest extends TestCase
         $array->replace($traversable);
 
         $this->assertSame($expectedArray, (array) $array);
-    }
-
-    public function testThrowIfInvalidArgumentGivenForReplace(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid input given. Should be an array or instance of \Traversable');
-        $array = new ArrayObject();
-
-        $array->replace('foo');
     }
 
     public function testShouldAllowCastToArrayFromCustomArrayObject(): void
@@ -361,13 +351,13 @@ class CustomArrayObject implements ArrayAccess, IteratorAggregate
     private $foo;
 
     #[ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return 'foo' === $offset;
     }
 
     #[ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->{$offset};
     }
@@ -385,7 +375,7 @@ class CustomArrayObject implements ArrayAccess, IteratorAggregate
     }
 
     #[ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator([
             'foo' => $this->foo,

--- a/src/Payum/Core/Tests/Bridge/Symfony/Validator/Constraints/CreditCardDateValidatorTest.php
+++ b/src/Payum/Core/Tests/Bridge/Symfony/Validator/Constraints/CreditCardDateValidatorTest.php
@@ -40,7 +40,7 @@ class CreditCardDateValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    protected function createValidator()
+    protected function createValidator(): CreditCardDateValidator
     {
         return new CreditCardDateValidator();
     }

--- a/src/Payum/Core/Tests/Mocks/Document/ArrayObject.php
+++ b/src/Payum/Core/Tests/Mocks/Document/ArrayObject.php
@@ -7,6 +7,7 @@ use Payum\Core\Model\ArrayObject as BaseArrayObject;
 
 /**
  * @Mongo\Document
+ * @extends BaseArrayObject<string, mixed>
  */
 class ArrayObject extends BaseArrayObject
 {

--- a/src/Payum/Core/Tests/Mocks/Entity/ArrayObject.php
+++ b/src/Payum/Core/Tests/Mocks/Entity/ArrayObject.php
@@ -7,6 +7,7 @@ use Payum\Core\Model\ArrayObject as BaseArrayObject;
 
 /**
  * @ORM\Entity
+ * @extends BaseArrayObject<string, mixed>
  */
 class ArrayObject extends BaseArrayObject
 {

--- a/src/Payum/Core/Tests/Mocks/Model/TestModel.php
+++ b/src/Payum/Core/Tests/Mocks/Model/TestModel.php
@@ -9,6 +9,8 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class TestModel
 {
+    public mixed $payum_id = null;
+
     protected $id;
 
     protected $price;

--- a/src/Payum/Klarna/Invoice/Action/Api/BaseApiAwareAction.php
+++ b/src/Payum/Klarna/Invoice/Action/Api/BaseApiAwareAction.php
@@ -83,6 +83,6 @@ abstract class BaseApiAwareAction implements ApiAwareInterface, ActionInterface
         $details['error_file'] = $e->getFile();
         $details['error_line'] = $e->getLine();
         $details['error_code'] = (int) $e->getCode();
-        $details['error_message'] = utf8_encode($e->getMessage());
+        $details['error_message'] = mb_convert_encoding((string) $e->getMessage(), 'UTF-8', 'ISO-8859-1');
     }
 }

--- a/src/Payum/Klarna/Invoice/Action/Api/GetAddressesAction.php
+++ b/src/Payum/Klarna/Invoice/Action/Api/GetAddressesAction.php
@@ -19,19 +19,19 @@ class GetAddressesAction extends BaseApiAwareAction
 
         foreach ($klarna->getAddresses($request->getPno()) as $address) {
             /** @var KlarnaAddr $address */
-            $address->setEmail(utf8_encode($address->getEmail()));
-            $address->setTelno(utf8_encode($address->getTelno()));
-            $address->setCellno(utf8_encode($address->getCellno()));
-            $address->setFirstName(utf8_encode($address->getFirstName()));
-            $address->setLastName(utf8_encode($address->getLastName()));
-            $address->setCompanyName(utf8_encode($address->getCompanyName()));
-            $address->setCareof(utf8_encode($address->getCareof()));
-            $address->setStreet(utf8_encode($address->getStreet()));
-            $address->setHouseNumber(utf8_encode($address->getHouseNumber()));
-            $address->setHouseExt(utf8_encode($address->getHouseExt()));
-            $address->setZipCode(utf8_encode($address->getZipCode()));
-            $address->setCity(utf8_encode($address->getCity()));
-            $address->setCountry(utf8_encode($address->getCountry()));
+            $address->setEmail(mb_convert_encoding((string) $address->getEmail(), 'UTF-8', 'ISO-8859-1'));
+            $address->setTelno(mb_convert_encoding((string) $address->getTelno(), 'UTF-8', 'ISO-8859-1'));
+            $address->setCellno(mb_convert_encoding((string) $address->getCellno(), 'UTF-8', 'ISO-8859-1'));
+            $address->setFirstName(mb_convert_encoding((string) $address->getFirstName(), 'UTF-8', 'ISO-8859-1'));
+            $address->setLastName(mb_convert_encoding((string) $address->getLastName(), 'UTF-8', 'ISO-8859-1'));
+            $address->setCompanyName(mb_convert_encoding((string) $address->getCompanyName(), 'UTF-8', 'ISO-8859-1'));
+            $address->setCareof(mb_convert_encoding((string) $address->getCareof(), 'UTF-8', 'ISO-8859-1'));
+            $address->setStreet(mb_convert_encoding((string) $address->getStreet(), 'UTF-8', 'ISO-8859-1'));
+            $address->setHouseNumber(mb_convert_encoding((string) $address->getHouseNumber(), 'UTF-8', 'ISO-8859-1'));
+            $address->setHouseExt(mb_convert_encoding((string) $address->getHouseExt(), 'UTF-8', 'ISO-8859-1'));
+            $address->setZipCode(mb_convert_encoding((string) $address->getZipCode(), 'UTF-8', 'ISO-8859-1'));
+            $address->setCity(mb_convert_encoding((string) $address->getCity(), 'UTF-8', 'ISO-8859-1'));
+            $address->setCountry(mb_convert_encoding((string) $address->getCountry(), 'UTF-8', 'ISO-8859-1'));
 
             $request->addAddress($address);
         }

--- a/src/Payum/Klarna/Invoice/Action/Api/PopulateKlarnaFromDetailsAction.php
+++ b/src/Payum/Klarna/Invoice/Action/Api/PopulateKlarnaFromDetailsAction.php
@@ -26,12 +26,12 @@ class PopulateKlarnaFromDetailsAction implements ActionInterface
                 $article = ArrayObject::ensureArrayObject($article);
 
                 $klarna->addArticle(
-                    utf8_decode($article['qty']),
-                    utf8_decode($article['artNo']),
-                    utf8_decode($article['title']),
-                    utf8_decode($article['price']),
-                    utf8_decode($article['vat']),
-                    utf8_decode($article['discount']),
+                    mb_convert_encoding((string) $article['qty'], 'ISO-8859-1'),
+                    mb_convert_encoding((string) $article['artNo'], 'ISO-8859-1'),
+                    mb_convert_encoding((string) $article['title'], 'ISO-8859-1'),
+                    mb_convert_encoding((string) $article['price'], 'ISO-8859-1'),
+                    mb_convert_encoding((string) $article['vat'], 'ISO-8859-1'),
+                    mb_convert_encoding((string) $article['discount'], 'ISO-8859-1'),
                     $article['flags'] ?: KlarnaFlags::NO_FLAG
                 );
             }
@@ -40,8 +40,8 @@ class PopulateKlarnaFromDetailsAction implements ActionInterface
         if ($details['partial_articles']) {
             foreach ($details['partial_articles'] as $article) {
                 $klarna->addArtNo(
-                    utf8_decode($article['qty']),
-                    utf8_decode($article['artNo'])
+                    mb_convert_encoding((string) $article['qty'], 'ISO-8859-1'),
+                    mb_convert_encoding((string) $article['artNo'], 'ISO-8859-1')
                 );
             }
         }
@@ -50,18 +50,18 @@ class PopulateKlarnaFromDetailsAction implements ActionInterface
             $address = ArrayObject::ensureArrayObject($details['shipping_address']);
 
             $klarna->setAddress(KlarnaFlags::IS_SHIPPING, new KlarnaAddr(
-                utf8_decode($address['email']),
-                utf8_decode($address['telno']),
-                utf8_decode($address['cellno']),
-                utf8_decode($address['fname']),
-                utf8_decode($address['lname']),
-                utf8_decode($address['careof']),
-                utf8_decode($address['street']),
-                utf8_decode($address['zip']),
-                utf8_decode($address['city']),
-                utf8_decode($address['country']),
-                utf8_decode($address['house_number']),
-                utf8_decode($address['house_extension'])
+                mb_convert_encoding((string) $address['email'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['telno'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['cellno'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['fname'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['lname'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['careof'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['street'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['zip'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['city'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['country'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['house_number'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['house_extension'], 'ISO-8859-1')
             ));
         }
 
@@ -69,18 +69,18 @@ class PopulateKlarnaFromDetailsAction implements ActionInterface
             $address = ArrayObject::ensureArrayObject($details['billing_address']);
 
             $klarna->setAddress(KlarnaFlags::IS_BILLING, new KlarnaAddr(
-                utf8_decode($address['email']),
-                utf8_decode($address['telno']),
-                utf8_decode($address['cellno']),
-                utf8_decode($address['fname']),
-                utf8_decode($address['lname']),
-                utf8_decode($address['careof']),
-                utf8_decode($address['street']),
-                utf8_decode($address['zip']),
-                utf8_decode($address['city']),
-                utf8_decode($address['country']),
-                utf8_decode($address['house_number']),
-                utf8_decode($address['house_extension'])
+                mb_convert_encoding((string) $address['email'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['telno'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['cellno'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['fname'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['lname'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['careof'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['street'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['zip'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['city'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['country'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['house_number'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $address['house_extension'], 'ISO-8859-1')
             ));
         }
 
@@ -88,13 +88,13 @@ class PopulateKlarnaFromDetailsAction implements ActionInterface
             $estoreInfo = ArrayObject::ensureArrayObject($details['estore_info']);
 
             $klarna->setEstoreInfo(
-                utf8_decode($estoreInfo['order_id1']),
-                utf8_decode($estoreInfo['order_id2']),
-                utf8_decode($estoreInfo['username'])
+                mb_convert_encoding((string) $estoreInfo['order_id1'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $estoreInfo['order_id2'], 'ISO-8859-1'),
+                mb_convert_encoding((string) $estoreInfo['username'], 'ISO-8859-1')
             );
         }
 
-        $klarna->setComment(utf8_decode($details['comment']));
+        $klarna->setComment(mb_convert_encoding((string) $details['comment'], 'ISO-8859-1'));
     }
 
     public function supports($request)

--- a/src/Payum/Klarna/Invoice/Tests/Action/Api/PopulateKlarnaFromDetailsActionTest.php
+++ b/src/Payum/Klarna/Invoice/Tests/Action/Api/PopulateKlarnaFromDetailsActionTest.php
@@ -113,8 +113,8 @@ class PopulateKlarnaFromDetailsActionTest extends TestCase
         $klarna->expects($this->atMost(2))
             ->method('setAddress')
             ->withConsecutive(
-                [KlarnaFlags::IS_SHIPPING, new KlarnaAddr('info@payum.com', '0700 00 00 00', '', 'Testperson-se', 'Approved', '', utf8_decode('Stårgatan 1'), '12345', 'Ankeborg', 209, '', '')],
-                [KlarnaFlags::IS_BILLING, new KlarnaAddr('info@payum.com', '0700 00 00 00', '', 'Testperson-se', 'Approved', '', utf8_decode('Stårgatan 1'), '12345', 'Ankeborg', 209, '', '')]
+                [KlarnaFlags::IS_SHIPPING, new KlarnaAddr('info@payum.com', '0700 00 00 00', '', 'Testperson-se', 'Approved', '', mb_convert_encoding('Stårgatan 1', 'ISO-8859-1'), '12345', 'Ankeborg', 209, '', '')],
+                [KlarnaFlags::IS_BILLING, new KlarnaAddr('info@payum.com', '0700 00 00 00', '', 'Testperson-se', 'Approved', '', mb_convert_encoding('Stårgatan 1', 'ISO-8859-1'), '12345', 'Ankeborg', 209, '', '')]
             );
 
         $klarna->expects($this->once())

--- a/src/Payum/Sofort/Action/StatusAction.php
+++ b/src/Payum/Sofort/Action/StatusAction.php
@@ -29,7 +29,7 @@ class StatusAction implements ActionInterface
             return;
         }
 
-        if (! isset($details['transaction_id']) || ! strlen($details['transaction_id'])) {
+        if (! isset($details['transaction_id']) || ! strlen((string) $details['transaction_id'])) {
             $request->markNew();
 
             return;

--- a/src/Payum/Sofort/SofortGatewayFactory.php
+++ b/src/Payum/Sofort/SofortGatewayFactory.php
@@ -57,7 +57,7 @@ class SofortGatewayFactory extends GatewayFactory
             $config['payum.api'] = function (ArrayObject $config) {
                 $config->validateNotEmpty($config['payum.required_options']);
 
-                if (! preg_match('/.*\:.*\:.*/', $config['config_key'])) {
+                if (! preg_match('/.*\:.*\:.*/', (string) $config['config_key'])) {
                     throw new \LogicException('The config_key is invalid. It must match the regexp "/.*\:.*\:.*/".');
                 }
 


### PR DESCRIPTION
### Before
  
  ```
Remaining self deprecation notices (97)

  40x: Function utf8_decode() is deprecated
    36x in PopulateKlarnaFromDetailsActionTest::testShouldPopulateKlarnaFromDetails from Payum\Klarna\Invoice\Tests\Action\Api
    3x in PopulateKlarnaFromDetailsActionTest::testShouldCorrectlyPutPartialArticles from Payum\Klarna\Invoice\Tests\Action\Api
    1x in PopulateKlarnaFromDetailsActionTest::testShouldNotFaileIfEmptyDetailsGiven from Payum\Klarna\Invoice\Tests\Action\Api

  36x: Function utf8_encode() is deprecated
    26x in GetAddressesActionTest::testShouldCallKlarnaGetAddresses from Payum\Klarna\Invoice\Tests\Action\Api
    1x in ActivateActionTest::testShouldCatchKlarnaExceptionAndSetErrorInfoToDetails from Payum\Klarna\Invoice\Tests\Action\Api
    1x in CancelReservationActionTest::testShouldCatchKlarnaExceptionAndSetErrorInfoToDetails from Payum\Klarna\Invoice\Tests\Action\Api
    1x in CheckOrderStatusActionTest::testShouldCatchKlarnaExceptionAndSetErrorInfoToDetails from Payum\Klarna\Invoice\Tests\Action\Api
    1x in CreditInvoiceActionTest::testShouldCatchKlarnaExceptionAndSetErrorInfoToDetails from Payum\Klarna\Invoice\Tests\Action\Api
    ...

  4x: Using ${var} in strings is deprecated, use {$var} instead
    2x in GatewayConfigTypeTest::testShouldBeSubClassOfAbstractType from Payum\Core\Tests\Bridge\Symfony\Form\Type
    2x in CreditCardTest::testShouldAllowGetPreviouslySetHolder from Payum\Core\Tests\Model

  2x: Creation of dynamic property Payum\Core\Tests\Mocks\Model\TestModel::$payum_id is deprecated
    1x in FilesystemStorageTest::testShouldStoreInfoBetweenUpdateAndFindWithDefaultId from Payum\Core\Tests\Storage
    1x in FilesystemStorageTest::testShouldAllowDeleteModel from Payum\Core\Tests\Storage

  2x: utf8_encode(): Passing null to parameter #1 ($string) of type string is deprecated
    2x in GetAddressesActionTest::testShouldCallKlarnaGetAddresses from Payum\Klarna\Invoice\Tests\Action\Api

  2x: utf8_decode(): Passing null to parameter #1 ($string) of type string is deprecated
    1x in PopulateKlarnaFromDetailsActionTest::testShouldNotFaileIfEmptyDetailsGiven from Payum\Klarna\Invoice\Tests\Action\Api
    1x in PopulateKlarnaFromDetailsActionTest::testShouldCorrectlyPutPartialArticles from Payum\Klarna\Invoice\Tests\Action\Api

  1x: Method "ArrayAccess::offsetExists()" might add "bool" as a native return type declaration in the future. Do the same in implementation "Payum\Core\Tests\Bridge\Spl\CustomArrayObject" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in AuthorizePaymentActionTest::testShouldImplementGatewayAwareInterface from Payum\Core\Tests\Action

  1x: Method "ArrayAccess::offsetGet()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Payum\Core\Tests\Bridge\Spl\CustomArrayObject" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in AuthorizePaymentActionTest::testShouldImplementGatewayAwareInterface from Payum\Core\Tests\Action

  1x: Method "IteratorAggregate::getIterator()" might add "\Traversable" as a native return type declaration in the future. Do the same in implementation "Payum\Core\Tests\Bridge\Spl\CustomArrayObject" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in AuthorizePaymentActionTest::testShouldImplementGatewayAwareInterface from Payum\Core\Tests\Action

  1x: Method "Symfony\Component\Validator\Test\ConstraintValidatorTestCase::createValidator()" might add "ConstraintValidatorInterface" as a native return type declaration in the future. Do the same in child class "Payum\Core\Tests\Bridge\Symfony\Validator\Constraints\CreditCardDateValidatorTest" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in AuthorizePaymentActionTest::testShouldImplementGatewayAwareInterface from Payum\Core\Tests\Action

  1x: Method "ArrayObject::offsetSet()" might add "void" as a native return type declaration in the future. Do the same in child class "Payum\Core\Bridge\Spl\ArrayObject" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in AuthorizePaymentActionTest::testShouldExecuteConvertRequestIfStatusNew from Payum\Core\Tests\Action

  1x: Method "ArrayObject::offsetUnset()" might add "void" as a native return type declaration in the future. Do the same in child class "Payum\Core\Bridge\Spl\ArrayObject" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in AuthorizePaymentActionTest::testShouldExecuteConvertRequestIfStatusNew from Payum\Core\Tests\Action

  1x: Method "ArrayObject::offsetGet()" might add "mixed" as a native return type declaration in the future. Do the same in child class "Payum\Core\Bridge\Spl\ArrayObject" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in AuthorizePaymentActionTest::testShouldExecuteConvertRequestIfStatusNew from Payum\Core\Tests\Action

  1x: Method "ArrayAccess::offsetExists()" might add "bool" as a native return type declaration in the future. Do the same in implementation "Payum\Core\Model\ArrayObject" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in ArrayObjectTest::setUp from Payum\Core\Tests\Functional\Bridge\Doctrine\Entity

  1x: Method "ArrayAccess::offsetGet()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Payum\Core\Model\ArrayObject" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in ArrayObjectTest::setUp from Payum\Core\Tests\Functional\Bridge\Doctrine\Entity

  1x: Method "IteratorAggregate::getIterator()" might add "\Traversable" as a native return type declaration in the future. Do the same in implementation "Payum\Core\Model\ArrayObject" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in ArrayObjectTest::setUp from Payum\Core\Tests\Functional\Bridge\Doctrine\Entity

  1x: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated
    1x in CaptureOffsiteActionTest::testShouldRedirectToBe2billSiteIfExecCodeNotPresentInQuery from Payum\Be2Bill\Tests\Action

Remaining indirect deprecation notices (7)

  1x: Class "Omnipay\Dummy\Gateway" should implement method "Omnipay\Common\GatewayInterface::acceptNotification(array $options = array()): \Omnipay\Common\Message\NotificationInterface": (Optional method) Receive and handle an instant payment notification (IPN).
    1x in PayumBuilderTest::testShouldRegisterOmnipayV3Factories from Payum\Core\Tests

  1x: Class "Omnipay\Dummy\Gateway" should implement method "Omnipay\Common\GatewayInterface::fetchTransaction(array $options = []): \Omnipay\Common\Message\RequestInterface": (Optional method) Fetches transaction information.
    1x in PayumBuilderTest::testShouldRegisterOmnipayV3Factories from Payum\Core\Tests

  1x: Creation of dynamic property net\authorize\util\Log::$sensitiveStringRegexes is deprecated
    1x in AuthorizeNetAimGatewayFactoryTest::testShouldAllowCreateGateway from Payum\AuthorizeNet\Aim\Tests

  1x: Return type of Klarna_Checkout_Order::offsetExists($key) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
    1x in CreateOrderActionTest::testShouldCreateOrderOnExecute from Payum\Klarna\Checkout\Tests\Action\Api

  1x: Return type of Klarna_Checkout_Order::offsetGet($key) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
    1x in CreateOrderActionTest::testShouldCreateOrderOnExecute from Payum\Klarna\Checkout\Tests\Action\Api

  1x: Return type of Klarna_Checkout_Order::offsetSet($key, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
    1x in CreateOrderActionTest::testShouldCreateOrderOnExecute from Payum\Klarna\Checkout\Tests\Action\Api

  1x: Return type of Klarna_Checkout_Order::offsetUnset($key) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
    1x in CreateOrderActionTest::testShouldCreateOrderOnExecute from Payum\Klarna\Checkout\Tests\Action\Api

Legacy deprecation notices (6)
  ```


### After
  
  ```
Remaining indirect deprecation notices (7)

  1x: Class "Omnipay\Dummy\Gateway" should implement method "Omnipay\Common\GatewayInterface::acceptNotification(array $options = array()): \Omnipay\Common\Message\NotificationInterface": (Optional method) Receive and handle an instant payment notification (IPN).
    1x in PayumBuilderTest::testShouldRegisterOmnipayV3Factories from Payum\Core\Tests

  1x: Class "Omnipay\Dummy\Gateway" should implement method "Omnipay\Common\GatewayInterface::fetchTransaction(array $options = []): \Omnipay\Common\Message\RequestInterface": (Optional method) Fetches transaction information.
    1x in PayumBuilderTest::testShouldRegisterOmnipayV3Factories from Payum\Core\Tests

  1x: Creation of dynamic property net\authorize\util\Log::$sensitiveStringRegexes is deprecated
    1x in AuthorizeNetAimGatewayFactoryTest::testShouldAllowCreateGateway from Payum\AuthorizeNet\Aim\Tests

  1x: Return type of Klarna_Checkout_Order::offsetExists($key) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
    1x in CreateOrderActionTest::testShouldCreateOrderOnExecute from Payum\Klarna\Checkout\Tests\Action\Api

  1x: Return type of Klarna_Checkout_Order::offsetGet($key) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
    1x in CreateOrderActionTest::testShouldCreateOrderOnExecute from Payum\Klarna\Checkout\Tests\Action\Api

  1x: Return type of Klarna_Checkout_Order::offsetSet($key, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
    1x in CreateOrderActionTest::testShouldCreateOrderOnExecute from Payum\Klarna\Checkout\Tests\Action\Api

  1x: Return type of Klarna_Checkout_Order::offsetUnset($key) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
    1x in CreateOrderActionTest::testShouldCreateOrderOnExecute from Payum\Klarna\Checkout\Tests\Action\Api

Legacy deprecation notices (6)
  ```
