### PR TITLE
Add default storages when not defined

### DIFF
--- a/docs/authorize-net/aim/get-it-started.md
+++ b/docs/authorize-net/aim/get-it-started.md
@@ -23,7 +23,6 @@ use Payum\Core\Payum;
 
 /** @var Payum $payum */
 $payum = (new PayumBuilder())
-    ->addDefaultStorages()
     ->addGateway('authorize_net', [
         'factory' => 'authorize_net_aim',
         'login_id' => 'REPLACE IT',

--- a/docs/be2bill/direct.md
+++ b/docs/be2bill/direct.md
@@ -23,8 +23,6 @@ use Payum\Core\Payum;
 
 /** @var Payum $payum */
 $payum = (new PayumBuilder())
-    ->addDefaultStorages()
-
     ->addGateway('be2bill_direct', [
         'factory' => 'be2bill_direct',
         'identifier' => 'REPLACE WITH YOURS',

--- a/docs/be2bill/offsite.md
+++ b/docs/be2bill/offsite.md
@@ -23,8 +23,6 @@ use Payum\Core\Payum;
 
 /** @var Payum $payum */
 $payum = (new PayumBuilder())
-    ->addDefaultStorages()
-
     ->addGateway('be2bill_offsite', [
         'factory' => 'be2bill_offsite',
         'identifier' => 'REPLACE WITH YOURS',

--- a/docs/encrypt-gateway-configs-stored-in-database.md
+++ b/docs/encrypt-gateway-configs-stored-in-database.md
@@ -32,7 +32,6 @@ $gatewayConfigStorage = new CryptoStorageDecorator($realStorage, $cypher);
 
 /** @var Payum $payum */
 $payum = (new PayumBuilder())
-    ->addDefaultStorages()
     ->setGatewayConfigStorage($gatewayConfigStorage)
 
     ->getPayum()

--- a/docs/get-it-started.md
+++ b/docs/get-it-started.md
@@ -52,7 +52,6 @@ $paymentClass = Payment::class;
 
 /** @var Payum $payum */
 $payum = (new PayumBuilder())
-    ->addDefaultStorages()
     ->addGateway('aGateway', [
         'factory' => 'offline',
     ])

--- a/docs/klarna/checkout/get-it-started.md
+++ b/docs/klarna/checkout/get-it-started.md
@@ -23,7 +23,6 @@ use Payum\Core\Payum;
 
 /** @var Payum $payum */
 $payum = (new PayumBuilder())
-    ->addDefaultStorages()
     ->addGateway('klarna', [
         'factory' => 'klarna_checkout',
         'merchant_id' => 'EDIT IT',

--- a/docs/klarna/invoice/get-it-started.md
+++ b/docs/klarna/invoice/get-it-started.md
@@ -23,7 +23,6 @@ use Payum\Core\Payum;
 
 /** @var Payum $payum */
 $payum = (new PayumBuilder())
-    ->addDefaultStorages()
     ->addGateway('klarna', [
         'factory' => 'klarna_invoice',
         'eid' => 'EDIT IT',

--- a/docs/laravel/blade-templating.md
+++ b/docs/laravel/blade-templating.md
@@ -10,7 +10,6 @@ All you have to do is change the configuration of payum on the gateway you want 
 <?php
 /** @var Payum $payum */
 $payum = (new PayumBuilder())
-    ->addDefaultStorages()
     ->addGateway('aGateway', [
         'factory' => 'klarna_checkout'
         'merchant_id' => '',

--- a/docs/offline/get-it-started.md
+++ b/docs/offline/get-it-started.md
@@ -23,7 +23,6 @@ use Payum\Core\Payum;
 
 /** @var Payum $payum */
 $payum = (new PayumBuilder())
-    ->addDefaultStorages()
     ->addGateway('gatewayName', [
         'factory' => 'offline',
     ])

--- a/docs/payex/get-it-started.md
+++ b/docs/payex/get-it-started.md
@@ -23,7 +23,6 @@ use Payum\Core\Payum;
 
 /** @var Payum $payum */
 $payum = (new PayumBuilder())
-    ->addDefaultStorages()
     ->addGateway('gatewayName', [
         'factory' => 'payex',
         'account_number' => 'REPLACE IT',

--- a/docs/paypal/express-checkout/get-it-started.md
+++ b/docs/paypal/express-checkout/get-it-started.md
@@ -21,8 +21,6 @@ use Payum\Core\Payum;
 
 /** @var Payum $payum */
 $payum = (new PayumBuilder())
-    ->addDefaultStorages()
-
     ->addGateway('gatewayName', [
         'factory' => 'paypal_express_checkout',
         'username'  => 'change it',

--- a/docs/paypal/masspay/get-it-started.md
+++ b/docs/paypal/masspay/get-it-started.md
@@ -21,8 +21,6 @@ use Payum\Core\Payum;
 
 /** @var Payum $payum */
 $payum = (new PayumBuilder())
-    ->addDefaultStorages()
-
     ->addGateway('aGateway', [
         'factory' => 'paypal_masspay',
         'username'  => 'change it',

--- a/docs/paypal/pro-checkout/get-it-started.md
+++ b/docs/paypal/pro-checkout/get-it-started.md
@@ -25,7 +25,6 @@ use Payum\Core\Payum;
 
 /** @var Payum $payum */
 $payum = (new PayumBuilder())
-    ->addDefaultStorages()
     ->addGateway('gatewayName', [
         'factory' => 'paypal_pro_checkout',
         'username' => 'REPLACE IT',

--- a/docs/paypal/pro-hosted/get-it-started.md
+++ b/docs/paypal/pro-hosted/get-it-started.md
@@ -21,8 +21,6 @@ use Payum\Core\Payum;
 
 /** @var Payum $payum */
 $payum = (new PayumBuilder())
-    ->addDefaultStorages()
-
     ->addGateway('aGateway', [
         'factory' => 'paypal_pro_hosted',
         'username'  => 'change it',

--- a/docs/paypal/rest/get-it-started.md
+++ b/docs/paypal/rest/get-it-started.md
@@ -21,7 +21,6 @@ use Payum\Core\Payum;
 
 /** @var Payum $payum */
 $payum = (new PayumBuilder())
-    ->addDefaultStorages()
     ->addGateway('paypalRest', [
         'factory' => 'paypal_rest',
         'client_id' => 'REPLACE IT', // Your PayPal REST API cliend ID.
@@ -44,7 +43,6 @@ use Payum\Core\Payum;
 
 /** @var Payum $payum */
 $payum = (new PayumBuilder())
-    ->addDefaultStorages()
     ->addGateway('paypalRest', [
         'factory' => 'paypal_rest',
         'client_id' => 'REPLACE IT',

--- a/docs/sofort/get-it-started.md
+++ b/docs/sofort/get-it-started.md
@@ -21,8 +21,6 @@ use Payum\Core\Payum;
 
 /** @var Payum $payum */
 $payum = (new PayumBuilder())
-    ->addDefaultStorages()
-
     ->addGateway('sofort', [
         'factory' => 'sofort',
         'config_key' => 'EDIT ME',

--- a/docs/stripe/checkout.md
+++ b/docs/stripe/checkout.md
@@ -23,7 +23,6 @@ use Payum\Core\Payum;
 
 /** @var Payum $payum */
 $payum = (new PayumBuilder())
-    ->addDefaultStorages()
     ->addGateway('gatewayName', [
         'factory' => 'stripe_checkout',
         'publishable_key' => 'EDIT IT',

--- a/docs/stripe/direct.md
+++ b/docs/stripe/direct.md
@@ -15,7 +15,6 @@ use Payum\Core\Payum;
 
 /** @var Payum $payum */
 $payum = (new PayumBuilder())
-    ->addDefaultStorages()
     ->addGateway('gatewayName', [
         'factory' => 'stripe_checkout',
         'publishable_key' => 'EDIT IT',

--- a/docs/stripe/js.md
+++ b/docs/stripe/js.md
@@ -23,7 +23,6 @@ use Payum\Core\Payum;
 
 /** @var Payum $payum */
 $payum = (new PayumBuilder())
-    ->addDefaultStorages()
     ->addGateway('gatewayName', [
         'factory' => 'stripe_js',
         'publishable_key' => 'EDIT IT',

--- a/src/Payum/Core/PayumBuilder.php
+++ b/src/Payum/Core/PayumBuilder.php
@@ -295,7 +295,7 @@ class PayumBuilder
     public function getPayum(): Payum
     {
         if (! $this->tokenStorage) {
-            throw new LogicException('Token storage must be configured.');
+            $this->addDefaultStorages();
         }
 
         /** @var StorageRegistryInterface<StorageInterface<TokenInterface>> $storageRegistry */

--- a/src/Payum/Core/Tests/PayumBuilderTest.php
+++ b/src/Payum/Core/Tests/PayumBuilderTest.php
@@ -63,10 +63,7 @@ class PayumBuilderTest extends TestCase
 
     public function testShouldBuildDefaultPayum(): void
     {
-        $payum = (new PayumBuilder())
-            ->addDefaultStorages()
-            ->getPayum()
-        ;
+        $payum = (new PayumBuilder())->getPayum();
 
         $this->assertInstanceOf(Payum::class, $payum);
         $this->assertInstanceOf(HttpRequestVerifier::class, $payum->getHttpRequestVerifier());

--- a/src/Payum/Core/Tests/PayumBuilderTest.php
+++ b/src/Payum/Core/Tests/PayumBuilderTest.php
@@ -52,15 +52,6 @@ class PayumBuilderTest extends TestCase
         ];
     }
 
-    public function testThrowsIfTokenStorageIsNotSet(): void
-    {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Token storage must be configured.');
-        $payum = (new PayumBuilder())->getPayum();
-
-        $this->assertInstanceOf(Payum::class, $payum);
-    }
-
     public function testShouldBuildDefaultPayum(): void
     {
         $payum = (new PayumBuilder())->getPayum();


### PR DESCRIPTION
Remove the need to call `addDefaultStorages()` on PayumBuilder. Register the storages by default if it's not set