### PR TITLE
Deprecate the Symfony bridge in favour of using PayumBundle

### DIFF
--- a/src/Payum/Core/Bridge/Symfony/Action/GetHttpRequestAction.php
+++ b/src/Payum/Core/Bridge/Symfony/Action/GetHttpRequestAction.php
@@ -8,7 +8,7 @@ use Payum\Core\Request\GetHttpRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-@trigger_error('The '.__NAMESPACE__.'\GetHttpRequestAction class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\GetHttpRequestAction class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/Action/GetHttpRequestAction.php
+++ b/src/Payum/Core/Bridge/Symfony/Action/GetHttpRequestAction.php
@@ -8,6 +8,11 @@ use Payum\Core\Request\GetHttpRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+@trigger_error('The '.__NAMESPACE__.'\GetHttpRequestAction class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 class GetHttpRequestAction implements ActionInterface
 {
     /**

--- a/src/Payum/Core/Bridge/Symfony/Action/ObtainCreditCardAction.php
+++ b/src/Payum/Core/Bridge/Symfony/Action/ObtainCreditCardAction.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
-@trigger_error('The '.__NAMESPACE__.'\ObtainCreditCardAction class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\ObtainCreditCardAction class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/Action/ObtainCreditCardAction.php
+++ b/src/Payum/Core/Bridge/Symfony/Action/ObtainCreditCardAction.php
@@ -18,6 +18,11 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
+@trigger_error('The '.__NAMESPACE__.'\ObtainCreditCardAction class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 class ObtainCreditCardAction implements ActionInterface, GatewayAwareInterface
 {
     use GatewayAwareTrait;

--- a/src/Payum/Core/Bridge/Symfony/Action/RenderTemplateAction.php
+++ b/src/Payum/Core/Bridge/Symfony/Action/RenderTemplateAction.php
@@ -7,6 +7,11 @@ use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\Request\RenderTemplate;
 use Symfony\Component\Templating\EngineInterface;
 
+@trigger_error('The '.__NAMESPACE__.'\RenderTemplateAction class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 class RenderTemplateAction implements ActionInterface
 {
     /**

--- a/src/Payum/Core/Bridge/Symfony/Action/RenderTemplateAction.php
+++ b/src/Payum/Core/Bridge/Symfony/Action/RenderTemplateAction.php
@@ -7,7 +7,7 @@ use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\Request\RenderTemplate;
 use Symfony\Component\Templating\EngineInterface;
 
-@trigger_error('The '.__NAMESPACE__.'\RenderTemplateAction class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\RenderTemplateAction class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/Builder/CoreGatewayFactoryBuilder.php
+++ b/src/Payum/Core/Bridge/Symfony/Builder/CoreGatewayFactoryBuilder.php
@@ -7,7 +7,7 @@ use Payum\Core\GatewayFactoryInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-@trigger_error('The '.__NAMESPACE__.'\CoreGatewayFactoryBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\CoreGatewayFactoryBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/Builder/CoreGatewayFactoryBuilder.php
+++ b/src/Payum/Core/Bridge/Symfony/Builder/CoreGatewayFactoryBuilder.php
@@ -7,6 +7,11 @@ use Payum\Core\GatewayFactoryInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
+@trigger_error('The '.__NAMESPACE__.'\CoreGatewayFactoryBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 class CoreGatewayFactoryBuilder implements ContainerAwareInterface
 {
     use ContainerAwareTrait;

--- a/src/Payum/Core/Bridge/Symfony/Builder/GatewayFactoryBuilder.php
+++ b/src/Payum/Core/Bridge/Symfony/Builder/GatewayFactoryBuilder.php
@@ -4,7 +4,7 @@ namespace Payum\Core\Bridge\Symfony\Builder;
 
 use Payum\Core\GatewayFactoryInterface;
 
-@trigger_error('The '.__NAMESPACE__.'\GatewayFactoryBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\GatewayFactoryBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/Builder/GatewayFactoryBuilder.php
+++ b/src/Payum/Core/Bridge/Symfony/Builder/GatewayFactoryBuilder.php
@@ -4,6 +4,11 @@ namespace Payum\Core\Bridge\Symfony\Builder;
 
 use Payum\Core\GatewayFactoryInterface;
 
+@trigger_error('The '.__NAMESPACE__.'\GatewayFactoryBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 class GatewayFactoryBuilder
 {
     /**

--- a/src/Payum/Core/Bridge/Symfony/Builder/HttpRequestVerifierBuilder.php
+++ b/src/Payum/Core/Bridge/Symfony/Builder/HttpRequestVerifierBuilder.php
@@ -7,7 +7,7 @@ use Payum\Core\Security\HttpRequestVerifierInterface;
 use Payum\Core\Security\TokenInterface;
 use Payum\Core\Storage\StorageInterface;
 
-@trigger_error('The '.__NAMESPACE__.'\HttpRequestVerifierBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\HttpRequestVerifierBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/Builder/HttpRequestVerifierBuilder.php
+++ b/src/Payum/Core/Bridge/Symfony/Builder/HttpRequestVerifierBuilder.php
@@ -7,6 +7,11 @@ use Payum\Core\Security\HttpRequestVerifierInterface;
 use Payum\Core\Security\TokenInterface;
 use Payum\Core\Storage\StorageInterface;
 
+@trigger_error('The '.__NAMESPACE__.'\HttpRequestVerifierBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 class HttpRequestVerifierBuilder
 {
     public function __invoke(): HttpRequestVerifierInterface

--- a/src/Payum/Core/Bridge/Symfony/Builder/ObtainCreditCardActionBuilder.php
+++ b/src/Payum/Core/Bridge/Symfony/Builder/ObtainCreditCardActionBuilder.php
@@ -7,6 +7,11 @@ use Payum\Core\Bridge\Symfony\Action\ObtainCreditCardAction;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+@trigger_error('The '.__NAMESPACE__.'\ObtainCreditCardActionBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 class ObtainCreditCardActionBuilder
 {
     private FormFactoryInterface $formFactory;

--- a/src/Payum/Core/Bridge/Symfony/Builder/ObtainCreditCardActionBuilder.php
+++ b/src/Payum/Core/Bridge/Symfony/Builder/ObtainCreditCardActionBuilder.php
@@ -7,7 +7,7 @@ use Payum\Core\Bridge\Symfony\Action\ObtainCreditCardAction;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-@trigger_error('The '.__NAMESPACE__.'\ObtainCreditCardActionBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\ObtainCreditCardActionBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/Builder/TokenFactoryBuilder.php
+++ b/src/Payum/Core/Bridge/Symfony/Builder/TokenFactoryBuilder.php
@@ -9,7 +9,7 @@ use Payum\Core\Security\TokenInterface;
 use Payum\Core\Storage\StorageInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-@trigger_error('The '.__NAMESPACE__.'\TokenFactoryBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\TokenFactoryBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/Builder/TokenFactoryBuilder.php
+++ b/src/Payum/Core/Bridge/Symfony/Builder/TokenFactoryBuilder.php
@@ -9,6 +9,11 @@ use Payum\Core\Security\TokenInterface;
 use Payum\Core\Storage\StorageInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+@trigger_error('The '.__NAMESPACE__.'\TokenFactoryBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 class TokenFactoryBuilder
 {
     private UrlGeneratorInterface $urlGenerator;

--- a/src/Payum/Core/Bridge/Symfony/ContainerAwareCoreGatewayFactory.php
+++ b/src/Payum/Core/Bridge/Symfony/ContainerAwareCoreGatewayFactory.php
@@ -7,6 +7,11 @@ use Payum\Core\CoreGatewayFactory;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
+@trigger_error('The '.__NAMESPACE__.'\ContainerAwareCoreGatewayFactory class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 class ContainerAwareCoreGatewayFactory extends CoreGatewayFactory implements ContainerAwareInterface
 {
     use ContainerAwareTrait;

--- a/src/Payum/Core/Bridge/Symfony/ContainerAwareCoreGatewayFactory.php
+++ b/src/Payum/Core/Bridge/Symfony/ContainerAwareCoreGatewayFactory.php
@@ -7,7 +7,7 @@ use Payum\Core\CoreGatewayFactory;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-@trigger_error('The '.__NAMESPACE__.'\ContainerAwareCoreGatewayFactory class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\ContainerAwareCoreGatewayFactory class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/ContainerAwareRegistry.php
+++ b/src/Payum/Core/Bridge/Symfony/ContainerAwareRegistry.php
@@ -6,9 +6,14 @@ use Payum\Core\Registry\AbstractRegistry;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
+@trigger_error('The '.__NAMESPACE__.'\ContainerAwareRegistry class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
 /**
  * @template T of object
  * @extends AbstractRegistry<T>
+ *
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * /
  */
 class ContainerAwareRegistry extends AbstractRegistry implements ContainerAwareInterface
 {

--- a/src/Payum/Core/Bridge/Symfony/ContainerAwareRegistry.php
+++ b/src/Payum/Core/Bridge/Symfony/ContainerAwareRegistry.php
@@ -6,7 +6,7 @@ use Payum\Core\Registry\AbstractRegistry;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-@trigger_error('The '.__NAMESPACE__.'\ContainerAwareRegistry class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\ContainerAwareRegistry class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @template T of object

--- a/src/Payum/Core/Bridge/Symfony/Event/ExecuteEvent.php
+++ b/src/Payum/Core/Bridge/Symfony/Event/ExecuteEvent.php
@@ -5,7 +5,7 @@ namespace Payum\Core\Bridge\Symfony\Event;
 use Payum\Core\Extension\Context;
 use Symfony\Contracts\EventDispatcher\Event;
 
-@trigger_error('The '.__NAMESPACE__.'\ExecuteEvent class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\ExecuteEvent class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/Event/ExecuteEvent.php
+++ b/src/Payum/Core/Bridge/Symfony/Event/ExecuteEvent.php
@@ -5,6 +5,11 @@ namespace Payum\Core\Bridge\Symfony\Event;
 use Payum\Core\Extension\Context;
 use Symfony\Contracts\EventDispatcher\Event;
 
+@trigger_error('The '.__NAMESPACE__.'\ExecuteEvent class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 class ExecuteEvent extends Event
 {
     /**

--- a/src/Payum/Core/Bridge/Symfony/Extension/EventDispatcherExtension.php
+++ b/src/Payum/Core/Bridge/Symfony/Extension/EventDispatcherExtension.php
@@ -8,7 +8,7 @@ use Payum\Core\Extension\Context;
 use Payum\Core\Extension\ExtensionInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
-@trigger_error('The '.__NAMESPACE__.'\EventDispatcherExtension class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\EventDispatcherExtension class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/Extension/EventDispatcherExtension.php
+++ b/src/Payum/Core/Bridge/Symfony/Extension/EventDispatcherExtension.php
@@ -8,6 +8,11 @@ use Payum\Core\Extension\Context;
 use Payum\Core\Extension\ExtensionInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
+@trigger_error('The '.__NAMESPACE__.'\EventDispatcherExtension class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 class EventDispatcherExtension implements ExtensionInterface
 {
     private EventDispatcherInterface $dispatcher;

--- a/src/Payum/Core/Bridge/Symfony/Form/Type/CreditCardExpirationDateType.php
+++ b/src/Payum/Core/Bridge/Symfony/Form/Type/CreditCardExpirationDateType.php
@@ -9,6 +9,11 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+@trigger_error('The '.__NAMESPACE__.'\CreditCardExpirationDateType class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 class CreditCardExpirationDateType extends AbstractType
 {
     public function finishView(FormView $view, FormInterface $form, array $options): void

--- a/src/Payum/Core/Bridge/Symfony/Form/Type/CreditCardExpirationDateType.php
+++ b/src/Payum/Core/Bridge/Symfony/Form/Type/CreditCardExpirationDateType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-@trigger_error('The '.__NAMESPACE__.'\CreditCardExpirationDateType class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\CreditCardExpirationDateType class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/Form/Type/CreditCardType.php
+++ b/src/Payum/Core/Bridge/Symfony/Form/Type/CreditCardType.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-@trigger_error('The '.__NAMESPACE__.'\CreditCardType class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\CreditCardType class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/Form/Type/CreditCardType.php
+++ b/src/Payum/Core/Bridge/Symfony/Form/Type/CreditCardType.php
@@ -8,6 +8,11 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+@trigger_error('The '.__NAMESPACE__.'\CreditCardType class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 class CreditCardType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void

--- a/src/Payum/Core/Bridge/Symfony/Form/Type/GatewayChoiceType.php
+++ b/src/Payum/Core/Bridge/Symfony/Form/Type/GatewayChoiceType.php
@@ -6,6 +6,11 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+@trigger_error('The '.__NAMESPACE__.'\GatewayChoiceType class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 class GatewayChoiceType extends AbstractType
 {
     /**

--- a/src/Payum/Core/Bridge/Symfony/Form/Type/GatewayChoiceType.php
+++ b/src/Payum/Core/Bridge/Symfony/Form/Type/GatewayChoiceType.php
@@ -6,7 +6,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-@trigger_error('The '.__NAMESPACE__.'\GatewayChoiceType class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\GatewayChoiceType class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/Form/Type/GatewayConfigType.php
+++ b/src/Payum/Core/Bridge/Symfony/Form/Type/GatewayConfigType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
-@trigger_error('The '.__NAMESPACE__.'\GatewayConfigType class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\GatewayConfigType class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/Form/Type/GatewayConfigType.php
+++ b/src/Payum/Core/Bridge/Symfony/Form/Type/GatewayConfigType.php
@@ -14,6 +14,11 @@ use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
+@trigger_error('The '.__NAMESPACE__.'\GatewayConfigType class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 class GatewayConfigType extends AbstractType
 {
     private GatewayFactoryRegistryInterface $registry;

--- a/src/Payum/Core/Bridge/Symfony/Form/Type/GatewayFactoriesChoiceType.php
+++ b/src/Payum/Core/Bridge/Symfony/Form/Type/GatewayFactoriesChoiceType.php
@@ -6,6 +6,11 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+@trigger_error('The '.__NAMESPACE__.'\GatewayFactoriesChoiceType class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 class GatewayFactoriesChoiceType extends AbstractType
 {
     /**

--- a/src/Payum/Core/Bridge/Symfony/Form/Type/GatewayFactoriesChoiceType.php
+++ b/src/Payum/Core/Bridge/Symfony/Form/Type/GatewayFactoriesChoiceType.php
@@ -6,7 +6,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-@trigger_error('The '.__NAMESPACE__.'\GatewayFactoriesChoiceType class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\GatewayFactoriesChoiceType class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/PayumEvents.php
+++ b/src/Payum/Core/Bridge/Symfony/PayumEvents.php
@@ -2,7 +2,7 @@
 
 namespace Payum\Core\Bridge\Symfony;
 
-@trigger_error('The '.__NAMESPACE__.'\PayumEvents class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\PayumEvents class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/PayumEvents.php
+++ b/src/Payum/Core/Bridge/Symfony/PayumEvents.php
@@ -2,6 +2,11 @@
 
 namespace Payum\Core\Bridge\Symfony;
 
+@trigger_error('The '.__NAMESPACE__.'\PayumEvents class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 final class PayumEvents
 {
     public const GATEWAY_PRE_EXECUTE = 'payum.gateway.pre_execute';

--- a/src/Payum/Core/Bridge/Symfony/Reply/HttpResponse.php
+++ b/src/Payum/Core/Bridge/Symfony/Reply/HttpResponse.php
@@ -5,6 +5,11 @@ namespace Payum\Core\Bridge\Symfony\Reply;
 use Payum\Core\Reply\Base;
 use Symfony\Component\HttpFoundation\Response;
 
+@trigger_error('The '.__NAMESPACE__.'\HttpResponse class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 class HttpResponse extends Base
 {
     /**

--- a/src/Payum/Core/Bridge/Symfony/Reply/HttpResponse.php
+++ b/src/Payum/Core/Bridge/Symfony/Reply/HttpResponse.php
@@ -5,7 +5,7 @@ namespace Payum\Core\Bridge\Symfony\Reply;
 use Payum\Core\Reply\Base;
 use Symfony\Component\HttpFoundation\Response;
 
-@trigger_error('The '.__NAMESPACE__.'\HttpResponse class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\HttpResponse class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/ReplyToSymfonyResponseConverter.php
+++ b/src/Payum/Core/Bridge/Symfony/ReplyToSymfonyResponseConverter.php
@@ -10,7 +10,7 @@ use ReflectionObject;
 use Symfony\Component\HttpFoundation\Response;
 use function trigger_error;
 
-@trigger_error('The '.__NAMESPACE__.'\ReplyToSymfonyResponseConverter class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\ReplyToSymfonyResponseConverter class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/ReplyToSymfonyResponseConverter.php
+++ b/src/Payum/Core/Bridge/Symfony/ReplyToSymfonyResponseConverter.php
@@ -8,7 +8,13 @@ use Payum\Core\Reply\HttpResponse;
 use Payum\Core\Reply\ReplyInterface;
 use ReflectionObject;
 use Symfony\Component\HttpFoundation\Response;
+use function trigger_error;
 
+@trigger_error('The '.__NAMESPACE__.'\ReplyToSymfonyResponseConverter class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 class ReplyToSymfonyResponseConverter
 {
     /**

--- a/src/Payum/Core/Bridge/Symfony/Security/HttpRequestVerifier.php
+++ b/src/Payum/Core/Bridge/Symfony/Security/HttpRequestVerifier.php
@@ -11,6 +11,11 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
+@trigger_error('The '.__NAMESPACE__.'\HttpRequestVerifier class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 class HttpRequestVerifier implements HttpRequestVerifierInterface
 {
     /**

--- a/src/Payum/Core/Bridge/Symfony/Security/HttpRequestVerifier.php
+++ b/src/Payum/Core/Bridge/Symfony/Security/HttpRequestVerifier.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-@trigger_error('The '.__NAMESPACE__.'\HttpRequestVerifier class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\HttpRequestVerifier class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/Security/TokenFactory.php
+++ b/src/Payum/Core/Bridge/Symfony/Security/TokenFactory.php
@@ -7,6 +7,11 @@ use Payum\Core\Security\AbstractTokenFactory;
 use Payum\Core\Storage\StorageInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+@trigger_error('The '.__NAMESPACE__.'\TokenFactory class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ */
 class TokenFactory extends AbstractTokenFactory
 {
     protected UrlGeneratorInterface $urlGenerator;

--- a/src/Payum/Core/Bridge/Symfony/Security/TokenFactory.php
+++ b/src/Payum/Core/Bridge/Symfony/Security/TokenFactory.php
@@ -7,7 +7,7 @@ use Payum\Core\Security\AbstractTokenFactory;
 use Payum\Core\Storage\StorageInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-@trigger_error('The '.__NAMESPACE__.'\TokenFactory class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\TokenFactory class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/Validator/Constraints/CreditCardDate.php
+++ b/src/Payum/Core/Bridge/Symfony/Validator/Constraints/CreditCardDate.php
@@ -9,8 +9,10 @@ use DateTime;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\MissingOptionsException;
 
+@trigger_error('The '.__NAMESPACE__.'\CreditCardDate class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
 /**
- * CreditCardDate
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
  */
 class CreditCardDate extends Constraint
 {

--- a/src/Payum/Core/Bridge/Symfony/Validator/Constraints/CreditCardDate.php
+++ b/src/Payum/Core/Bridge/Symfony/Validator/Constraints/CreditCardDate.php
@@ -9,7 +9,7 @@ use DateTime;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\MissingOptionsException;
 
-@trigger_error('The '.__NAMESPACE__.'\CreditCardDate class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\CreditCardDate class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/Validator/Constraints/CreditCardDateValidator.php
+++ b/src/Payum/Core/Bridge/Symfony/Validator/Constraints/CreditCardDateValidator.php
@@ -9,7 +9,7 @@ use DateTime;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
-@trigger_error('The '.__NAMESPACE__.'\CreditCardDateValidator class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\CreditCardDateValidator class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.

--- a/src/Payum/Core/Bridge/Symfony/Validator/Constraints/CreditCardDateValidator.php
+++ b/src/Payum/Core/Bridge/Symfony/Validator/Constraints/CreditCardDateValidator.php
@@ -9,8 +9,10 @@ use DateTime;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
+@trigger_error('The '.__NAMESPACE__.'\CreditCardDateValidator class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+
 /**
- * CreditCardDateValidator
+ * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
  *
  * Validate if the Credit Card is not expired
  */


### PR DESCRIPTION
Deprecate the Symfony Bridge classes, in favour of a full integration in PayumBundle.

These classes will be moved to PayumBundle, so that the bundle is fully responsible for it's own integration and the integration is not split between repositories. 

Fixes #838

Related: Payum/PayumBundle#557