### PR TITLE
feat: fix ci

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
         "omnipay/common": "^3.0",
         "doctrine/dbal": "^2.7 || ^3.0",
         "doctrine/orm": "^2.5",
+        "doctrine/annotations": "^1.14.3 || ^2.0.1",
         "doctrine/persistence": "^1.3.3 || ^2.0",
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
         "propel/propel1": "~1.7",

--- a/src/Payum/Paypal/Rest/Tests/PaypalRestGatewayFactoryTest.php
+++ b/src/Payum/Paypal/Rest/Tests/PaypalRestGatewayFactoryTest.php
@@ -116,7 +116,7 @@ class PaypalRestGatewayFactoryTest extends AbstractGatewayFactoryTest
         $this->expectException(\Payum\Core\Exception\InvalidArgumentException::class);
 
         if (method_exists($this, 'expectExceptionMessageRegExp')) {
-            $this->expectExceptionMessageMatches('/Given \"config_path\" is invalid. \w+/');
+            $this->expectExceptionMessageRegExp('/Given \"config_path\" is invalid. \w+/');
         } else {
             $this->expectExceptionMessageMatches('/Given \"config_path\" is invalid. \w+/');
         }


### PR DESCRIPTION
try to fix ci error on --prefer-lowest
One test is changed to fix this.

Additional the `"doctrine/annotations": "^1.14.3 || ^2.0.1", ` is now added.
I guess this dependency was made optional in some other dependency and was now missing.