### PR TITLE
Fix Manual for Using Recurring Payments in Stripe.

### DIFF
--- a/docs/stripe/subscription-billing.md
+++ b/docs/stripe/subscription-billing.md
@@ -13,9 +13,31 @@ use Payum\Stripe\Request\Api\CreatePlan;
 $plan = new \ArrayObject([
     "amount" => 2000,
     "interval" => "month",
-    "name" => "Amazing Gold Plan",
     "currency" => "usd",
-    "id" => "gold"
+    "id" => "gold",
+    "product" => [
+        "name" => "Amazing Gold Plan"
+    ]
+]);
+
+/** @var \Payum\Core\Payum $payum */
+$payum->getGateway('gatewayName')->execute(new CreatePlan($plan));
+```
+
+or with existing product, for example [Stripe API - Create a Plan](https://stripe.com/docs/api/plans/create)
+
+```php
+<?php
+// prepare.php
+
+use Payum\Stripe\Request\Api\CreatePlan;
+
+$plan = new \ArrayObject([
+    "amount" => 2000,
+    "interval" => "month",
+    "currency" => "usd",
+    "id" => "gold",
+    "product" => "prod_NjpI7DbZx6AlWQ" // Product ID
 ]);
 
 /** @var \Payum\Core\Payum $payum */


### PR DESCRIPTION
I fix manual because it is obsolete and don't work. 

NOTE: Also I Create new Payum/Stripe Actions that used the new [Prices API](https://stripe.com/docs/api/plans/create#prices) , that replaces the Plans API and has more options. I can create another Pull Request for these actions in [payum/stripe](https://github.com/Payum/Stripe) repository if you want.