### PR TITLE
Update KlarnaInvoice package to use solidworx/klarna-invoice

### DIFF
--- a/src/Payum/AuthorizeNet/Aim/Tests/Action/ConvertPaymentActionTest.php
+++ b/src/Payum/AuthorizeNet/Aim/Tests/Action/ConvertPaymentActionTest.php
@@ -67,7 +67,7 @@ class ConvertPaymentActionTest extends GenericActionTest
         $this->assertNotEmpty($result);
 
         $this->assertArrayHasKey('amount', $result);
-        $this->assertSame(1.23, $result['amount']);
+        $this->assertEqualsWithDelta(1.23, $result['amount'], PHP_FLOAT_EPSILON);
 
         $this->assertArrayHasKey('invoice_num', $result);
         $this->assertSame('theNumber', $result['invoice_num']);

--- a/src/Payum/Klarna/Invoice/composer.json
+++ b/src/Payum/Klarna/Invoice/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "payum/core": "^1.5",
-        "fp/klarna-invoice": "0.1.*"
+        "solidworx/klarna-invoice": "0.2.*"
     },
     "require-dev": {
         "payum/core": "^1.5",

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/ConvertPaymentActionTest.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Tests/Action/ConvertPaymentActionTest.php
@@ -70,7 +70,7 @@ class ConvertPaymentActionTest extends GenericActionTest
         $this->assertSame('theNumber', $details['INVNUM']);
 
         $this->assertArrayHasKey('PAYMENTREQUEST_0_AMT', $details);
-        $this->assertSame(1.23, $details['PAYMENTREQUEST_0_AMT']);
+        $this->assertEqualsWithDelta(1.23, $details['PAYMENTREQUEST_0_AMT'], PHP_FLOAT_EPSILON);
 
         $this->assertArrayHasKey('PAYMENTREQUEST_0_CURRENCYCODE', $details);
         $this->assertSame('USD', $details['PAYMENTREQUEST_0_CURRENCYCODE']);

--- a/src/Payum/Paypal/ProCheckout/Nvp/Tests/Action/ConvertPaymentActionTest.php
+++ b/src/Payum/Paypal/ProCheckout/Nvp/Tests/Action/ConvertPaymentActionTest.php
@@ -66,7 +66,7 @@ class ConvertPaymentActionTest extends GenericActionTest
         $this->assertNotEmpty($details);
 
         $this->assertArrayHasKey('AMT', $details);
-        $this->assertSame(1.23, $details['AMT']);
+        $this->assertEqualsWithDelta(1.23, $details['AMT'], PHP_FLOAT_EPSILON);
 
         $this->assertArrayHasKey('CURRENCY', $details);
         $this->assertSame('USD', $details['CURRENCY']);

--- a/src/Payum/Paypal/ProHosted/Nvp/Tests/Action/ConvertPaymentActionTest.php
+++ b/src/Payum/Paypal/ProHosted/Nvp/Tests/Action/ConvertPaymentActionTest.php
@@ -65,7 +65,7 @@ class ConvertPaymentActionTest extends GenericActionTest
         $this->assertSame('theNumber', $details['INVNUM']);
 
         $this->assertArrayHasKey('AMT', $details);
-        $this->assertSame(123.0, $details['AMT']);
+        $this->assertEqualsWithDelta(123.0, $details['AMT'], PHP_FLOAT_EPSILON);
 
         $this->assertArrayHasKey('CURRENCYCODE', $details);
         $this->assertSame('USD', $details['CURRENCYCODE']);

--- a/src/Payum/Paypal/Rest/Tests/PaypalRestGatewayFactoryTest.php
+++ b/src/Payum/Paypal/Rest/Tests/PaypalRestGatewayFactoryTest.php
@@ -116,7 +116,7 @@ class PaypalRestGatewayFactoryTest extends AbstractGatewayFactoryTest
         $this->expectException(\Payum\Core\Exception\InvalidArgumentException::class);
 
         if (method_exists($this, 'expectExceptionMessageRegExp')) {
-            $this->expectExceptionMessageRegExp('/Given \"config_path\" is invalid. \w+/');
+            $this->expectExceptionMessageMatches('/Given \"config_path\" is invalid. \w+/');
         } else {
             $this->expectExceptionMessageMatches('/Given \"config_path\" is invalid. \w+/');
         }


### PR DESCRIPTION
The `fp/klarna-invoice` package doesn't seem to be maintained anymore, and currently emits a lot of deprecation notices when using with PHP 8+

```
PHP Deprecated:  Return type of KlarnaConfig::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/fp/klarna-invoice/klarnaconfig.php on line 130

PHP Deprecated:  Return type of KlarnaConfig::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/fp/klarna-invoice/klarnaconfig.php on line 142

PHP Deprecated:  Return type of KlarnaConfig::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/fp/klarna-invoice/klarnaconfig.php on line 158

PHP Deprecated:  Return type of KlarnaConfig::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/fp/klarna-invoice/klarnaconfig.php on line 170
```

The `fp/klarna-invoice` package has been forked to [solidworx/klarna-invoice](https://github.com/SolidWorx/KlarnaInvoice) and the deprecations fixed. So let's use the forked package, where we can then continue making other improvements to the package.