### PR TITLE
Deprecate setting APIs on actions through ApiAwareInterface and ApiAwareTrait

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -11,6 +11,8 @@
   * Any custom class implementing this interface should update their signature. The new signatures are:
     * `public function getGateway(string $name): GatewayInterface;`
     * `public function getGateways(): array;`
+* The `Payum\Core\ApiAwareInterface` and `Payum\Core\ApiAwareTrait` has been deprecated. Inject the required API in the action's constructor instead.
+* The `payum.api` config has been deprecated.
 
 ## 1.5.0
 

--- a/src/Payum/Core/ApiAwareInterface.php
+++ b/src/Payum/Core/ApiAwareInterface.php
@@ -3,7 +3,13 @@
 namespace Payum\Core;
 
 use Payum\Core\Exception\UnsupportedApiException;
+use function trigger_error;
 
+@trigger_error('The ' . __NAMESPACE__ . '\ApiAwareInterface is deprecated since 2.0.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use dependency-injection to inject the api class instead.
+ */
 interface ApiAwareInterface
 {
     /**

--- a/src/Payum/Core/ApiAwareTrait.php
+++ b/src/Payum/Core/ApiAwareTrait.php
@@ -5,18 +5,31 @@ namespace Payum\Core;
 use Payum\Core\Exception\LogicException;
 use Payum\Core\Exception\UnsupportedApiException;
 use function is_object;
+use function trigger_error;
 
+/**
+ * @deprecated since 2.0. Add the API class to the action constructor instead
+ */
 trait ApiAwareTrait
 {
     /**
      * @var mixed
+     * @deprecated since 2.0. BC will be removed in 3.x. Use dependency-injection to inject the api instead.
      */
     protected $api;
 
+    /**
+     * @deprecated since 2.0. BC will be removed in 3.x. Use dependency-injection to inject the api instead.
+     */
     protected string|object|null $apiClass;
 
+    /**
+     * @deprecated since 2.0. BC will be removed in 3.x. Use dependency-injection to inject the api instead.
+     */
     public function setApi($api): void
     {
+        @trigger_error(sprintf('The method %s is deprecated since 2.0. Use dependency-injection to inject the api instead.', __METHOD__), E_USER_DEPRECATED);
+
         if (empty($this->apiClass)) {
             throw new LogicException('You must configure apiClass in __constructor method of the class the trait is applied to.');
         }

--- a/src/Payum/Core/CoreGatewayFactory.php
+++ b/src/Payum/Core/CoreGatewayFactory.php
@@ -215,7 +215,8 @@ class CoreGatewayFactory implements GatewayFactoryInterface
     {
         foreach ($config as $name => $value) {
             if (str_starts_with($name, 'payum.api')) {
-                $prepend = in_array($name, $config['payum.prepend_apis']);
+                @trigger_error('The payum.api.* config is deprecated and will be removed in 3.0. Use dependency-injection to inject the api into the action instead.', E_USER_DEPRECATED);
+                $prepend = in_array($name, $config['payum.prepend_apis'], true);
 
                 $gateway->addApi($value, $prepend);
             }

--- a/src/Payum/Core/Gateway.php
+++ b/src/Payum/Core/Gateway.php
@@ -23,6 +23,7 @@ class Gateway implements GatewayInterface
 
     /**
      * @var mixed[]
+     * @deprecated since 2.0. BC will be removed in 3.x. Use dependency-injection to inject the api into the action instead.
      */
     protected $apis = [];
 
@@ -47,6 +48,14 @@ class Gateway implements GatewayInterface
      */
     public function addApi($api, $forcePrepend = false): void
     {
+        @trigger_error(
+            sprintf(
+                'The %s method is deprecated and will be removed in 3.0. Use dependency-injection to inject the api into the action instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
         $forcePrepend ?
             array_unshift($this->apis, $api) :
             array_push($this->apis, $api)
@@ -161,6 +170,15 @@ class Gateway implements GatewayInterface
             }
 
             if ($action instanceof ApiAwareInterface) {
+                @trigger_error(
+                    sprintf(
+                        'Implementing the %s interface in %s is deprecated and will be removed in 2.0. Use dependency-injection to inject the api into the action instead.',
+                        ApiAwareInterface::class,
+                        $action::class,
+                    ),
+                    E_USER_DEPRECATED
+                );
+
                 $apiSet = false;
                 $unsupportedException = null;
                 foreach ($this->apis as $api) {

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Action/Api/BaseApiAwareAction.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Action/Api/BaseApiAwareAction.php
@@ -6,9 +6,10 @@ use Payum\Core\Action\ActionInterface;
 use Payum\Core\ApiAwareInterface;
 use Payum\Core\Exception\UnsupportedApiException;
 use Payum\Paypal\ExpressCheckout\Nvp\Api;
+use function trigger_error;
 
 /**
- * @deprecated since 1.4.1 will be removed in 2.x
+ * @deprecated since 1.4.1 will be removed in 3.x
  */
 abstract class BaseApiAwareAction implements ActionInterface, ApiAwareInterface
 {
@@ -19,6 +20,8 @@ abstract class BaseApiAwareAction implements ActionInterface, ApiAwareInterface
 
     public function setApi($api): void
     {
+        @trigger_error('The ' . self::class . '::setApi is deprecated since 1.4.1 and will be removed in 3.x.', E_USER_DEPRECATED);
+
         if (! $api instanceof Api) {
             throw new UnsupportedApiException('Not supported.');
         }


### PR DESCRIPTION
Deprecate the `payum.api` config and setting APIs using the ApiAwareInterface and ApiAwareTrait.

Instead, the API can just be added to the action through the constructor. This helps with static-analysis, since we can set the correct property and type for the API. It also allows multiple API classes to be added to an action.

E.G To move away from the `payum.api` config in Stripe, the following changes can be made in the gateway factory:

```php

$config->validateNotEmpty(['publishable_key', 'secret_key']);

$api = new Keys($config['publishable_key'], $config['secret_key']);

$config->defaults([
    // ...
    'payum.action.create_charge' => new CreateChargeAction($api),
]);

/****/

class CreateChargeAction {
    protected $api;

    public function __construct(Keys $api)
    {
        $this->api = $api;
    }
}
```