### PR TITLE
Add Dependency Injection integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,9 @@
         "league/uri": "^6.4",
         "league/uri-components": "^2.2",
         "twig/twig": "^2.4 || ^3.0",
-        "php-http/discovery": "^1.19"
+        "php-http/discovery": "^1.19",
+        "psr/container": "^2.0",
+        "php-di/php-di": "^7.0"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
         "php-http/discovery": "^1.19",
         "php-http/message-factory": "^1.1",
         "psr/container": "^2.0",
-        "psr/log": "^1 || ^2 || ^3"
+        "psr/log": "^1 || ^2 || ^3",
+        "php-http/message-factory": "^1.1"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "php-http/message-factory": "^1.1",
         "psr/container": "^2.0",
         "psr/log": "^1 || ^2 || ^3",
-        "php-http/message-factory": "^1.1"
+        "symfony/deprecation-contracts": "^2.5 || ^3.0"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/composer.json
+++ b/composer.json
@@ -46,8 +46,10 @@
         "league/uri": "^6.4 || ^7.0",
         "league/uri-components": "^2.2 || ^7.0",
         "twig/twig": "^2.4 || ^3.0",
+        "php-di/php-di": "^7.0",
         "php-http/discovery": "^1.19",
         "php-http/message-factory": "^1.1",
+        "psr/container": "^2.0",
         "psr/log": "^1 || ^2 || ^3"
     },
     "require-dev": {

--- a/docs/di/customization.md
+++ b/docs/di/customization.md
@@ -160,53 +160,24 @@ $payum = (new PayumBuilder())
     ->getPayum();
 ```
 
-## Advanced: Pre-building the Global Container
+## Advanced: Using Your Own Container
 
-For advanced use cases (e.g., framework integration), you can build and provide the entire global container
-with `setGlobalContainer()`.
+For framework integration you can hand your application's container to `setGlobalContainer()`. It is placed
+**in front of** Payum's global container: a service is looked up in your container first, and whatever it
+does not have comes from Payum's defaults.
 
-**This replaces Payum's global container completely.** Payum will not build one of its own, which means:
-
-- The container you pass has to define Payum's own shared services itself. At a minimum
-  `GenericTokenFactoryInterface`, `HttpRequestVerifierInterface` and `payum.security.token_storage`
-  (the latter can be supplied with `setTokenStorage()` instead), plus `TokenFactoryInterface` and the
-  PSR-17/18 services if your gateways make HTTP calls.
-- `addGlobalService()` is ignored — register those services in your own container instead.
-- `addDefaultStorages()` still registers storages on the builder, but the storage extensions are expected
-  from your container.
+That means you only declare the services you actually want to provide yourself. There is no need to
+re-create the token factory, the request verifier or the HTTP client just to get a container accepted.
 
 ```php
 <?php
 
 use DI\ContainerBuilder;
-use Payum\Core\Bridge\PlainPhp\Security\HttpRequestVerifier;
-use Payum\Core\Bridge\PlainPhp\Security\TokenFactory;
-use Payum\Core\Security\GenericTokenFactory;
-use Payum\Core\Security\GenericTokenFactoryInterface;
-use Payum\Core\Security\HttpRequestVerifierInterface;
-use Payum\Core\Security\TokenFactoryInterface;
-use Psr\Container\ContainerInterface;
 use Psr\Http\Client\ClientInterface;
 
-// Build your own container
+// Only what you want to control yourself
 $builder = new ContainerBuilder();
 $builder->addDefinitions([
-    // Payum's own shared services
-    'payum.security.token_storage' => $tokenStorage,
-    TokenFactoryInterface::class => fn () => new TokenFactory($tokenStorage, $storageRegistry, 'https://example.com'),
-    GenericTokenFactoryInterface::class => fn (ContainerInterface $c) => new GenericTokenFactory(
-        $c->get(TokenFactoryInterface::class),
-        [
-            'capture' => 'capture.php',
-            'notify' => 'notify.php',
-            'authorize' => 'authorize.php',
-            'refund' => 'refund.php',
-            'payout' => 'payout.php',
-        ]
-    ),
-    HttpRequestVerifierInterface::class => fn () => new HttpRequestVerifier($tokenStorage),
-
-    // Your own services
     ClientInterface::class => function () {
         return new \GuzzleHttp\Client(['timeout' => 60]);
     },
@@ -215,21 +186,40 @@ $builder->addDefinitions([
     },
 ]);
 
-$container = $builder->build();
-
-// Provide it to PayumBuilder
 $payum = (new PayumBuilder())
-    ->setGlobalContainer($container)
+    ->setGlobalContainer($builder->build())
     // ... add gateways
     ->getPayum();
 ```
 
-Pass a PHP-DI container and everything in it — including `'my.custom.service'` — is available from every
-gateway. Any other PSR-11 container shares only the service ids listed above; register anything else you
-want your gateways to see under one of those ids, or use `addGlobalService()` instead.
+Here the gateways use your Guzzle client, while the token storage, token factories and request verifier are
+still the ones Payum builds. Override any of them by adding a definition for
+`payum.security.token_storage`, `TokenFactoryInterface`, `GenericTokenFactoryInterface` or
+`HttpRequestVerifierInterface` to your container — Payum picks them up and builds the rest on top of them.
+Define the token storage there and the default storages are not created at all.
 
-If you only need to add or replace a handful of services, `addGlobalService()` is the better fit — it
-leaves Payum's own services in place.
+`addGlobalService()` keeps working alongside a container of your own; those services are layered under it.
+
+### Reaching Your Services From a Gateway
+
+Pass a PHP-DI container and everything in it — including `'my.custom.service'` — can be injected into your
+gateway's actions.
+
+Most framework containers cannot list what they hold, so Payum has no way to know which ids to make
+injectable. Register those with `addGlobalService()`, which works alongside your container:
+
+```php
+<?php
+
+$payum = (new PayumBuilder())
+    ->setGlobalContainer($frameworkContainer)
+
+    // Makes the logger injectable into gateway actions
+    ->addGlobalService(LoggerInterface::class, fn () => $frameworkContainer->get('logger'))
+
+    // ... add gateways
+    ->getPayum();
+```
 
 ## Accessing Services
 

--- a/docs/di/customization.md
+++ b/docs/di/customization.md
@@ -1,0 +1,427 @@
+# Dependency Injection - Customization Guide
+
+## Overview
+
+Payum v2.0's DI system is designed for maximum flexibility. You can customize virtually any service, add your own global services, or integrate with external containers.
+
+## Adding Global Services
+
+Global services are available to all gateways and are instantiated only once. Every id you register with
+`addGlobalService()` is wired into each gateway's container, so gateway factories and actions can ask for
+it by that id.
+
+### Adding a Logger
+
+```php
+<?php
+
+use Psr\Log\LoggerInterface;
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+
+$logger = new Logger('payum');
+$logger->pushHandler(new StreamHandler('/var/log/payum.log'));
+
+$payum = (new PayumBuilder())
+    ->addGlobalService(LoggerInterface::class, $logger)
+    ->addGlobalService('my.custom.logger', $logger) // Alternative ID
+    ->addDefaultStorages()
+    // ... add gateways
+    ->getPayum();
+```
+
+### Adding a Cache Service
+
+```php
+<?php
+
+use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+
+$redisClient = new \Redis();
+$redisClient->connect('127.0.0.1', 6379);
+
+$cache = new Psr16Cache(new RedisAdapter($redisClient));
+
+$payum = (new PayumBuilder())
+    ->addGlobalService(CacheInterface::class, $cache)
+    ->addDefaultStorages()
+    // ... add gateways
+    ->getPayum();
+```
+
+## Overriding Default Services
+
+### Custom HTTP Client
+
+Replace the default PSR-18 HTTP client with your own:
+
+```php
+<?php
+
+use Psr\Http\Client\ClientInterface;
+use GuzzleHttp\Client;
+
+$customClient = new Client([
+    'timeout' => 30,
+    'verify' => true,
+    'headers' => [
+        'User-Agent' => 'MyApp/1.0',
+    ],
+]);
+
+$payum = (new PayumBuilder())
+    ->addGlobalService(ClientInterface::class, $customClient)
+    ->addDefaultStorages()
+    // ... add gateways
+    ->getPayum();
+```
+
+### Custom HTTP Factory (PSR-17)
+
+```php
+<?php
+
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Nyholm\Psr7\Factory\Psr17Factory;
+
+$factory = new Psr17Factory();
+
+$payum = (new PayumBuilder())
+    ->addGlobalService(RequestFactoryInterface::class, $factory)
+    ->addGlobalService(StreamFactoryInterface::class, $factory)
+    ->addDefaultStorages()
+    // ... add gateways
+    ->getPayum();
+```
+
+### Custom Token Storage
+
+```php
+<?php
+
+use Payum\Core\Storage\StorageInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Payum\Core\Bridge\Doctrine\Storage\DoctrineStorage;
+
+$tokenStorage = new DoctrineStorage(
+    $entityManager,
+    'App\Entity\PaymentToken'
+);
+
+$payum = (new PayumBuilder())
+    ->setTokenStorage($tokenStorage)
+    // ... add gateways
+    ->getPayum();
+```
+
+## Using Service Factories
+
+For services that need lazy initialization or configuration:
+
+```php
+<?php
+
+use Psr\Log\LoggerInterface;
+
+$payum = (new PayumBuilder())
+    ->addGlobalService(LoggerInterface::class, function () {
+        // This closure is called only when the service is first requested
+        $logger = new \Monolog\Logger('payum');
+        $logger->pushHandler(new \Monolog\Handler\StreamHandler('/var/log/payum.log'));
+        return $logger;
+    })
+    ->addDefaultStorages()
+    // ... add gateways
+    ->getPayum();
+```
+
+## Gateway-Specific Configuration
+
+You can add services specific to a single gateway:
+
+```php
+<?php
+
+$payum = (new PayumBuilder())
+    ->addDefaultStorages()
+
+    ->addGateway('stripe', [
+        'factory' => 'stripe_checkout',
+        'publishable_key' => 'pk_test_...',
+        'secret_key' => 'sk_test_...',
+
+        // Gateway-specific service (not shared)
+        'stripe.custom_option' => 'custom_value',
+    ])
+
+    ->getPayum();
+```
+
+## Advanced: Pre-building the Global Container
+
+For advanced use cases (e.g., framework integration), you can build and provide the entire global container
+with `setGlobalContainer()`.
+
+**This replaces Payum's global container completely.** Payum will not build one of its own, which means:
+
+- The container you pass has to define Payum's own shared services itself. At a minimum
+  `GenericTokenFactoryInterface`, `HttpRequestVerifierInterface` and `payum.security.token_storage`
+  (the latter can be supplied with `setTokenStorage()` instead), plus `TokenFactoryInterface` and the
+  PSR-17/18 services if your gateways make HTTP calls.
+- `addGlobalService()` is ignored — register those services in your own container instead.
+- `addDefaultStorages()` still registers storages on the builder, but the storage extensions are expected
+  from your container.
+
+```php
+<?php
+
+use DI\ContainerBuilder;
+use Payum\Core\Bridge\PlainPhp\Security\HttpRequestVerifier;
+use Payum\Core\Bridge\PlainPhp\Security\TokenFactory;
+use Payum\Core\Security\GenericTokenFactory;
+use Payum\Core\Security\GenericTokenFactoryInterface;
+use Payum\Core\Security\HttpRequestVerifierInterface;
+use Payum\Core\Security\TokenFactoryInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Client\ClientInterface;
+
+// Build your own container
+$builder = new ContainerBuilder();
+$builder->addDefinitions([
+    // Payum's own shared services
+    'payum.security.token_storage' => $tokenStorage,
+    TokenFactoryInterface::class => fn () => new TokenFactory($tokenStorage, $storageRegistry, 'https://example.com'),
+    GenericTokenFactoryInterface::class => fn (ContainerInterface $c) => new GenericTokenFactory(
+        $c->get(TokenFactoryInterface::class),
+        [
+            'capture' => 'capture.php',
+            'notify' => 'notify.php',
+            'authorize' => 'authorize.php',
+            'refund' => 'refund.php',
+            'payout' => 'payout.php',
+        ]
+    ),
+    HttpRequestVerifierInterface::class => fn () => new HttpRequestVerifier($tokenStorage),
+
+    // Your own services
+    ClientInterface::class => function () {
+        return new \GuzzleHttp\Client(['timeout' => 60]);
+    },
+    'my.custom.service' => function () {
+        return new MyCustomService();
+    },
+]);
+
+$container = $builder->build();
+
+// Provide it to PayumBuilder
+$payum = (new PayumBuilder())
+    ->setGlobalContainer($container)
+    // ... add gateways
+    ->getPayum();
+```
+
+Pass a PHP-DI container and everything in it — including `'my.custom.service'` — is available from every
+gateway. Any other PSR-11 container shares only the service ids listed above; register anything else you
+want your gateways to see under one of those ids, or use `addGlobalService()` instead.
+
+If you only need to add or replace a handful of services, `addGlobalService()` is the better fit — it
+leaves Payum's own services in place.
+
+## Accessing Services
+
+### From Gateway Context
+
+If you've added a global service, you can access it from within actions:
+
+```php
+<?php
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Request\Capture;
+use Psr\Log\LoggerInterface;
+
+class MyAction implements ActionInterface
+{
+    public function __construct(
+        private readonly LoggerInterface $logger
+    ) {}
+
+    public function execute($request): void
+    {
+        $this->logger->info('Processing payment request');
+        // ... action logic
+    }
+
+    public function supports($request): bool
+    {
+        return $request instanceof Capture;
+    }
+}
+```
+
+### Registering Actions with Dependencies
+
+When creating gateway factories, inject dependencies via constructor:
+
+```php
+<?php
+
+use Payum\Core\CoreGatewayFactory;
+use Psr\Log\LoggerInterface;
+use function DI\autowire;
+use function DI\get;
+
+class MyGatewayFactory extends CoreGatewayFactory
+{
+    public function configureContainer(): array
+    {
+        return array_merge(parent::configureContainer(), [
+            MyAction::class => autowire()
+                ->constructor(logger: get(LoggerInterface::class)),
+        ]);
+    }
+
+    public function getActions(): array
+    {
+        return array_merge(parent::getActions(), [
+            MyAction::class,
+        ]);
+    }
+}
+```
+
+`get(LoggerInterface::class)` resolves here because the logger was registered with
+`addGlobalService(LoggerInterface::class, $logger)` — shared services are wired into every gateway
+container.
+
+## Service Lifecycle
+
+### Global Services (Singleton)
+
+Services in the global container are instantiated once and reused:
+
+```php
+<?php
+
+$payum = (new PayumBuilder())
+    ->addGlobalService(ClientInterface::class, $httpClient)
+    ->addGateway('stripe', ['factory' => 'stripe_checkout', /* ... */])
+    ->addGateway('paypal', ['factory' => 'paypal_rest', /* ... */])
+    ->getPayum();
+
+// Both gateways will use the SAME $httpClient instance
+$stripe = $payum->getGateway('stripe');
+$paypal = $payum->getGateway('paypal');
+```
+
+### Per-Gateway Services (Per-Gateway Instance)
+
+Services defined in gateway-specific config are instantiated per gateway:
+
+```php
+<?php
+
+$payum = (new PayumBuilder())
+    ->addGateway('stripe1', [
+        'factory' => 'stripe_checkout',
+        'secret_key' => 'sk_test_account1',
+        // Each gateway has its own API client
+    ])
+    ->addGateway('stripe2', [
+        'factory' => 'stripe_checkout',
+        'secret_key' => 'sk_test_account2',
+        // Separate API client instance
+    ])
+    ->getPayum();
+```
+
+## Best Practices
+
+### 1. Use Type Hints
+
+Always use class names or interface names as service IDs:
+
+```php
+// ✅ Good
+->addGlobalService(LoggerInterface::class, $logger)
+
+// ❌ Avoid
+->addGlobalService('logger', $logger)
+```
+
+### 2. Prefer Interfaces Over Concrete Classes
+
+Use PSR interfaces when available:
+
+```php
+// ✅ Good - uses PSR-18
+->addGlobalService(ClientInterface::class, $client)
+
+// ❌ Avoid - couples to Guzzle
+->addGlobalService(GuzzleClient::class, $client)
+```
+
+### 3. Use Lazy Loading for Expensive Services
+
+Use closures for services that are expensive to create:
+
+```php
+// ✅ Good - lazy loaded
+->addGlobalService(ClientInterface::class, function () {
+    return new ExpensiveHttpClient();
+})
+
+// ❌ Avoid - created immediately even if never used
+->addGlobalService(ClientInterface::class, new ExpensiveHttpClient())
+```
+
+### 4. Document Custom Services
+
+When adding custom services, document them for your team:
+
+```php
+<?php
+
+// Custom services:
+// - AppLoggerInterface: Application logger with custom formatters
+// - AppCacheInterface: Redis-backed cache for API responses
+$payum = (new PayumBuilder())
+    ->addGlobalService(AppLoggerInterface::class, $logger)
+    ->addGlobalService(AppCacheInterface::class, $cache)
+    // ...
+```
+
+## Troubleshooting
+
+### Service Not Found
+
+If you get a "service not found" error:
+
+1. Check the service ID matches exactly (including namespace)
+2. Ensure you added the service before calling `getPayum()`
+3. Verify you're using the global container for shared services
+
+### Service Not Shared
+
+If services aren't being shared across gateways:
+
+1. Use `addGlobalService()` not gateway-specific config
+2. Check you're using the same service ID in both places
+
+### Circular Dependencies
+
+If you encounter circular dependency errors:
+
+1. Use `get()` references instead of direct instantiation
+2. Consider using setter injection for optional dependencies
+3. Refactor to break the circular dependency
+
+## See Also
+
+- [Getting Started](getting-started.md)
+- [Migration Guide](migration-guide.md)
+- [Framework Integration](framework-integration.md)

--- a/docs/di/framework-integration.md
+++ b/docs/di/framework-integration.md
@@ -104,14 +104,12 @@ services:
 
 ### Advanced: Using Symfony Container Directly
 
-Symfony's container is already PSR-11, so it can be handed to `setGlobalContainer()` directly. Note that
-this **replaces** Payum's global container: the container you pass must define Payum's own shared services
-(`GenericTokenFactoryInterface`, `HttpRequestVerifierInterface`, `payum.security.token_storage`, and the
-PSR-17/18 services if your gateways make HTTP calls). See
-[Pre-building the Global Container](customization.md#advanced-pre-building-the-global-container).
+Symfony's container is already PSR-11, so it can be handed to `setGlobalContainer()` directly. Your
+container is consulted first and Payum's own services fill in the rest, so you only declare what you want to
+control — see [Using Your Own Container](customization.md#advanced-using-your-own-container).
 
-Since Symfony service ids are strings rather than class names by default, an adapter is usually needed to
-map Payum's ids onto your services:
+Since Symfony service ids are strings rather than class names by default, an adapter is useful to map
+Payum's ids onto your services:
 
 ```php
 <?php
@@ -334,10 +332,12 @@ $payum = (new PayumBuilder())
     ->getPayum();
 ```
 
-Remember that a pre-built container replaces Payum's own, so `$yourContainer` must provide
-`GenericTokenFactoryInterface`, `HttpRequestVerifierInterface` and `payum.security.token_storage`
-(the last one can also come from `setTokenStorage()`). With an adapter around a non-PHP-DI container,
-those service ids are also the ones your gateways can resolve.
+`$yourContainer` only needs the services you want to provide yourself; Payum falls back to its own for
+everything else. Declare `payum.security.token_storage`, `TokenFactoryInterface`,
+`GenericTokenFactoryInterface` or `HttpRequestVerifierInterface` there to take over any of them.
+
+To have one of your own services injected into a gateway's actions, register it with `addGlobalService()`
+as well — Payum cannot discover the ids of a container that does not list its entries.
 
 ## Best Practices
 

--- a/docs/di/framework-integration.md
+++ b/docs/di/framework-integration.md
@@ -1,0 +1,446 @@
+# Framework Integration with Dependency Injection
+
+## Overview
+
+Payum v2.0's DI system can integrate with any PSR-11 compatible container, including Symfony, Laravel, and custom frameworks. This guide explains integration patterns.
+
+## Integration Strategy
+
+Payum v2.0 supports two integration approaches:
+
+1. **PayumBuilder with Custom Services** (Recommended for most cases)
+   - Use PayumBuilder's built-in PHP-DI container
+   - Inject framework services as global services
+   - Simple, framework-agnostic
+
+2. **Custom Container Integration** (Advanced)
+   - Provide your framework's container to PayumBuilder
+   - Full integration with framework DI
+   - Requires more setup
+
+## Symfony Integration
+
+### Using PayumBundle (Recommended)
+
+PayumBundle provides native Symfony integration:
+
+```php
+# config/packages/payum.yaml
+payum:
+    security:
+        token_storage:
+            App\Entity\PaymentToken: { doctrine: orm }
+
+    storages:
+        App\Entity\Payment: { doctrine: orm }
+
+    gateways:
+        stripe:
+            factory: stripe_checkout
+            publishable_key: '%env(STRIPE_PUBLISHABLE_KEY)%'
+            secret_key: '%env(STRIPE_SECRET_KEY)%'
+```
+
+### Using PayumBuilder with Symfony Services
+
+If not using PayumBundle, you can inject Symfony services:
+
+```php
+<?php
+
+namespace App\Service;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Payum\Core\Bridge\Doctrine\Storage\DoctrineStorage;
+use Payum\Core\Payum;
+use Payum\Core\PayumBuilder;
+use Psr\Log\LoggerInterface;
+
+class PayumFactory
+{
+    public function __construct(
+        private LoggerInterface $logger,
+        private EntityManagerInterface $em
+    ) {}
+
+    public function createPayum(): Payum
+    {
+        return (new PayumBuilder())
+            // Inject Symfony services as global services
+            ->addGlobalService(LoggerInterface::class, $this->logger)
+            ->addGlobalService(EntityManagerInterface::class, $this->em)
+
+            // Use Doctrine storage
+            ->setTokenStorage(new DoctrineStorage(
+                $this->em,
+                'App\Entity\PaymentToken'
+            ))
+
+            // Configure gateways
+            ->addGateway('stripe', [
+                'factory' => 'stripe_checkout',
+                'publishable_key' => $_ENV['STRIPE_PUBLISHABLE_KEY'],
+                'secret_key' => $_ENV['STRIPE_SECRET_KEY'],
+            ])
+
+            ->getPayum();
+    }
+}
+```
+
+Register as a service:
+
+```yaml
+# config/services.yaml
+services:
+    App\Service\PayumFactory:
+        arguments:
+            $logger: '@logger'
+            $em: '@doctrine.orm.entity_manager'
+
+    Payum\Core\Payum:
+        factory: ['@App\Service\PayumFactory', 'createPayum']
+```
+
+### Advanced: Using Symfony Container Directly
+
+Symfony's container is already PSR-11, so it can be handed to `setGlobalContainer()` directly. Note that
+this **replaces** Payum's global container: the container you pass must define Payum's own shared services
+(`GenericTokenFactoryInterface`, `HttpRequestVerifierInterface`, `payum.security.token_storage`, and the
+PSR-17/18 services if your gateways make HTTP calls). See
+[Pre-building the Global Container](customization.md#advanced-pre-building-the-global-container).
+
+Since Symfony service ids are strings rather than class names by default, an adapter is usually needed to
+map Payum's ids onto your services:
+
+```php
+<?php
+
+namespace App\DependencyInjection;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
+
+class PayumContainerAdapter implements ContainerInterface
+{
+    public function __construct(
+        private SymfonyContainerInterface $symfonyContainer
+    ) {}
+
+    public function get(string $id)
+    {
+        return $this->symfonyContainer->get($id);
+    }
+
+    public function has(string $id): bool
+    {
+        return $this->symfonyContainer->has($id);
+    }
+}
+
+// In your factory
+$payum = (new PayumBuilder())
+    ->setGlobalContainer(new PayumContainerAdapter($container))
+    ->getPayum();
+```
+
+For most applications the `addGlobalService()` approach shown above is simpler and does not require you to
+re-declare Payum's own services.
+
+## Laravel Integration
+
+### Using Service Provider
+
+Create a Payum service provider:
+
+```php
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Payum\Core\PayumBuilder;
+use Payum\Core\Payum;
+use Psr\Log\LoggerInterface;
+
+class PayumServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->singleton(Payum::class, function ($app) {
+            return (new PayumBuilder())
+                // Inject Laravel services
+                ->addGlobalService(
+                    LoggerInterface::class,
+                    $app->make(LoggerInterface::class)
+                )
+
+                // Use Eloquent storage (custom implementation)
+                ->setTokenStorage(new EloquentTokenStorage())
+
+                // Configure gateways
+                ->addGateway('stripe', [
+                    'factory' => 'stripe_checkout',
+                    'publishable_key' => config('payum.gateways.stripe.publishable_key'),
+                    'secret_key' => config('payum.gateways.stripe.secret_key'),
+                ])
+
+                ->getPayum();
+        });
+    }
+}
+```
+
+Register in `config/app.php`:
+
+```php
+'providers' => [
+    // ...
+    App\Providers\PayumServiceProvider::class,
+],
+```
+
+### Configuration File
+
+Create `config/payum.php`:
+
+```php
+<?php
+
+return [
+    'gateways' => [
+        'stripe' => [
+            'publishable_key' => env('STRIPE_PUBLISHABLE_KEY'),
+            'secret_key' => env('STRIPE_SECRET_KEY'),
+        ],
+    ],
+];
+```
+
+### Using in Controllers
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use Payum\Core\Payum;
+use Illuminate\Http\Request;
+
+class PaymentController extends Controller
+{
+    public function __construct(
+        private Payum $payum
+    ) {}
+
+    public function prepare(Request $request)
+    {
+        $gateway = $this->payum->getGateway('stripe');
+
+        $payment = new \App\Models\Payment();
+        $payment->total_amount = $request->input('amount');
+        $payment->currency_code = 'USD';
+        $payment->description = 'Order #' . $request->input('order_id');
+
+        $this->payum->getStorage('App\Models\Payment')->update($payment);
+
+        $token = $this->payum->getTokenFactory()->createCaptureToken(
+            'stripe',
+            $payment,
+            route('payment.done')
+        );
+
+        return redirect($token->getTargetUrl());
+    }
+}
+```
+
+## Plain PHP Integration
+
+For frameworks without native DI:
+
+```php
+<?php
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+use Payum\Core\PayumBuilder;
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+
+// Create your services
+$logger = new Logger('payum');
+$logger->pushHandler(new StreamHandler('/var/log/payum.log'));
+
+// Build Payum with custom services
+$payum = (new PayumBuilder())
+    ->addDefaultStorages()
+
+    // Add custom services
+    ->addGlobalService(\Psr\Log\LoggerInterface::class, $logger)
+
+    // Configure gateways
+    ->addGateway('stripe', [
+        'factory' => 'stripe_checkout',
+        'publishable_key' => getenv('STRIPE_PUBLISHABLE_KEY'),
+        'secret_key' => getenv('STRIPE_SECRET_KEY'),
+    ])
+
+    ->getPayum();
+
+// Use Payum
+$gateway = $payum->getGateway('stripe');
+```
+
+## Custom Framework Integration
+
+### Step 1: Create Container Adapter (Optional)
+
+If you want full container integration:
+
+```php
+<?php
+
+namespace App\Payum;
+
+use Psr\Container\ContainerInterface;
+
+class CustomContainerAdapter implements ContainerInterface
+{
+    public function __construct(
+        private YourFrameworkContainer $container
+    ) {}
+
+    public function get(string $id)
+    {
+        return $this->container->get($id);
+    }
+
+    public function has(string $id): bool
+    {
+        return $this->container->has($id);
+    }
+}
+```
+
+### Step 2: Configure Payum
+
+```php
+<?php
+
+$payum = (new PayumBuilder())
+    ->setGlobalContainer(new CustomContainerAdapter($yourContainer))
+    // ... configure gateways
+    ->getPayum();
+```
+
+Remember that a pre-built container replaces Payum's own, so `$yourContainer` must provide
+`GenericTokenFactoryInterface`, `HttpRequestVerifierInterface` and `payum.security.token_storage`
+(the last one can also come from `setTokenStorage()`). With an adapter around a non-PHP-DI container,
+those service ids are also the ones your gateways can resolve.
+
+## Best Practices
+
+### 1. Singleton Registration
+
+Register Payum as a singleton in your container:
+
+```php
+// Symfony
+services:
+    Payum\Core\Payum:
+        factory: ['@App\Service\PayumFactory', 'create']
+        shared: true
+
+// Laravel
+$this->app->singleton(Payum::class, function($app) { ... });
+```
+
+### 2. Environment-Specific Configuration
+
+Use environment variables for gateway credentials:
+
+```php
+// .env
+STRIPE_PUBLISHABLE_KEY=pk_test_...
+STRIPE_SECRET_KEY=sk_test_...
+
+// Configuration
+->addGateway('stripe', [
+    'factory' => 'stripe_checkout',
+    'publishable_key' => getenv('STRIPE_PUBLISHABLE_KEY'),
+    'secret_key' => getenv('STRIPE_SECRET_KEY'),
+])
+```
+
+### 3. Storage Configuration
+
+Use framework-native storage:
+
+```php
+// Symfony/Doctrine
+->setTokenStorage(new DoctrineStorage($em, PaymentToken::class))
+
+// Laravel/Eloquent (custom implementation)
+->setTokenStorage(new EloquentTokenStorage())
+```
+
+### 4. Logging Integration
+
+Inject framework logger:
+
+```php
+->addGlobalService(LoggerInterface::class, $frameworkLogger)
+```
+
+### 5. HTTP Client Sharing
+
+Share framework HTTP client:
+
+```php
+use Psr\Http\Client\ClientInterface;
+
+->addGlobalService(ClientInterface::class, $frameworkHttpClient)
+```
+
+## Troubleshooting
+
+### Service Not Found
+
+**Problem:** Container can't find a service
+
+**Solution:** Ensure service is registered in global container:
+
+```php
+->addGlobalService(YourService::class, $serviceInstance)
+```
+
+### Circular Dependency
+
+**Problem:** Circular dependency detected
+
+**Solution:** Use lazy loading:
+
+```php
+->addGlobalService(YourService::class, fn() => new YourService($dep))
+```
+
+### Gateway Not Using Custom Service
+
+**Problem:** Gateway doesn't use overridden service
+
+**Solution:** Add service BEFORE configuring gateways:
+
+```php
+$payum = (new PayumBuilder())
+    ->addGlobalService(ClientInterface::class, $customClient)  // First
+    ->addGateway('stripe', [...])  // Then
+    ->getPayum();
+```
+
+## See Also
+
+- [Getting Started](getting-started.md)
+- [Customization Guide](customization.md)
+- [Migration Guide](migration-guide.md)
+- [Symfony PayumBundle Documentation](https://github.com/Payum/PayumBundle/blob/master/docs/index.md)

--- a/docs/di/getting-started.md
+++ b/docs/di/getting-started.md
@@ -155,7 +155,12 @@ Each gateway container is assembled from three layers. Later layers win:
 2. The shared services listed above (so a global service always wins over a factory default)
 3. The config passed to `addGateway()` (so a single gateway can override anything)
 
-Anything not defined in any of those layers is autowired by PHP-DI.
+Anything not defined in any of those layers is looked up in the global container, and otherwise autowired
+by PHP-DI.
+
+If you gave Payum a container of your own with `setGlobalContainer()`, that container sits in front of the
+global one: your services win, and Payum's defaults fill in whatever you did not provide. See
+[Using Your Own Container](customization.md#advanced-using-your-own-container).
 
 ## Writing a Gateway Factory
 

--- a/docs/di/getting-started.md
+++ b/docs/di/getting-started.md
@@ -1,0 +1,269 @@
+# Dependency Injection - Getting Started
+
+## Overview
+
+Starting with Payum v2.0, the library uses a modern dependency injection (DI) container system powered by [PHP-DI 7.0](https://php-di.org/). This replaces the old ArrayObject-based configuration with a more maintainable, type-safe approach.
+
+## Key Benefits
+
+- **Type Safety**: Services are properly typed and autowired
+- **Shared Services**: HTTP clients and other services are shared across all gateways
+- **Customization**: Easy to override default services or add your own
+- **Framework Integration**: Compatible with Symfony, Laravel, and other frameworks
+- **Performance**: Services are lazy-loaded and reused where appropriate
+
+## Architecture Overview
+
+Payum v2.0 uses a **hybrid container architecture**:
+
+```
+┌─────────────────────────────────────────────┐
+│     Global Container (Payum-wide)           │
+│  - HttpRequestVerifier                      │
+│  - GenericTokenFactory                      │
+│  - TokenFactory                             │
+│  - TokenStorage                             │
+│  - Storage Extensions                       │
+│  - PSR-18 HTTP Client (shared)              │
+│  - PSR-17 Factories                         │
+│  - Anything from addGlobalService()         │
+└──────────────┬──────────────────────────────┘
+               │ delegated to
+        ┌──────┼──────┬──────┐
+        ▼      ▼      ▼      ▼
+    ┌────────┬───────┬───────┬────────┐
+    │Gateway │Gateway│Gateway│Gateway │
+    │stripe  │paypal │offline│custom  │
+    └────────┴───────┴───────┴────────┘
+```
+
+- **Global Container**: Holds services shared across all gateways (HTTP client, token storage, etc.)
+- **Per-Gateway Containers**: One container per gateway, holding the gateway's own services (API clients,
+  actions, configuration). The shared services are available here too — asking a gateway container for, say,
+  the PSR-18 client gives you the one and only instance from the global container.
+
+## Basic Usage
+
+### Using PayumBuilder (Recommended)
+
+The easiest way to use Payum with DI is through the `PayumBuilder`:
+
+```php
+<?php
+
+use Payum\Core\PayumBuilder;
+
+$payum = (new PayumBuilder())
+    ->addDefaultStorages()
+
+    ->addGateway('stripe', [
+        'factory' => 'stripe_checkout',
+        'publishable_key' => 'pk_test_...',
+        'secret_key' => 'sk_test_...',
+    ])
+
+    ->addGateway('paypal', [
+        'factory' => 'paypal_rest',
+        'client_id' => 'your-client-id',
+        'client_secret' => 'your-client-secret',
+        'sandbox' => true,
+    ])
+
+    ->getPayum();
+
+// Use the gateway
+$gateway = $payum->getGateway('stripe');
+$gateway->execute(new Capture($payment));
+```
+
+### Adding Global Services
+
+You can add services that will be available to all gateways:
+
+```php
+<?php
+
+use Psr\Log\LoggerInterface;
+use Monolog\Logger;
+
+$logger = new Logger('payum');
+
+$payum = (new PayumBuilder())
+    ->addDefaultStorages()
+
+    // Add a global service
+    ->addGlobalService(LoggerInterface::class, $logger)
+
+    ->addGateway('stripe', [
+        'factory' => 'stripe_checkout',
+        // ... config
+    ])
+
+    ->getPayum();
+```
+
+### Overriding Default Services
+
+You can override default services like the HTTP client:
+
+```php
+<?php
+
+use Psr\Http\Client\ClientInterface;
+
+$customHttpClient = new MyCustomHttpClient();
+
+$payum = (new PayumBuilder())
+    ->addDefaultStorages()
+
+    // Override the default HTTP client
+    ->addGlobalService(ClientInterface::class, $customHttpClient)
+
+    ->addGateway('stripe', ['factory' => 'stripe_checkout', /* ... */])
+    ->getPayum();
+```
+
+## Understanding the Container System
+
+### Global Services
+
+These services are instantiated once and shared across all gateways:
+
+- `payum.security.token_storage` - Token storage
+- `HttpRequestVerifierInterface` - Verifies security tokens
+- `GenericTokenFactoryInterface` - Creates payment tokens
+- `TokenFactoryInterface` - Low-level token factory
+- `ClientInterface` (PSR-18) - HTTP client
+- `StreamFactoryInterface` (PSR-17) - HTTP stream factory
+- `RequestFactoryInterface` (PSR-17) - HTTP request factory
+- Storage extensions for all registered models
+- Every service registered with `addGlobalService()`
+
+### Per-Gateway Services
+
+These services are specific to each gateway:
+
+- API client classes (e.g., `Stripe\Api\Keys`)
+- Action classes (e.g., `CaptureAction`, `StatusAction`)
+- Gateway-specific configuration
+
+### Service Resolution Order
+
+Each gateway container is assembled from three layers. Later layers win:
+
+1. The gateway factory's `configureContainer()` definitions (the factory's own defaults)
+2. The shared services listed above (so a global service always wins over a factory default)
+3. The config passed to `addGateway()` (so a single gateway can override anything)
+
+Anything not defined in any of those layers is autowired by PHP-DI.
+
+## Writing a Gateway Factory
+
+A gateway factory declares the services its gateway needs and which of them are actions and extensions.
+Extend `CoreGatewayFactory` and override the methods you care about:
+
+```php
+<?php
+
+use Payum\Core\CoreGatewayFactory;
+use function DI\autowire;
+use function DI\get;
+
+class MyGatewayFactory extends CoreGatewayFactory
+{
+    public function configureContainer(): array
+    {
+        return array_merge(parent::configureContainer(), [
+            'my_gateway.client_id' => '',
+            'my_gateway.secret' => '',
+
+            Api::class => autowire()
+                ->constructor(
+                    get('my_gateway.client_id'),
+                    get('my_gateway.secret')
+                ),
+
+            CaptureAction::class => autowire(),
+            StatusAction::class => autowire(),
+        ]);
+    }
+
+    public function getActions(): array
+    {
+        return array_merge(parent::getActions(), [
+            CaptureAction::class,
+            StatusAction::class,
+        ]);
+    }
+}
+```
+
+`CoreGatewayFactory` already implements `ContainerConfiguration`, so extending it is enough — there is no
+need to add `implements ContainerConfiguration` yourself.
+
+### Extension Points
+
+| Method | Purpose |
+|---|---|
+| `configureContainer(): array` | Return the PHP-DI definitions for the gateway (config values, API classes, actions). |
+| `getActions(): array` | Return the **class names** of the actions to register on the gateway, in order. |
+| `getExtensions(): array` | Return the extensions to register on the gateway. |
+
+`createGateway()` resolves everything `getActions()` and `getExtensions()` return from the container and
+registers it on a fresh `Gateway`. Actions must be given as class strings; extensions may be either class
+strings or ready-made instances.
+
+Actions and extensions are appended in the order returned. If a service has to run *before* everything
+else, mark its class with `Payum\Core\Action\PrependActionInterface` or
+`Payum\Core\Extension\PrependExtensionInterface` and it will be prepended instead:
+
+```php
+<?php
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Action\PrependActionInterface;
+
+class MyEarlyAction implements ActionInterface, PrependActionInterface
+{
+    // ... always consulted before the actions registered ahead of it
+}
+```
+
+You only need to override `createGateway()` when you have to do something to the `Gateway` itself that
+`getActions()`/`getExtensions()` cannot express.
+
+### Registering the Factory
+
+Register the factory under a name, then reference that name from `addGateway()`:
+
+```php
+<?php
+
+$payum = (new PayumBuilder())
+    ->addDefaultStorages()
+    ->addGatewayFactory('my_gateway', new MyGatewayFactory())
+    ->addGateway('mine', [
+        'factory' => 'my_gateway',
+
+        // These override the defaults declared in configureContainer()
+        'my_gateway.client_id' => 'theClientId',
+        'my_gateway.secret' => 'theSecret',
+    ])
+    ->getPayum();
+```
+
+Coming from Payum v1.x? The [Migration Guide](migration-guide.md) shows how the old `populateConfig()`
+style maps onto this one.
+
+## Next Steps
+
+- [Customization Guide](customization.md) - Learn how to customize services
+- [Migration Guide](migration-guide.md) - Migrate your code from v1.x to v2.0
+- [Framework Integration](framework-integration.md) - Integrate with Symfony/Laravel
+- [The Architecture](../the-architecture.md) - Deep dive into Payum's architecture
+
+## Need Help?
+
+- 📖 [Full Documentation](https://payum.gitbook.io/payum/)
+- 🐛 [Report Issues](https://github.com/Payum/Payum/issues)
+- 💬 [Community Support](https://github.com/Payum/Payum/discussions)

--- a/docs/di/migration-guide.md
+++ b/docs/di/migration-guide.md
@@ -1,0 +1,443 @@
+# Migration Guide: v1.x to v2.0
+
+## Overview
+
+Payum v2.0 introduces a modern dependency injection (DI) container system. This guide helps you migrate your code from the old ArrayObject-based configuration to the new DI-based approach.
+
+**Good news:** Your existing code will continue to work in v2.0! The old pattern is deprecated but still functional, giving you time to migrate gradually.
+
+## Migration Timeline
+
+- **v2.0 (current)**: Both the old and the new pattern work
+- **v3.0**: The old pattern is removed — see [Deprecated APIs](#deprecated-apis) for the full list
+
+## For PayumBuilder Users
+
+If you're using `PayumBuilder` (the recommended approach), you typically don't need to change anything. Your code will work as-is:
+
+```php
+<?php
+
+// This still works in v2.0!
+$payum = (new PayumBuilder())
+    ->addDefaultStorages()
+    ->addGateway('stripe', [
+        'factory' => 'stripe_checkout',
+        'publishable_key' => 'pk_test_...',
+        'secret_key' => 'sk_test_...',
+    ])
+    ->getPayum();
+```
+
+### Optional: Use New DI Features
+
+Take advantage of new DI features like global services:
+
+```php
+<?php
+
+use Psr\Log\LoggerInterface;
+
+$payum = (new PayumBuilder())
+    ->addDefaultStorages()
+
+    // NEW: Add global services
+    ->addGlobalService(LoggerInterface::class, $logger)
+
+    // NEW: Override default HTTP client
+    ->addGlobalService(ClientInterface::class, $customHttpClient)
+
+    ->addGateway('stripe', ['factory' => 'stripe_checkout', /* ... */])
+    ->getPayum();
+```
+
+## For Custom Gateway Factory Authors
+
+If you've created custom gateway factories, extend `CoreGatewayFactory` and move your configuration into
+`configureContainer()`, `getActions()` and `getExtensions()`.
+
+### Before (v1.x Pattern)
+
+```php
+<?php
+
+namespace App\Payment;
+
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\GatewayFactory;
+
+class MyGatewayFactory extends GatewayFactory
+{
+    protected function populateConfig(ArrayObject $config): void
+    {
+        $config->defaults([
+            'payum.factory_name' => 'my_gateway',
+            'payum.factory_title' => 'My Gateway',
+
+            'payum.action.capture' => new CaptureAction(),
+            'payum.action.status' => new StatusAction(),
+
+            'payum.api' => function (ArrayObject $config) {
+                $config->validateNotEmpty(['client_id', 'client_secret']);
+
+                return new Api(
+                    $config['client_id'],
+                    $config['client_secret'],
+                    $config['sandbox'] ?? true
+                );
+            },
+        ]);
+
+        if (! $config['payum.api']) {
+            $config['payum.api'] = function (ArrayObject $config) {
+                $config->validateNotEmpty(['client_id', 'client_secret']);
+
+                return new Api(
+                    $config['client_id'],
+                    $config['client_secret'],
+                    $config['sandbox'] ?? true
+                );
+            };
+        }
+
+        $config['payum.paths'] = array_replace([
+            'PayumMyGateway' => __DIR__ . '/Resources/views',
+        ], $config['payum.paths'] ?: []);
+    }
+}
+```
+
+### After (v2.0 Pattern)
+
+```php
+<?php
+
+namespace App\Payment;
+
+use Payum\Core\CoreGatewayFactory;
+use function DI\autowire;
+use function DI\get;
+
+class MyGatewayFactory extends CoreGatewayFactory
+{
+    public function configureContainer(): array
+    {
+        return array_merge(parent::configureContainer(), [
+            // Configuration values
+            'my_gateway.client_id' => '',
+            'my_gateway.client_secret' => '',
+            'my_gateway.sandbox' => true,
+
+            // API class with dependency injection
+            Api::class => autowire()
+                ->constructor(
+                    clientId: get('my_gateway.client_id'),
+                    clientSecret: get('my_gateway.client_secret'),
+                    sandbox: get('my_gateway.sandbox')
+                ),
+
+            // Actions with autowiring
+            CaptureAction::class => autowire()
+                ->constructorParameter('api', get(Api::class)),
+
+            StatusAction::class => autowire()
+                ->constructorParameter('api', get(Api::class)),
+
+            // Template paths. Merge, do not replace, so that paths registered elsewhere survive.
+            'payum.paths' => array_merge(
+                parent::configureContainer()['payum.paths'] ?? [],
+                [
+                    'PayumMyGateway' => __DIR__ . '/Resources/views',
+                ]
+            ),
+        ]);
+    }
+
+    public function getActions(): array
+    {
+        return array_merge(parent::getActions(), [
+            CaptureAction::class,
+            StatusAction::class,
+        ]);
+    }
+}
+```
+
+Two things worth noting:
+
+- `CoreGatewayFactory` already implements `ContainerConfiguration`, so `extends CoreGatewayFactory` is
+  enough — you do not have to repeat `implements ContainerConfiguration`.
+- `populateConfig()` is replaced by `configureContainer()`. Drop it; there is nothing to keep for
+  backwards compatibility.
+
+### Registering the Factory
+
+Register the factory under a name and reference that name from `addGateway()`:
+
+```php
+<?php
+
+$payum = (new PayumBuilder())
+    ->addDefaultStorages()
+    ->addGatewayFactory('my_gateway', new MyGatewayFactory())
+    ->addGateway('mine', [
+        'factory' => 'my_gateway',
+
+        // These override the defaults declared in configureContainer()
+        'my_gateway.client_id' => 'theClientId',
+        'my_gateway.client_secret' => 'theClientSecret',
+        'my_gateway.sandbox' => false,
+    ])
+    ->getPayum();
+```
+
+## Key Changes
+
+### 1. Extend `CoreGatewayFactory` Instead of `GatewayFactory`
+
+```php
+// Before
+class MyGatewayFactory extends GatewayFactory
+
+// After — CoreGatewayFactory already implements ContainerConfiguration
+class MyGatewayFactory extends CoreGatewayFactory
+```
+
+### 2. Implement `configureContainer()` Instead of `populateConfig()`
+
+```php
+// Before
+protected function populateConfig(ArrayObject $config): void
+
+// After
+public function configureContainer(): array
+```
+
+### 3. Use `configureContainer()` Return Array, Not ArrayObject Mutation
+
+```php
+// Before
+$config->defaults(['key' => 'value']);
+
+// After
+return array_merge(parent::configureContainer(), [
+    'key' => 'value',
+]);
+```
+
+### 4. Use Dependency Injection Instead of Closures
+
+```php
+// Before
+'payum.api' => function (ArrayObject $config) {
+    return new Api($config['client_id'], $config['client_secret']);
+}
+
+// After
+Api::class => autowire()
+    ->constructor(
+        get('my_gateway.client_id'),
+        get('my_gateway.client_secret')
+    )
+```
+
+### 5. Return Your Actions From `getActions()`
+
+```php
+// Before
+// Actions were automatically added from 'payum.action.*' keys
+
+// After — return class names; createGateway() resolves and registers them for you
+public function getActions(): array
+{
+    return array_merge(parent::getActions(), [
+        CaptureAction::class,
+        StatusAction::class,
+    ]);
+}
+```
+
+`getActions()` must return **class strings**, not instances — each one is resolved from the container so
+that its dependencies get injected. `getExtensions()` works the same way, but also accepts ready-made
+extension instances.
+
+Actions are registered in the order returned. To have one consulted first regardless of position,
+implement `Payum\Core\Action\PrependActionInterface` on it (or
+`Payum\Core\Extension\PrependExtensionInterface` for an extension).
+
+Override `createGateway()` only when you need to do something to the `Gateway` object itself that these two
+methods cannot express.
+
+## For Action Authors
+
+### Before (ApiAwareInterface - Deprecated)
+
+```php
+<?php
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\ApiAwareInterface;
+use Payum\Core\ApiAwareTrait;
+
+class CaptureAction implements ActionInterface, ApiAwareInterface
+{
+    use ApiAwareTrait;
+
+    public function __construct()
+    {
+        $this->apiClass = Api::class;
+    }
+
+    public function execute($request): void
+    {
+        $this->api->capturePayment(/* ... */);
+    }
+}
+```
+
+### After (Constructor Injection - Recommended)
+
+```php
+<?php
+
+use Payum\Core\Action\ActionInterface;
+
+class CaptureAction implements ActionInterface
+{
+    public function __construct(
+        private readonly Api $api
+    ) {}
+
+    public function execute($request): void
+    {
+        $this->api->capturePayment(/* ... */);
+    }
+
+    public function supports($request): bool
+    {
+        return $request instanceof Capture;
+    }
+}
+```
+
+## Deprecated APIs
+
+The following are deprecated and will be removed in v3.0. Everything still works until then, so you can
+migrate at your own pace.
+
+| Deprecated | Replacement |
+|---|---|
+| `GatewayFactory` as the base class for a gateway factory | `CoreGatewayFactory` |
+| `GatewayFactory::populateConfig()` | `configureContainer()` |
+| `GatewayFactoryInterface::createConfig()` | `configureContainer()` |
+| `GatewayFactoryInterface::create()` | `createGateway()` |
+| `'payum.action.*'` and `'payum.extension.*'` config keys | `getActions()` and `getExtensions()` |
+| `'payum.api.*'` config keys and `ApiAwareInterface` | Constructor injection (see [For Action Authors](#for-action-authors)) |
+| `'httplug.client'` | `Psr\Http\Client\ClientInterface` |
+| `'httplug.stream_factory'` | `Psr\Http\Message\StreamFactoryInterface` |
+| `'httplug.message_factory'` | `Psr\Http\Message\RequestFactoryInterface` |
+| `Payum\Core\Bridge\Spl\ArrayObject` as a service | `Psr\Container\ContainerInterface` |
+
+## Testing Your Migration
+
+### 1. Run Existing Tests
+
+```bash
+bin/phpunit
+```
+
+Your existing tests should keep passing.
+
+### 2. Test New Features
+
+Add tests for new DI features:
+
+```php
+<?php
+
+class PayumBuilderTest extends TestCase
+{
+    public function testGlobalServices(): void
+    {
+        $logger = new NullLogger();
+
+        $payum = (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addGlobalService(LoggerInterface::class, $logger)
+            ->addGateway('offline', ['factory' => 'offline'])
+            ->getPayum();
+
+        // Verify gateway was created successfully
+        $this->assertInstanceOf(GatewayInterface::class, $payum->getGateway('offline'));
+    }
+}
+```
+
+## Common Migration Issues
+
+### Issue: "Service not found"
+
+**Cause:** Service ID doesn't match
+
+**Solution:** Use fully-qualified class names:
+
+```php
+// Wrong
+get('Api')
+
+// Correct
+get(Api::class)
+```
+
+### Issue: "Circular dependency detected"
+
+**Cause:** Services depend on each other
+
+**Solution:** Use `get()` for lazy resolution:
+
+```php
+// Wrong - creates instance immediately
+MyService::class => new MyService($container->get(OtherService::class))
+
+// Correct - lazy resolution
+MyService::class => autowire()
+    ->constructor(get(OtherService::class))
+```
+
+### Issue: Actions not receiving API
+
+**Cause:** Forgot to inject API in `configureContainer()`
+
+**Solution:** Add constructor parameter in action definition:
+
+```php
+CaptureAction::class => autowire()
+    ->constructorParameter('api', get(Api::class))
+```
+
+## Need Help?
+
+- 📖 [DI Getting Started Guide](getting-started.md)
+- 📖 [DI Customization Guide](customization.md)
+- 🐛 [Report Issues](https://github.com/Payum/Payum/issues)
+- 💬 [Community Discussions](https://github.com/Payum/Payum/discussions)
+
+## Summary Checklist
+
+For custom gateway factories:
+
+- [ ] Extend `CoreGatewayFactory` instead of `GatewayFactory` (it implements `ContainerConfiguration` already)
+- [ ] Move the config from `populateConfig()` into `configureContainer()`
+- [ ] Return your action class names from `getActions()` (and extensions from `getExtensions()`)
+- [ ] Use `autowire()` and `get()` for dependencies
+- [ ] Drop `populateConfig()` — `configureContainer()` replaces it
+- [ ] Update actions to use constructor injection
+- [ ] Run tests and verify no errors
+- [ ] Check for and address deprecation warnings
+
+For PayumBuilder users:
+
+- [ ] Optionally add global services with `addGlobalService()`
+- [ ] Optionally override default services
+- [ ] Run tests and verify everything works
+- [ ] Consider using new DI features for better customization

--- a/src/Payum/Core/Action/PrependActionInterface.php
+++ b/src/Payum/Core/Action/PrependActionInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Payum\Core\Action;
+
+interface PrependActionInterface
+{
+}

--- a/src/Payum/Core/CoreGatewayFactory.php
+++ b/src/Payum/Core/CoreGatewayFactory.php
@@ -2,12 +2,15 @@
 
 namespace Payum\Core;
 
+use DI\ContainerBuilder;
+use Exception;
 use GuzzleHttp\Psr7\Request;
 use Http\Adapter\Buzz\Client as HttpBuzzClient;
 use Http\Adapter\Guzzle5\Client as HttpGuzzle5Client;
 use Http\Adapter\Guzzle6\Client as HttpGuzzle6Client;
 use Http\Adapter\Guzzle7\Client as HttpGuzzle7Client;
 use Http\Client\Curl\Client as HttpCurlClient;
+use Http\Client\HttpClient;
 use Http\Client\Socket\Client as HttpSocketClient;
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\MessageFactoryDiscovery;
@@ -26,21 +29,39 @@ use Payum\Core\Action\ExecuteSameRequestWithModelDetailsAction;
 use Payum\Core\Action\GetCurrencyAction;
 use Payum\Core\Action\GetTokenAction;
 use Payum\Core\Action\PayoutPayoutAction;
+use Payum\Core\Action\PrependActionInterface;
 use Payum\Core\Bridge\Httplug\HttplugClient;
 use Payum\Core\Bridge\PlainPhp\Action\GetHttpRequestAction;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Bridge\Twig\Action\RenderTemplateAction;
 use Payum\Core\Bridge\Twig\TwigUtil;
+use Payum\Core\DI\ContainerConfiguration;
 use Payum\Core\Extension\EndlessCycleDetectorExtension;
+use Payum\Core\Extension\PrependExtensionInterface;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Symfony\Component\HttpClient\HttplugClient as SymfonyHttplugClient;
 use Twig\Environment;
+use Twig\Error\LoaderError;
 use Twig\Loader\ChainLoader;
+use function array_combine;
+use function array_map;
+use function array_merge;
+use function class_exists;
+use function DI\autowire;
+use function DI\get;
+use function in_array;
+use function is_string;
+use function sprintf;
 use function trigger_error;
 use const E_USER_DEPRECATED;
 
-class CoreGatewayFactory implements GatewayFactoryInterface
+class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfiguration, GatewayFactoryConfigInterface
 {
     /**
      * @var array<string, mixed>
@@ -57,15 +78,26 @@ class CoreGatewayFactory implements GatewayFactoryInterface
 
     /**
      * @param array<string, mixed> $config
+     *
+     * @throws ContainerExceptionInterface | NotFoundExceptionInterface | Exception
      */
     public function create(array $config = []): Gateway
     {
-        $config = ArrayObject::ensureArrayObject($config);
-        $config->defaults($this->createConfig());
+        @trigger_error(sprintf('The %s is deprecated since 2.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class), E_USER_DEPRECATED);
 
-        $gateway = new Gateway();
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->addDefinitions($config);
 
-        $this->buildClosures($config);
+        $container = $containerBuilder->build();
+
+        $gateway = $this->createGateway($container);
+
+        $entries = $container->getKnownEntryNames();
+
+        $config = ArrayObject::ensureArrayObject(array_combine(
+            $entries,
+            array_map(static fn (string $name) => $container->get($name), $entries)
+        ));
 
         $this->buildActions($gateway, $config);
         $this->buildApis($gateway, $config);
@@ -81,137 +113,184 @@ class CoreGatewayFactory implements GatewayFactoryInterface
      */
     public function createConfig(array $config = []): array
     {
-        $config = ArrayObject::ensureArrayObject($config);
-        $config->defaults($this->defaultConfig);
+        @trigger_error(sprintf('The %s is deprecated since 2.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class), E_USER_DEPRECATED);
 
-        $config->defaults([
-            'httplug.message_factory' => static function (ArrayObject $config): MessageFactory {
-                @trigger_error('Using "httplug.message_factory" is deprecated, use "payum.http_message_factory" instead, which will return a PSR-17 RequestFactoryInterface since payum/core 2.0.0', E_USER_DEPRECATED);
-
-                if (class_exists(MessageFactoryDiscovery::class)) {
-                    return MessageFactoryDiscovery::find();
-                }
-
-                if (class_exists(Request::class)) {
-                    return new GuzzleMessageFactory();
-                }
-
-                if (class_exists(\Laminas\Diactoros\Request::class)) {
-                    return new DiactorosMessageFactory();
-                }
-
-                if (class_exists(\Nyholm\Psr7\Request::class)) {
-                    return new HttplugFactory();
-                }
-
-                throw new LogicException('The httplug.message_factory could not be guessed. Install one of the following packages: php-http/guzzle7-adapter. You can also overwrite the config option with your implementation.');
-            },
-            'httplug.stream_factory' => static function (ArrayObject $config) {
-                @trigger_error('Using "httplug.stream_factory" is deprecated, use "payum.http_stream_factory" instead which will return a PSR-17 StreamFactoryInterface since payum/core 2.0.0', E_USER_DEPRECATED);
-                if (class_exists(StreamFactoryDiscovery::class)) {
-                    return StreamFactoryDiscovery::find();
-                }
-
-                if (class_exists(Request::class)) {
-                    return new GuzzleStreamFactory();
-                }
-
-                if (class_exists(\Nyholm\Psr7\Request::class)) {
-                    return new HttplugFactory();
-                }
-
-                throw new LogicException('The httplug.stream_factory could not be guessed. Install one of the following packages: php-http/guzzle7-adapter. You can also overwrite the config option with your implementation.');
-            },
-            'httplug.client' => static function (ArrayObject $config) {
-                @trigger_error('Using "httplug.client" is deprecated, use "payum.http_client" instead which will return a PSR-18 ClientInterface since payum/core 2.0.0', E_USER_DEPRECATED);
-
-                if (class_exists(HttpClientDiscovery::class)) {
-                    return HttpClientDiscovery::find();
-                }
-
-                if (class_exists(HttpGuzzle7Client::class)) {
-                    return new HttpGuzzle7Client();
-                }
-
-                if (class_exists(HttpGuzzle6Client::class)) {
-                    return new HttpGuzzle6Client();
-                }
-
-                if (class_exists(HttpGuzzle5Client::class)) {
-                    return new HttpGuzzle5Client();
-                }
-
-                if (class_exists(SymfonyHttplugClient::class)) {
-                    return new SymfonyHttplugClient();
-                }
-
-                if (class_exists(HttpSocketClient::class)) {
-                    return new HttpSocketClient();
-                }
-
-                if (class_exists(HttpCurlClient::class)) {
-                    return new HttpCurlClient($config['httplug.message_factory'], $config['httplug.stream_factory']);
-                }
-
-                if (class_exists(HttpBuzzClient::class)) {
-                    return new HttpBuzzClient();
-                }
-
-                throw new LogicException('The httplug.client could not be guessed. Install one of the following packages: php-http/guzzle7-adapter, php-http/guzzle7-adapter. You can also overwrite the config option with your implementation.');
-            },
-
-            'payum.http_client' => static fn (ArrayObject $config): HttplugClient => new HttplugClient(Psr18ClientDiscovery::find()),
-            'payum.http_stream_factory' => static fn (ArrayObject $config): StreamFactoryInterface => Psr17FactoryDiscovery::findStreamFactory(),
-            'payum.http_message_factory' => static fn (ArrayObject $config): RequestFactoryInterface => Psr17FactoryDiscovery::findRequestFactory(),
-
-            'payum.template.layout' => '@PayumCore/layout.html.twig',
-
-            'twig.env' => fn () => new Environment(new ChainLoader()),
-            'twig.register_paths' => function (ArrayObject $config) {
-                $twig = $config['twig.env'];
-                if (! $twig instanceof Environment) {
-                    throw new LogicException(sprintf(
-                        'The `twig.env config option must contains instance of Twig\Environment but got %s`',
-                        get_debug_type($twig)
-                    ));
-                }
-
-                TwigUtil::registerPaths($twig, $config['payum.paths']);
-
-                return null;
-            },
-            'payum.action.get_http_request' => new GetHttpRequestAction(),
-            'payum.action.capture_payment' => new CapturePaymentAction(),
-            'payum.action.authorize_payment' => new AuthorizePaymentAction(),
-            'payum.action.payout_payout' => new PayoutPayoutAction(),
-            'payum.action.execute_same_request_with_model_details' => new ExecuteSameRequestWithModelDetailsAction(),
-            'payum.action.render_template' => fn (ArrayObject $config) => new RenderTemplateAction($config['twig.env'], $config['payum.template.layout']),
-            'payum.extension.endless_cycle_detector' => new EndlessCycleDetectorExtension(),
-            'payum.action.get_currency' => fn (ArrayObject $config) => new GetCurrencyAction(),
-            'payum.prepend_actions' => [],
-            'payum.prepend_extensions' => [],
-            'payum.prepend_apis' => [],
-            'payum.default_options' => [],
-            'payum.required_options' => [],
-
-            'payum.api.http_client' => fn (ArrayObject $config) => $config['payum.http_client'],
-
-            'payum.security.token_storage' => null,
-        ]);
-
-        if ($config['payum.security.token_storage']) {
-            $config['payum.action.get_token'] = static fn (ArrayObject $config) => new GetTokenAction($config['payum.security.token_storage']);
-        }
-
-        $config['payum.paths'] = array_replace([
-            'PayumCore' => __DIR__ . '/Resources/views',
-        ], $config['payum.paths'] ?: []);
-
-        return (array) $config;
+        return $this->configureContainer();
     }
 
+    public function configureContainer(): array
+    {
+        return array_merge(
+            $this->defaultConfig,
+            [
+                'httplug.message_factory' => static function (): MessageFactory {
+                    @trigger_error('Using "httplug.message_factory" is deprecated, use "payum.http_message_factory" instead, which will return a PSR-17 RequestFactoryInterface since payum/core 2.0.0', E_USER_DEPRECATED);
+
+                    if (class_exists(MessageFactoryDiscovery::class)) {
+                        return MessageFactoryDiscovery::find();
+                    }
+
+                    if (class_exists(Request::class)) {
+                        return new GuzzleMessageFactory();
+                    }
+
+                    if (class_exists(\Laminas\Diactoros\Request::class)) {
+                        return new DiactorosMessageFactory();
+                    }
+
+                    if (class_exists(\Nyholm\Psr7\Request::class)) {
+                        return new HttplugFactory();
+                    }
+
+                    throw new LogicException('The httplug.message_factory could not be guessed. Install one of the following packages: php-http/guzzle7-adapter. You can also overwrite the config option with your implementation.');
+                },
+                'httplug.stream_factory' => static function () {
+                    @trigger_error('Using "httplug.stream_factory" is deprecated, use "payum.http_stream_factory" instead which will return a PSR-17 StreamFactoryInterface since payum/core 2.0.0', E_USER_DEPRECATED);
+                    if (class_exists(StreamFactoryDiscovery::class)) {
+                        return StreamFactoryDiscovery::find();
+                    }
+
+                    if (class_exists(Request::class)) {
+                        return new GuzzleStreamFactory();
+                    }
+
+                    if (class_exists(\Nyholm\Psr7\Request::class)) {
+                        return new HttplugFactory();
+                    }
+
+                    throw new LogicException('The httplug.stream_factory could not be guessed. Install one of the following packages: php-http/guzzle7-adapter. You can also overwrite the config option with your implementation.');
+                },
+                'httplug.client' => static function (ContainerInterface $config) {
+                    @trigger_error('Using "httplug.client" is deprecated, use "payum.http_client" instead which will return a PSR-18 ClientInterface since payum/core 2.0.0', E_USER_DEPRECATED);
+
+                    if (class_exists(HttpClientDiscovery::class)) {
+                        return HttpClientDiscovery::find();
+                    }
+
+                    if (class_exists(HttpGuzzle7Client::class)) {
+                        return new HttpGuzzle7Client();
+                    }
+
+                    if (class_exists(HttpGuzzle6Client::class)) {
+                        return new HttpGuzzle6Client();
+                    }
+
+                    if (class_exists(HttpGuzzle5Client::class)) {
+                        return new HttpGuzzle5Client();
+                    }
+
+                    if (class_exists(SymfonyHttplugClient::class)) {
+                        return new SymfonyHttplugClient();
+                    }
+
+                    if (class_exists(HttpSocketClient::class)) {
+                        return new HttpSocketClient();
+                    }
+
+                    if (class_exists(HttpCurlClient::class)) {
+                        return new HttpCurlClient($config->get('httplug.message_factory'), $config->get('httplug.stream_factory'));
+                    }
+
+                    if (class_exists(HttpBuzzClient::class)) {
+                        return new HttpBuzzClient();
+                    }
+
+                    throw new LogicException('The httplug.client could not be guessed. Install one of the following packages: php-http/guzzle7-adapter, php-http/guzzle7-adapter. You can also overwrite the config option with your implementation.');
+                },
+
+                'payum.http_client' => static fn (): HttplugClient => new HttplugClient(Psr18ClientDiscovery::find()),
+                'payum.http_stream_factory' => static fn (): StreamFactoryInterface => Psr17FactoryDiscovery::findStreamFactory(),
+                'payum.http_message_factory' => static fn (): RequestFactoryInterface => Psr17FactoryDiscovery::findRequestFactory(),
+                'payum.template.layout' => '@PayumCore/layout.html.twig',
+
+                'twig.env' => static fn () => new Environment(new ChainLoader()),
+                'payum.default_options' => [],
+                'payum.required_options' => [],
+
+                'payum.api.http_client' => get('payum.http_client'),
+
+                'payum.security.token_storage' => null,
+
+                'payum.paths' => [],
+
+                ClientInterface::class => get('payum.http_client'),
+                StreamFactoryInterface::class => get('payum.http_stream_factory'),
+                RequestFactoryInterface::class => get('payum.http_message_factory'),
+                ResponseFactoryInterface::class => get('payum.http_message_factory'),
+
+                Environment::class => get('twig.env'),
+
+                HttpClient::class => get('payum.http_client'),
+
+                RenderTemplateAction::class => autowire()->constructor(layout: get('payum.template.layout')),
+                GetTokenAction::class => autowire()->constructor(tokenStorage: get('payum.security.token_storage')),
+            ]
+        );
+    }
+
+    /**
+     * @throws ContainerExceptionInterface | NotFoundExceptionInterface | LoaderError
+     */
+    public function createGateway(ContainerInterface $container): Gateway
+    {
+        TwigUtil::registerPaths(
+            $container->get('twig.env'),
+            array_merge(
+                [
+                    'PayumCore' => __DIR__ . '/Resources/views',
+                ],
+                (array) $container->get('payum.paths'),
+            )
+        );
+
+        $gateway = new Gateway();
+
+        foreach ($this->getActions() as $action) {
+            if (is_string($action)) {
+                $action = $container->get($action);
+            }
+
+            $gateway->addAction($action, $action instanceof PrependActionInterface);
+        }
+
+        foreach ($this->getExtensions() as $extension) {
+            if (is_string($extension)) {
+                $extension = $container->get($extension);
+            }
+
+            $gateway->addExtension($extension, $extension instanceof PrependExtensionInterface);
+        }
+
+        return $gateway;
+    }
+
+    public function getActions(): array
+    {
+        return [
+            GetHttpRequestAction::class,
+            CapturePaymentAction::class,
+            AuthorizePaymentAction::class,
+            PayoutPayoutAction::class,
+            ExecuteSameRequestWithModelDetailsAction::class,
+            RenderTemplateAction::class,
+            GetCurrencyAction::class,
+            GetTokenAction::class,
+        ];
+    }
+
+    public function getExtensions(): array
+    {
+        return [
+            EndlessCycleDetectorExtension::class,
+        ];
+    }
+
+    /**
+     * @deprecated since 2.0. Implement the ContainerConfiguration interface instead.
+     */
     protected function buildClosures(ArrayObject $config): void
     {
+        @trigger_error(sprintf('The %s is deprecated since 2.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class), E_USER_DEPRECATED);
         // with higher priority
         foreach ([
             'payum.http_client',
@@ -239,8 +318,12 @@ class CoreGatewayFactory implements GatewayFactoryInterface
         }
     }
 
+    /**
+     * @deprecated since 2.0. Implement the ContainerConfiguration interface instead.
+     */
     protected function buildActions(Gateway $gateway, ArrayObject $config): void
     {
+        @trigger_error(sprintf('The %s is deprecated since 2.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class), E_USER_DEPRECATED);
         foreach ($config as $name => $value) {
             if (str_starts_with($name, 'payum.action')) {
                 $prepend = in_array($name, $config['payum.prepend_actions'], true);
@@ -250,8 +333,12 @@ class CoreGatewayFactory implements GatewayFactoryInterface
         }
     }
 
+    /**
+     * @deprecated since 2.0. Implement the ContainerConfiguration interface instead.
+     */
     protected function buildApis(Gateway $gateway, ArrayObject $config): void
     {
+        @trigger_error(sprintf('The %s is deprecated since 2.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class), E_USER_DEPRECATED);
         foreach ($config as $name => $value) {
             if (str_starts_with($name, 'payum.api')) {
                 @trigger_error('The payum.api.* config is deprecated and will be removed in 3.0. Use dependency-injection to inject the api into the action instead.', E_USER_DEPRECATED);
@@ -262,8 +349,12 @@ class CoreGatewayFactory implements GatewayFactoryInterface
         }
     }
 
+    /**
+     * @deprecated since 2.0. Implement the ContainerConfiguration interface instead.
+     */
     protected function buildExtensions(Gateway $gateway, ArrayObject $config): void
     {
+        @trigger_error(sprintf('The %s is deprecated since 2.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class), E_USER_DEPRECATED);
         foreach ($config as $name => $value) {
             if (str_starts_with($name, 'payum.extension')) {
                 $prepend = in_array($name, $config['payum.prepend_extensions'], true);

--- a/src/Payum/Core/CoreGatewayFactory.php
+++ b/src/Payum/Core/CoreGatewayFactory.php
@@ -2,7 +2,6 @@
 
 namespace Payum\Core;
 
-use ReflectionType;
 use Closure;
 use DI\ContainerBuilder;
 use Exception;
@@ -49,6 +48,7 @@ use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use ReflectionFunction;
 use ReflectionNamedType;
+use ReflectionType;
 use Symfony\Component\HttpClient\HttplugClient as SymfonyHttplugClient;
 use Twig\Environment;
 use Twig\Error\LoaderError;

--- a/src/Payum/Core/CoreGatewayFactory.php
+++ b/src/Payum/Core/CoreGatewayFactory.php
@@ -2,6 +2,7 @@
 
 namespace Payum\Core;
 
+use ReflectionType;
 use Closure;
 use DI\ContainerBuilder;
 use Exception;
@@ -386,7 +387,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
 
             $params = $reflection->getParameters();
             $firstParam = $params[0];
-            return ! $firstParam->getType() || ($firstParam->getType() instanceof ReflectionNamedType && ArrayObject::class === $firstParam->getType()->getName());
+            return ! $firstParam->getType() instanceof ReflectionType || ($firstParam->getType() instanceof ReflectionNamedType && ArrayObject::class === $firstParam->getType()->getName());
         };
 
         /** @var ContainerInterface $container */

--- a/src/Payum/Core/CoreGatewayFactory.php
+++ b/src/Payum/Core/CoreGatewayFactory.php
@@ -2,6 +2,7 @@
 
 namespace Payum\Core;
 
+use Closure;
 use DI\ContainerBuilder;
 use Exception;
 use GuzzleHttp\Psr7\Request;
@@ -45,6 +46,8 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use ReflectionFunction;
+use ReflectionNamedType;
 use Symfony\Component\HttpClient\HttplugClient as SymfonyHttplugClient;
 use Twig\Environment;
 use Twig\Error\LoaderError;
@@ -53,11 +56,13 @@ use function array_combine;
 use function array_map;
 use function array_merge;
 use function class_exists;
-use function DI\autowire;
-use function DI\get;
+use function func_get_args;
+use function func_num_args;
 use function in_array;
 use function is_string;
 use function sprintf;
+use function str_starts_with;
+use function trigger_deprecation;
 use function trigger_error;
 use const E_USER_DEPRECATED;
 
@@ -86,33 +91,47 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
         @trigger_error(sprintf('The %s is deprecated since 2.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class), E_USER_DEPRECATED);
 
         $containerBuilder = new ContainerBuilder();
-        $containerBuilder->addDefinitions($this->configureContainer());
         $containerBuilder->addDefinitions($config);
+        $containerBuilder->addDefinitions($this->configureContainer());
+        $containerBuilder->addDefinitions([
+            ArrayObject::class => static function (ContainerInterface $container) {
+                trigger_deprecation('payum/core', '2.0.0', 'The %s service is deprecated and will be removed in 3.0. Use the %s service instead.', ArrayObject::class, ContainerInterface::class);
+                return new class($container) extends ArrayObject {
+                    private ContainerInterface $container;
+
+                    public function __construct(ContainerInterface $container)
+                    {
+                        parent::__construct();
+
+                        $this->container = $container;
+                    }
+
+                    public function offsetGet($key): mixed
+                    {
+                        return $this->container->get($key);
+                    }
+                };
+            },
+        ]);
 
         $container = $containerBuilder->build();
 
-        $gateway = $this->createGateway($container);
-
         $entries = $container->getKnownEntryNames();
 
-        // Skip entries that are already handled by createGateway() or shouldn't be in config
-        $entriesToSkip = [
-            GetTokenAction::class, // Already handled conditionally in createGateway()
-            RenderTemplateAction::class, // Already handled in createGateway()
-        ];
-
-        $configEntries = array_filter($entries, static fn (string $name): bool => ! in_array($name, $entriesToSkip, true));
-
-        $config = ArrayObject::ensureArrayObject(array_combine(
-            $configEntries,
-            array_map(static fn (string $name) => $container->get($name), $configEntries)
+        $configArray = ArrayObject::ensureArrayObject($config);
+        $configArray->defaults(array_combine(
+            $entries,
+            array_map(static fn (string $name) => static fn () => $container->get($name), $entries)
         ));
 
-        $this->buildActions($gateway, $config);
-        $this->buildApis($gateway, $config);
-        $this->buildExtensions($gateway, $config);
+        $gateway = new Gateway();
 
-        return $gateway;
+        $this->buildClosures($configArray);
+        $this->buildActions($gateway, $configArray);
+        $this->buildApis($gateway, $configArray);
+        $this->buildExtensions($gateway, $configArray);
+
+        return $this->createGateway($container, $gateway);
     }
 
     /**
@@ -124,7 +143,18 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
     {
         @trigger_error(sprintf('The %s is deprecated since 2.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class), E_USER_DEPRECATED);
 
-        return $this->configureContainer();
+        $containerConfig = $this->configureContainer();
+
+        $result = array_merge($containerConfig, $config);
+
+        if (isset($config['payum.paths'])) {
+            $result['payum.paths'] = array_merge(
+                $containerConfig['payum.paths'] ?? [],
+                $config['payum.paths']
+            );
+        }
+
+        return $result;
     }
 
     public function configureContainer(): array
@@ -169,7 +199,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
 
                     throw new LogicException('The httplug.stream_factory could not be guessed. Install one of the following packages: php-http/guzzle7-adapter. You can also overwrite the config option with your implementation.');
                 },
-                'httplug.client' => static function (ContainerInterface $config) {
+                'httplug.client' => static function (ArrayObject $config) {
                     @trigger_error('Using "httplug.client" is deprecated, use "payum.http_client" instead which will return a PSR-18 ClientInterface since payum/core 2.0.0', E_USER_DEPRECATED);
 
                     if (class_exists(HttpClientDiscovery::class)) {
@@ -197,7 +227,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
                     }
 
                     if (class_exists(HttpCurlClient::class)) {
-                        return new HttpCurlClient($config->get('httplug.message_factory'), $config->get('httplug.stream_factory'));
+                        return new HttpCurlClient($config['httplug.message_factory'], $config['httplug.stream_factory']);
                     }
 
                     if (class_exists(HttpBuzzClient::class)) {
@@ -213,12 +243,9 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
                 RequestFactoryInterface::class => static fn (): RequestFactoryInterface => Psr17FactoryDiscovery::findRequestFactory(),
 
                 // Legacy Payum service names - delegate to PSR interfaces
-                'payum.http_client' => static fn (ContainerInterface $c): HttplugClient =>
-                    new HttplugClient($c->get(ClientInterface::class)),
-                'payum.http_stream_factory' => static fn (ContainerInterface $c): StreamFactoryInterface =>
-                    $c->get(StreamFactoryInterface::class),
-                'payum.http_message_factory' => static fn (ContainerInterface $c): RequestFactoryInterface =>
-                    $c->get(RequestFactoryInterface::class),
+                'payum.http_client' => static fn (ContainerInterface $c): HttplugClient => new HttplugClient($c->get(ClientInterface::class)),
+                'payum.http_stream_factory' => static fn (ContainerInterface $c): StreamFactoryInterface => $c->get(StreamFactoryInterface::class),
+                'payum.http_message_factory' => static fn (ContainerInterface $c): RequestFactoryInterface => $c->get(RequestFactoryInterface::class),
                 'payum.template.layout' => '@PayumCore/layout.html.twig',
 
                 'twig.env' => static fn () => new Environment(new ChainLoader()),
@@ -233,19 +260,34 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
                 'payum.api.http_client' => static fn (ContainerInterface $c) => $c->get('payum.http_client'),
 
                 // Token storage - should be provided externally
-                'payum.security.token_storage' => null,
+                // 'payum.security.token_storage' => null,
 
-                'payum.paths' => [],
+                'payum.paths' => [
+                    'PayumCore' => __DIR__ . '/Resources/views',
+                ],
 
                 // Additional aliases
-                ResponseFactoryInterface::class => static fn (ContainerInterface $c): RequestFactoryInterface =>
-                    $c->get(RequestFactoryInterface::class),
+                ResponseFactoryInterface::class => static fn (ContainerInterface $c): RequestFactoryInterface => $c->get(RequestFactoryInterface::class),
                 Environment::class => static fn (ContainerInterface $c) => $c->get('twig.env'),
                 HttpClient::class => static fn (ContainerInterface $c) => $c->get('payum.http_client'),
 
-                // Actions
-                RenderTemplateAction::class => static fn (ContainerInterface $c) =>
-                    new RenderTemplateAction($c->get('twig.env'), $c->get('payum.template.layout')),
+                // BC: Deprecated action entries (used by deprecated buildActions method)
+                'payum.action.get_http_request' => static fn () => new GetHttpRequestAction(),
+                'payum.action.capture_payment' => static fn () => new CapturePaymentAction(),
+                'payum.action.authorize_payment' => static fn () => new AuthorizePaymentAction(),
+                'payum.action.payout_payout' => static fn () => new PayoutPayoutAction(),
+                'payum.action.execute_same_request_with_model_details' => static fn () => new ExecuteSameRequestWithModelDetailsAction(),
+                'payum.action.get_currency' => static fn () => new GetCurrencyAction(),
+                'payum.action.render_template' => static fn (ContainerInterface $c) => new RenderTemplateAction($c->get('twig.env'), $c->get('payum.template.layout')),
+                'payum.action.get_token' => static fn (ContainerInterface $c) => $c->has('payum.security.token_storage')
+                    ? new GetTokenAction($c->get('payum.security.token_storage'))
+                    : null,
+
+                // BC: Deprecated extension entries (used by deprecated buildExtensions method)
+                'payum.extension.endless_cycle_detector' => static fn () => new EndlessCycleDetectorExtension(),
+
+                // New DI approach: Action classes for createGateway()
+                RenderTemplateAction::class => static fn (ContainerInterface $c) => new RenderTemplateAction($c->get('twig.env'), $c->get('payum.template.layout')),
 
                 // GetTokenAction is conditionally added in createGateway() if token storage is available
                 GetTokenAction::class => static fn (ContainerInterface $c) => $c->has('payum.security.token_storage')
@@ -260,6 +302,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
      */
     public function createGateway(ContainerInterface $container): Gateway
     {
+
         TwigUtil::registerPaths(
             $container->get('twig.env'),
             array_merge(
@@ -270,11 +313,15 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
             )
         );
 
-        $gateway = new Gateway();
+        if (2 === func_num_args() && func_get_args()[1] instanceof Gateway) {
+            $gateway = func_get_args()[1];
+        } else {
+            $gateway = new Gateway();
+        }
 
         foreach ($this->getActions() as $action) {
             // Skip GetTokenAction if token storage is not configured
-            if ($action === GetTokenAction::class && ! $container->has('payum.security.token_storage')) {
+            if (GetTokenAction::class === $action && ! $container->has('payum.security.token_storage')) {
                 continue;
             }
 
@@ -323,29 +370,37 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
     protected function buildClosures(ArrayObject $config): void
     {
         @trigger_error(sprintf('The %s is deprecated since 2.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class), E_USER_DEPRECATED);
-        // with higher priority
-        foreach ([
-            'payum.http_client',
-            'payum.http_stream_factory',
-            'payum.http_message_factory',
 
-            'httplug.message_factory',
-            'httplug.stream_factory',
-            'httplug.client',
-
-            'payum.paths',
-            'twig.env',
-            'twig.register_paths',
-        ] as $name) {
-            $value = $config[$name];
-            if (is_callable($value)) {
-                $config[$name] = $value($config);
+        // Helper to check if closure expects ArrayObject
+        $canInvokeWithArrayObject = static function ($value): bool {
+            if (! $value instanceof Closure) {
+                return false;
             }
-        }
+
+            $reflection = new ReflectionFunction($value);
+            if (0 === $reflection->getNumberOfParameters()) {
+                return true;
+            }
+
+            $params = $reflection->getParameters();
+            $firstParam = $params[0];
+            return ! $firstParam->getType() || ($firstParam->getType() instanceof ReflectionNamedType && ArrayObject::class === $firstParam->getType()->getName());
+        };
+
+        /** @var ContainerInterface $container */
+        $container = $config[ContainerInterface::class]();
 
         foreach ($config as $name => $value) {
+            if (GetTokenAction::class === $name && ! $container->has('payum.security.token_storage')) {
+                continue;
+            }
+
             if (is_callable($value) && ! (is_string($value) && function_exists('\\' . $value))) {
-                $config[$name] = $value($config);
+                if ($canInvokeWithArrayObject($value)) {
+                    $config[$name] = $value($config);
+                } else {
+                    $config[$name] = $container->get($name);
+                }
             }
         }
     }
@@ -357,7 +412,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
     {
         @trigger_error(sprintf('The %s is deprecated since 2.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class), E_USER_DEPRECATED);
         foreach ($config as $name => $value) {
-            if (str_starts_with($name, 'payum.action')) {
+            if (str_starts_with($name, 'payum.action') && null !== $value) {
                 $prepend = in_array($name, $config['payum.prepend_actions'], true);
 
                 $gateway->addAction($value, $prepend);

--- a/src/Payum/Core/CoreGatewayFactory.php
+++ b/src/Payum/Core/CoreGatewayFactory.php
@@ -60,7 +60,6 @@ use function func_get_args;
 use function func_num_args;
 use function in_array;
 use function is_string;
-use function sprintf;
 use function str_starts_with;
 use function trigger_deprecation;
 use function trigger_error;
@@ -88,7 +87,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
      */
     public function create(array $config = []): Gateway
     {
-        @trigger_error(sprintf('The %s is deprecated since 2.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class), E_USER_DEPRECATED);
+        trigger_deprecation('payum/core', '2.0.0', 'The %s is deprecated. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class);
 
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->addDefinitions($config);
@@ -109,6 +108,11 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
                     public function offsetGet($key): mixed
                     {
                         return $this->container->get($key);
+                    }
+
+                    public function offsetExists($key): bool
+                    {
+                        return $this->container->has($key);
                     }
                 };
             },
@@ -141,7 +145,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
      */
     public function createConfig(array $config = []): array
     {
-        @trigger_error(sprintf('The %s is deprecated since 2.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class), E_USER_DEPRECATED);
+        trigger_deprecation('payum/core', '2.0.0', 'The %s is deprecated. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class);
 
         $containerConfig = $this->configureContainer();
 
@@ -160,7 +164,6 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
     public function configureContainer(): array
     {
         return array_merge(
-            $this->defaultConfig,
             [
                 'httplug.message_factory' => static function (): MessageFactory {
                     @trigger_error('Using "httplug.message_factory" is deprecated, use "payum.http_message_factory" instead, which will return a PSR-17 RequestFactoryInterface since payum/core 2.0.0', E_USER_DEPRECATED);
@@ -293,7 +296,8 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
                 GetTokenAction::class => static fn (ContainerInterface $c) => $c->has('payum.security.token_storage')
                     ? new GetTokenAction($c->get('payum.security.token_storage'))
                     : throw new LogicException('Token storage must be configured to use GetTokenAction'),
-            ]
+            ],
+            $this->defaultConfig,
         );
     }
 
@@ -325,9 +329,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
                 continue;
             }
 
-            if (is_string($action)) {
-                $action = $container->get($action);
-            }
+            $action = $container->get($action);
 
             $gateway->addAction($action, $action instanceof PrependActionInterface);
         }
@@ -369,7 +371,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
      */
     protected function buildClosures(ArrayObject $config): void
     {
-        @trigger_error(sprintf('The %s is deprecated since 2.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class), E_USER_DEPRECATED);
+        trigger_deprecation('payum/core', '2.0.0', 'The %s is deprecated. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class);
 
         // Helper to check if closure expects ArrayObject
         $canInvokeWithArrayObject = static function ($value): bool {
@@ -410,10 +412,10 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
      */
     protected function buildActions(Gateway $gateway, ArrayObject $config): void
     {
-        @trigger_error(sprintf('The %s is deprecated since 2.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class), E_USER_DEPRECATED);
+        trigger_deprecation('payum/core', '2.0.0', 'The %s is deprecated. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class);
         foreach ($config as $name => $value) {
             if (str_starts_with($name, 'payum.action') && null !== $value) {
-                $prepend = in_array($name, $config['payum.prepend_actions'], true);
+                $prepend = in_array($name, $config['payum.prepend_actions'], true) || $value instanceof PrependActionInterface;
 
                 $gateway->addAction($value, $prepend);
             }
@@ -425,7 +427,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
      */
     protected function buildApis(Gateway $gateway, ArrayObject $config): void
     {
-        @trigger_error(sprintf('The %s is deprecated since 2.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class), E_USER_DEPRECATED);
+        trigger_deprecation('payum/core', '2.0.0', 'The %s is deprecated. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class);
         foreach ($config as $name => $value) {
             if (str_starts_with($name, 'payum.api')) {
                 @trigger_error('The payum.api.* config is deprecated and will be removed in 3.0. Use dependency-injection to inject the api into the action instead.', E_USER_DEPRECATED);
@@ -441,10 +443,10 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
      */
     protected function buildExtensions(Gateway $gateway, ArrayObject $config): void
     {
-        @trigger_error(sprintf('The %s is deprecated since 2.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class), E_USER_DEPRECATED);
+        trigger_deprecation('payum/core', '2.0.0', 'The %s is deprecated. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class);
         foreach ($config as $name => $value) {
             if (str_starts_with($name, 'payum.extension')) {
-                $prepend = in_array($name, $config['payum.prepend_extensions'], true);
+                $prepend = in_array($name, $config['payum.prepend_extensions'], true) || $value instanceof PrependExtensionInterface;
 
                 $gateway->addExtension($value, $prepend);
             }

--- a/src/Payum/Core/CoreGatewayFactory.php
+++ b/src/Payum/Core/CoreGatewayFactory.php
@@ -86,6 +86,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
         @trigger_error(sprintf('The %s is deprecated since 2.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class), E_USER_DEPRECATED);
 
         $containerBuilder = new ContainerBuilder();
+        $containerBuilder->addDefinitions($this->configureContainer());
         $containerBuilder->addDefinitions($config);
 
         $container = $containerBuilder->build();
@@ -94,9 +95,17 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
 
         $entries = $container->getKnownEntryNames();
 
+        // Skip entries that are already handled by createGateway() or shouldn't be in config
+        $entriesToSkip = [
+            GetTokenAction::class, // Already handled conditionally in createGateway()
+            RenderTemplateAction::class, // Already handled in createGateway()
+        ];
+
+        $configEntries = array_filter($entries, static fn (string $name): bool => ! in_array($name, $entriesToSkip, true));
+
         $config = ArrayObject::ensureArrayObject(array_combine(
-            $entries,
-            array_map(static fn (string $name) => $container->get($name), $entries)
+            $configEntries,
+            array_map(static fn (string $name) => $container->get($name), $configEntries)
         ));
 
         $this->buildActions($gateway, $config);
@@ -198,32 +207,50 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
                     throw new LogicException('The httplug.client could not be guessed. Install one of the following packages: php-http/guzzle7-adapter, php-http/guzzle7-adapter. You can also overwrite the config option with your implementation.');
                 },
 
-                'payum.http_client' => static fn (): HttplugClient => new HttplugClient(Psr18ClientDiscovery::find()),
-                'payum.http_stream_factory' => static fn (): StreamFactoryInterface => Psr17FactoryDiscovery::findStreamFactory(),
-                'payum.http_message_factory' => static fn (): RequestFactoryInterface => Psr17FactoryDiscovery::findRequestFactory(),
+                // PSR-18/17 services - lazily discover if not provided
+                ClientInterface::class => static fn (): ClientInterface => Psr18ClientDiscovery::find(),
+                StreamFactoryInterface::class => static fn (): StreamFactoryInterface => Psr17FactoryDiscovery::findStreamFactory(),
+                RequestFactoryInterface::class => static fn (): RequestFactoryInterface => Psr17FactoryDiscovery::findRequestFactory(),
+
+                // Legacy Payum service names - delegate to PSR interfaces
+                'payum.http_client' => static fn (ContainerInterface $c): HttplugClient =>
+                    new HttplugClient($c->get(ClientInterface::class)),
+                'payum.http_stream_factory' => static fn (ContainerInterface $c): StreamFactoryInterface =>
+                    $c->get(StreamFactoryInterface::class),
+                'payum.http_message_factory' => static fn (ContainerInterface $c): RequestFactoryInterface =>
+                    $c->get(RequestFactoryInterface::class),
                 'payum.template.layout' => '@PayumCore/layout.html.twig',
 
                 'twig.env' => static fn () => new Environment(new ChainLoader()),
                 'payum.default_options' => [],
                 'payum.required_options' => [],
 
-                'payum.api.http_client' => get('payum.http_client'),
+                // Backwards compatibility arrays for deprecated build* methods
+                'payum.prepend_actions' => [],
+                'payum.prepend_apis' => [],
+                'payum.prepend_extensions' => [],
 
+                'payum.api.http_client' => static fn (ContainerInterface $c) => $c->get('payum.http_client'),
+
+                // Token storage - should be provided externally
                 'payum.security.token_storage' => null,
 
                 'payum.paths' => [],
 
-                ClientInterface::class => get('payum.http_client'),
-                StreamFactoryInterface::class => get('payum.http_stream_factory'),
-                RequestFactoryInterface::class => get('payum.http_message_factory'),
-                ResponseFactoryInterface::class => get('payum.http_message_factory'),
+                // Additional aliases
+                ResponseFactoryInterface::class => static fn (ContainerInterface $c): RequestFactoryInterface =>
+                    $c->get(RequestFactoryInterface::class),
+                Environment::class => static fn (ContainerInterface $c) => $c->get('twig.env'),
+                HttpClient::class => static fn (ContainerInterface $c) => $c->get('payum.http_client'),
 
-                Environment::class => get('twig.env'),
+                // Actions
+                RenderTemplateAction::class => static fn (ContainerInterface $c) =>
+                    new RenderTemplateAction($c->get('twig.env'), $c->get('payum.template.layout')),
 
-                HttpClient::class => get('payum.http_client'),
-
-                RenderTemplateAction::class => autowire()->constructor(layout: get('payum.template.layout')),
-                GetTokenAction::class => autowire()->constructor(tokenStorage: get('payum.security.token_storage')),
+                // GetTokenAction is conditionally added in createGateway() if token storage is available
+                GetTokenAction::class => static fn (ContainerInterface $c) => $c->has('payum.security.token_storage')
+                    ? new GetTokenAction($c->get('payum.security.token_storage'))
+                    : throw new LogicException('Token storage must be configured to use GetTokenAction'),
             ]
         );
     }
@@ -246,6 +273,11 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
         $gateway = new Gateway();
 
         foreach ($this->getActions() as $action) {
+            // Skip GetTokenAction if token storage is not configured
+            if ($action === GetTokenAction::class && ! $container->has('payum.security.token_storage')) {
+                continue;
+            }
+
             if (is_string($action)) {
                 $action = $container->get($action);
             }

--- a/src/Payum/Core/DI/ContainerConfiguration.php
+++ b/src/Payum/Core/DI/ContainerConfiguration.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Payum\Core\DI;
+
+use Payum\Core\Gateway;
+use Psr\Container\ContainerInterface;
+
+interface ContainerConfiguration
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function configureContainer(): array;
+
+    public function createGateway(ContainerInterface $container): Gateway;
+}

--- a/src/Payum/Core/DI/FallbackContainer.php
+++ b/src/Payum/Core/DI/FallbackContainer.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Payum\Core\DI;
+
+use DI\Container;
+use Psr\Container\ContainerInterface;
+use function array_merge;
+use function array_unique;
+use function array_values;
+
+/**
+ * Looks a service up in the primary container and falls back to the secondary one when the primary does
+ * not have it.
+ *
+ * This lets an application hand its own container to Payum without having to re-declare every service
+ * Payum needs: whatever the application defines wins, the rest comes from Payum's own defaults.
+ */
+final class FallbackContainer implements ContainerInterface
+{
+    public function __construct(
+        private ContainerInterface $primary,
+        private ContainerInterface $fallback
+    ) {
+    }
+
+    public function get(string $id): mixed
+    {
+        return $this->primary->has($id) ?
+            $this->primary->get($id) :
+            $this->fallback->get($id);
+    }
+
+    public function has(string $id): bool
+    {
+        return $this->primary->has($id) || $this->fallback->has($id);
+    }
+
+    /**
+     * The ids of both containers, as far as they are able to report them. A container which cannot
+     * enumerate its entries contributes nothing.
+     *
+     * @return list<string>
+     */
+    public function getKnownEntryNames(): array
+    {
+        return array_values(array_unique(array_merge(
+            self::knownEntryNamesOf($this->primary),
+            self::knownEntryNamesOf($this->fallback),
+        )));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function knownEntryNamesOf(ContainerInterface $container): array
+    {
+        if ($container instanceof self) {
+            return $container->getKnownEntryNames();
+        }
+
+        if ($container instanceof Container) {
+            return array_values($container->getKnownEntryNames());
+        }
+
+        return [];
+    }
+}

--- a/src/Payum/Core/Extension/PrependExtensionInterface.php
+++ b/src/Payum/Core/Extension/PrependExtensionInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Payum\Core\Extension;
+
+interface PrependExtensionInterface
+{
+}

--- a/src/Payum/Core/Gateway.php
+++ b/src/Payum/Core/Gateway.php
@@ -17,9 +17,9 @@ use Throwable;
 class Gateway implements GatewayInterface
 {
     /**
-     * @var Action\ActionInterface[]
+     * @var list<class-string<Action\ActionInterface>|Action\ActionInterface>
      */
-    protected $actions = [];
+    protected array $actions = [];
 
     /**
      * @var mixed[]
@@ -35,7 +35,7 @@ class Gateway implements GatewayInterface
     /**
      * @var Context[]
      */
-    protected $stack = [];
+    protected array $stack = [];
 
     public function __construct()
     {

--- a/src/Payum/Core/GatewayFactory.php
+++ b/src/Payum/Core/GatewayFactory.php
@@ -3,8 +3,9 @@
 namespace Payum\Core;
 
 use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\DI\ContainerConfiguration;
 
-class GatewayFactory implements GatewayFactoryInterface
+class GatewayFactory implements GatewayFactoryInterface /*, ContainerConfiguration */ // This class will implement ContainerConfiguration from version 3.0, and will remove the GatewayFactoryInterface
 {
     /**
      * @var GatewayFactoryInterface

--- a/src/Payum/Core/GatewayFactoryConfigInterface.php
+++ b/src/Payum/Core/GatewayFactoryConfigInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Payum\Core;
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Extension\ExtensionInterface;
+use Psr\Container\ContainerInterface;
+
+interface GatewayFactoryConfigInterface
+{
+    public function createGateway(ContainerInterface $container): Gateway;
+
+    /**
+     * @return array<string, class-string<ActionInterface>>|list<class-string<ActionInterface>>
+     */
+    public function getActions(): array;
+
+    /**
+     * @return list<ExtensionInterface|class-string<ExtensionInterface>>
+     */
+    public function getExtensions(): array;
+}

--- a/src/Payum/Core/PayumBuilder.php
+++ b/src/Payum/Core/PayumBuilder.php
@@ -3,6 +3,9 @@
 namespace Payum\Core;
 
 use DI\ContainerBuilder;
+use Exception;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use LogicException;
 use Omnipay\Omnipay;
 use Payum\AuthorizeNet\Aim\AuthorizeNetAimGatewayFactory;
@@ -31,6 +34,12 @@ use Payum\Core\Security\TokenFactoryInterface;
 use Payum\Core\Security\TokenInterface;
 use Payum\Core\Storage\FilesystemStorage;
 use Payum\Core\Storage\StorageInterface;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Payum\Klarna\Checkout\KlarnaCheckoutGatewayFactory;
 use Payum\Klarna\Invoice\KlarnaInvoiceGatewayFactory;
 use Payum\Offline\OfflineGatewayFactory;
@@ -121,6 +130,16 @@ class PayumBuilder
      * @var ?RegistryInterface<object>
      */
     protected ?RegistryInterface $mainRegistry = null;
+
+    /**
+     * @var ?ContainerInterface
+     */
+    protected ?ContainerInterface $globalContainer = null;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $globalDefinitions = [];
 
     public function addDefaultStorages(): static
     {
@@ -278,16 +297,56 @@ class PayumBuilder
     }
 
     /**
-     * @return Payum<StorageRegistryInterface<StorageInterface<TokenInterface>>>
+     * Add a global service definition that will be available to all gateways.
+     * This allows sharing services (like HTTP clients, loggers) across all gateway instances.
+     *
+     * @param class-string|string $id The service identifier (can be a class name or custom string)
+     * @param mixed $service The service instance or callable factory
+     * @return static
      */
-    public function getPayum(): Payum
+    public function addGlobalService(string $id, mixed $service): static
     {
+        $this->globalDefinitions[$id] = $service;
+
+        return $this;
+    }
+
+    /**
+     * Set a pre-built global container (for framework integration).
+     * When set, this container will be used instead of building one from global definitions.
+     *
+     * @param ContainerInterface $container
+     * @return static
+     */
+    public function setGlobalContainer(ContainerInterface $container): static
+    {
+        $this->globalContainer = $container;
+
+        return $this;
+    }
+
+    /**
+     * Build the global container with services shared across all gateways.
+     * This includes HTTP clients, token storage, token factories, and storage extensions.
+     *
+     * @return ContainerInterface
+     * @throws Exception
+     */
+    protected function buildGlobalContainer(): ContainerInterface
+    {
+        if ($this->globalContainer) {
+            return $this->globalContainer;
+        }
+
+        $builder = new ContainerBuilder();
+
         if (! $this->tokenStorage) {
             $this->addDefaultStorages();
         }
 
         /** @var StorageRegistryInterface<StorageInterface<TokenInterface>> $storageRegistry */
         $storageRegistry = $this->buildRegistry([], $this->storages);
+
         $tokenFactory = $this->buildTokenFactory($this->tokenStorage, $storageRegistry);
         $genericTokenFactory = $this->buildGenericTokenFactory($tokenFactory, array_replace([
             'capture' => 'capture.php',
@@ -296,8 +355,43 @@ class PayumBuilder
             'refund' => 'refund.php',
             'payout' => 'payout.php',
         ], $this->genericTokenFactoryPaths));
-
         $httpRequestVerifier = $this->buildHttpRequestVerifier($this->tokenStorage);
+        
+        $builder->addDefinitions([
+            HttpRequestVerifierInterface::class => $httpRequestVerifier,
+            GenericTokenFactoryInterface::class => $genericTokenFactory,
+            TokenFactoryInterface::class => $tokenFactory,
+            'payum.security.token_storage' => $this->tokenStorage,
+            ClientInterface::class => fn () => Psr18ClientDiscovery::find(),
+            StreamFactoryInterface::class => fn () => Psr17FactoryDiscovery::findStreamFactory(),
+            RequestFactoryInterface::class => fn () => Psr17FactoryDiscovery::findRequestFactory(),
+        ]);
+
+        foreach ($this->storages as $modelClass => $storage) {
+            $extensionName = 'payum.extension.storage_' .
+                strtolower(str_replace('\\', '_', $modelClass));
+            $builder->addDefinitions([
+                $extensionName => new StorageExtension($storage),
+            ]);
+        }
+
+        $builder->addDefinitions($this->globalDefinitions);
+
+        return $builder->build();
+    }
+
+    /**
+     * @return Payum<StorageRegistryInterface<StorageInterface<TokenInterface>>>
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     * @throws Exception
+     */
+    public function getPayum(): Payum
+    {
+        $globalContainer = $this->buildGlobalContainer();
+
+        $genericTokenFactory = $globalContainer->get(GenericTokenFactoryInterface::class);
+        $httpRequestVerifier = $globalContainer->get(HttpRequestVerifierInterface::class);
 
         $coreGatewayFactory = $this->buildCoreGatewayFactory(array_replace_recursive([
             'payum.extension.token_factory' => new GenericTokenFactoryExtension($genericTokenFactory),
@@ -320,10 +414,27 @@ class PayumBuilder
             foreach ($this->gatewayConfigs as $name => $gatewayConfig) {
                 $containerBuilder = new ContainerBuilder();
 
-                $containerBuilder->addDefinitions($gatewayConfig);
                 $containerBuilder->addDefinitions([
-                    'payum.security.token_storage' => fn () => $this->tokenStorage,
+                    'payum.security.token_storage' => fn () => $globalContainer->get('payum.security.token_storage'),
+                    HttpRequestVerifierInterface::class => fn () => $globalContainer->get(HttpRequestVerifierInterface::class),
+                    GenericTokenFactoryInterface::class => fn () => $globalContainer->get(GenericTokenFactoryInterface::class),
+                    TokenFactoryInterface::class => fn () => $globalContainer->get(TokenFactoryInterface::class),
+                    ClientInterface::class => fn () => $globalContainer->get(ClientInterface::class),
+                    StreamFactoryInterface::class => fn () => $globalContainer->get(StreamFactoryInterface::class),
+                    RequestFactoryInterface::class => fn () => $globalContainer->get(RequestFactoryInterface::class),
                 ]);
+
+                // Add storage extensions from global container
+                foreach ($this->storages as $modelClass => $storage) {
+                    $extensionName = 'payum.extension.storage_' .
+                        strtolower(str_replace('\\', '_', $modelClass));
+                    $containerBuilder->addDefinitions([
+                        $extensionName => fn () => $globalContainer->get($extensionName),
+                    ]);
+                }
+
+                // Add gateway-specific config (overrides are possible)
+                $containerBuilder->addDefinitions($gatewayConfig);
 
                 $gatewayFactory = $registry->getGatewayFactory($gatewayConfig['factory']);
                 unset($gatewayConfig['factory']);

--- a/src/Payum/Core/PayumBuilder.php
+++ b/src/Payum/Core/PayumBuilder.php
@@ -34,12 +34,6 @@ use Payum\Core\Security\TokenFactoryInterface;
 use Payum\Core\Security\TokenInterface;
 use Payum\Core\Storage\FilesystemStorage;
 use Payum\Core\Storage\StorageInterface;
-use Psr\Container\ContainerExceptionInterface;
-use Psr\Container\ContainerInterface;
-use Psr\Container\NotFoundExceptionInterface;
-use Psr\Http\Client\ClientInterface;
-use Psr\Http\Message\RequestFactoryInterface;
-use Psr\Http\Message\StreamFactoryInterface;
 use Payum\Klarna\Checkout\KlarnaCheckoutGatewayFactory;
 use Payum\Klarna\Invoice\KlarnaInvoiceGatewayFactory;
 use Payum\Offline\OfflineGatewayFactory;
@@ -54,6 +48,12 @@ use Payum\Paypal\Rest\PaypalRestGatewayFactory;
 use Payum\Sofort\SofortGatewayFactory;
 use Payum\Stripe\StripeCheckoutGatewayFactory;
 use Payum\Stripe\StripeJsGatewayFactory;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use function in_array;
 use function strtolower;
 use function sys_get_temp_dir;
@@ -131,9 +131,6 @@ class PayumBuilder
      */
     protected ?RegistryInterface $mainRegistry = null;
 
-    /**
-     * @var ?ContainerInterface
-     */
     protected ?ContainerInterface $globalContainer = null;
 
     /**
@@ -302,7 +299,6 @@ class PayumBuilder
      *
      * @param class-string|string $id The service identifier (can be a class name or custom string)
      * @param mixed $service The service instance or callable factory
-     * @return static
      */
     public function addGlobalService(string $id, mixed $service): static
     {
@@ -314,70 +310,12 @@ class PayumBuilder
     /**
      * Set a pre-built global container (for framework integration).
      * When set, this container will be used instead of building one from global definitions.
-     *
-     * @param ContainerInterface $container
-     * @return static
      */
     public function setGlobalContainer(ContainerInterface $container): static
     {
         $this->globalContainer = $container;
 
         return $this;
-    }
-
-    /**
-     * Build the global container with services shared across all gateways.
-     * This includes HTTP clients, token storage, token factories, and storage extensions.
-     *
-     * @return ContainerInterface
-     * @throws Exception
-     */
-    protected function buildGlobalContainer(): ContainerInterface
-    {
-        if ($this->globalContainer) {
-            return $this->globalContainer;
-        }
-
-        $builder = new ContainerBuilder();
-
-        if (! $this->tokenStorage) {
-            $this->addDefaultStorages();
-        }
-
-        /** @var StorageRegistryInterface<StorageInterface<TokenInterface>> $storageRegistry */
-        $storageRegistry = $this->buildRegistry([], $this->storages);
-
-        $tokenFactory = $this->buildTokenFactory($this->tokenStorage, $storageRegistry);
-        $genericTokenFactory = $this->buildGenericTokenFactory($tokenFactory, array_replace([
-            'capture' => 'capture.php',
-            'notify' => 'notify.php',
-            'authorize' => 'authorize.php',
-            'refund' => 'refund.php',
-            'payout' => 'payout.php',
-        ], $this->genericTokenFactoryPaths));
-        $httpRequestVerifier = $this->buildHttpRequestVerifier($this->tokenStorage);
-        
-        $builder->addDefinitions([
-            HttpRequestVerifierInterface::class => $httpRequestVerifier,
-            GenericTokenFactoryInterface::class => $genericTokenFactory,
-            TokenFactoryInterface::class => $tokenFactory,
-            'payum.security.token_storage' => $this->tokenStorage,
-            ClientInterface::class => fn () => Psr18ClientDiscovery::find(),
-            StreamFactoryInterface::class => fn () => Psr17FactoryDiscovery::findStreamFactory(),
-            RequestFactoryInterface::class => fn () => Psr17FactoryDiscovery::findRequestFactory(),
-        ]);
-
-        foreach ($this->storages as $modelClass => $storage) {
-            $extensionName = 'payum.extension.storage_' .
-                strtolower(str_replace('\\', '_', $modelClass));
-            $builder->addDefinitions([
-                $extensionName => new StorageExtension($storage),
-            ]);
-        }
-
-        $builder->addDefinitions($this->globalDefinitions);
-
-        return $builder->build();
     }
 
     /**
@@ -461,6 +399,60 @@ class PayumBuilder
         }
 
         return new Payum($registry, $httpRequestVerifier, $genericTokenFactory, $this->tokenStorage);
+    }
+
+    /**
+     * Build the global container with services shared across all gateways.
+     * This includes HTTP clients, token storage, token factories, and storage extensions.
+     *
+     * @throws Exception
+     */
+    protected function buildGlobalContainer(): ContainerInterface
+    {
+        if ($this->globalContainer) {
+            return $this->globalContainer;
+        }
+
+        $builder = new ContainerBuilder();
+
+        if (! $this->tokenStorage) {
+            $this->addDefaultStorages();
+        }
+
+        /** @var StorageRegistryInterface<StorageInterface<TokenInterface>> $storageRegistry */
+        $storageRegistry = $this->buildRegistry([], $this->storages);
+
+        $tokenFactory = $this->buildTokenFactory($this->tokenStorage, $storageRegistry);
+        $genericTokenFactory = $this->buildGenericTokenFactory($tokenFactory, array_replace([
+            'capture' => 'capture.php',
+            'notify' => 'notify.php',
+            'authorize' => 'authorize.php',
+            'refund' => 'refund.php',
+            'payout' => 'payout.php',
+        ], $this->genericTokenFactoryPaths));
+        $httpRequestVerifier = $this->buildHttpRequestVerifier($this->tokenStorage);
+
+        $builder->addDefinitions([
+            HttpRequestVerifierInterface::class => $httpRequestVerifier,
+            GenericTokenFactoryInterface::class => $genericTokenFactory,
+            TokenFactoryInterface::class => $tokenFactory,
+            'payum.security.token_storage' => $this->tokenStorage,
+            ClientInterface::class => fn () => Psr18ClientDiscovery::find(),
+            StreamFactoryInterface::class => fn () => Psr17FactoryDiscovery::findStreamFactory(),
+            RequestFactoryInterface::class => fn () => Psr17FactoryDiscovery::findRequestFactory(),
+        ]);
+
+        foreach ($this->storages as $modelClass => $storage) {
+            $extensionName = 'payum.extension.storage_' .
+                strtolower(str_replace('\\', '_', $modelClass));
+            $builder->addDefinitions([
+                $extensionName => new StorageExtension($storage),
+            ]);
+        }
+
+        $builder->addDefinitions($this->globalDefinitions);
+
+        return $builder->build();
     }
 
     /**

--- a/src/Payum/Core/PayumBuilder.php
+++ b/src/Payum/Core/PayumBuilder.php
@@ -57,7 +57,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 use function in_array;
 use function strtolower;
 use function sys_get_temp_dir;
-use function trigger_error;
+use function trigger_deprecation;
 
 class PayumBuilder
 {
@@ -330,10 +330,11 @@ class PayumBuilder
 
         $genericTokenFactory = $globalContainer->get(GenericTokenFactoryInterface::class);
         $httpRequestVerifier = $globalContainer->get(HttpRequestVerifierInterface::class);
+        $tokenStorage = $this->tokenStorage ?? $globalContainer->get('payum.security.token_storage');
 
         $coreGatewayFactory = $this->buildCoreGatewayFactory(array_replace_recursive([
             'payum.extension.token_factory' => new GenericTokenFactoryExtension($genericTokenFactory),
-            'payum.security.token_storage' => $this->tokenStorage,
+            'payum.security.token_storage' => $tokenStorage,
         ], $this->coreGatewayFactoryConfig));
 
         $gatewayFactories = array_replace(
@@ -371,24 +372,23 @@ class PayumBuilder
                     ]);
                 }
 
-                // Add gateway-specific config (overrides are possible)
-                $containerBuilder->addDefinitions($gatewayConfig);
-
                 $gatewayFactory = $registry->getGatewayFactory($gatewayConfig['factory']);
                 unset($gatewayConfig['factory']);
 
                 if ($gatewayFactory instanceof ContainerConfiguration) {
                     $containerBuilder->addDefinitions($gatewayFactory->configureContainer());
 
+                    // Add gateway-specific config last, so that it overrides the factory defaults
+                    $containerBuilder->addDefinitions($gatewayConfig);
+
                     $gateways[$name] = $gatewayFactory->createGateway($containerBuilder->build());
                 } else {
-                    @trigger_error(
-                        sprintf(
-                            'Not implementing %s for gateway factory %s is deprecated since 2.0.',
-                            ContainerConfiguration::class,
-                            $gatewayFactory::class,
-                        ),
-                        E_USER_DEPRECATED
+                    trigger_deprecation(
+                        'payum/core',
+                        '2.0.0',
+                        'Not implementing %s for gateway factory %s is deprecated.',
+                        ContainerConfiguration::class,
+                        $gatewayFactory::class,
                     );
 
                     $gateways[$name] = $gatewayFactory->create($gatewayConfig);
@@ -398,7 +398,7 @@ class PayumBuilder
             $registry = $this->buildRegistry($gateways, $this->storages, $gatewayFactories);
         }
 
-        return new Payum($registry, $httpRequestVerifier, $genericTokenFactory, $this->tokenStorage);
+        return new Payum($registry, $httpRequestVerifier, $genericTokenFactory, $tokenStorage);
     }
 
     /**

--- a/src/Payum/Core/PayumBuilder.php
+++ b/src/Payum/Core/PayumBuilder.php
@@ -2,10 +2,13 @@
 
 namespace Payum\Core;
 
+use DI\Container;
 use DI\ContainerBuilder;
+use DI\FactoryInterface;
 use Exception;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Discovery\Psr18ClientDiscovery;
+use Invoker\InvokerInterface;
 use LogicException;
 use Omnipay\Omnipay;
 use Payum\AuthorizeNet\Aim\AuthorizeNetAimGatewayFactory;
@@ -351,34 +354,20 @@ class PayumBuilder
         if ($this->gatewayConfigs) {
             $gateways = $this->gateways;
             foreach ($this->gatewayConfigs as $name => $gatewayConfig) {
-                $containerBuilder = new ContainerBuilder();
-
-                $containerBuilder->addDefinitions([
-                    'payum.security.token_storage' => fn () => $globalContainer->get('payum.security.token_storage'),
-                    HttpRequestVerifierInterface::class => fn () => $globalContainer->get(HttpRequestVerifierInterface::class),
-                    GenericTokenFactoryInterface::class => fn () => $globalContainer->get(GenericTokenFactoryInterface::class),
-                    TokenFactoryInterface::class => fn () => $globalContainer->get(TokenFactoryInterface::class),
-                    ClientInterface::class => fn () => $globalContainer->get(ClientInterface::class),
-                    StreamFactoryInterface::class => fn () => $globalContainer->get(StreamFactoryInterface::class),
-                    RequestFactoryInterface::class => fn () => $globalContainer->get(RequestFactoryInterface::class),
-                ]);
-
-                // Add storage extensions from global container
-                foreach ($this->storages as $modelClass => $storage) {
-                    $extensionName = 'payum.extension.storage_' .
-                        strtolower(str_replace('\\', '_', $modelClass));
-                    $containerBuilder->addDefinitions([
-                        $extensionName => fn () => $globalContainer->get($extensionName),
-                    ]);
-                }
-
                 $gatewayFactory = $registry->getGatewayFactory($gatewayConfig['factory']);
                 unset($gatewayConfig['factory']);
 
                 if ($gatewayFactory instanceof ContainerConfiguration) {
+                    $containerBuilder = new ContainerBuilder();
+
+                    // The gateway factory defaults come first, ...
                     $containerBuilder->addDefinitions($gatewayFactory->configureContainer());
 
-                    // Add gateway-specific config last, so that it overrides the factory defaults
+                    // ... then the services shared by every gateway, so that they win over the factory
+                    // defaults, ...
+                    $containerBuilder->addDefinitions($this->buildSharedDefinitions($globalContainer));
+
+                    // ... and finally the gateway config, which overrides both.
                     $containerBuilder->addDefinitions($gatewayConfig);
 
                     $gateways[$name] = $gatewayFactory->createGateway($containerBuilder->build());
@@ -443,16 +432,66 @@ class PayumBuilder
         ]);
 
         foreach ($this->storages as $modelClass => $storage) {
-            $extensionName = 'payum.extension.storage_' .
-                strtolower(str_replace('\\', '_', $modelClass));
             $builder->addDefinitions([
-                $extensionName => new StorageExtension($storage),
+                $this->getStorageExtensionId($modelClass) => new StorageExtension($storage),
             ]);
         }
 
         $builder->addDefinitions($this->globalDefinitions);
 
         return $builder->build();
+    }
+
+    /**
+     * Definitions delegating to the global container, so that every gateway resolves the very same
+     * instance of a shared service.
+     *
+     * @return array<string, callable>
+     */
+    protected function buildSharedDefinitions(ContainerInterface $globalContainer): array
+    {
+        $ids = [
+            'payum.security.token_storage',
+            HttpRequestVerifierInterface::class,
+            GenericTokenFactoryInterface::class,
+            TokenFactoryInterface::class,
+            ClientInterface::class,
+            StreamFactoryInterface::class,
+            RequestFactoryInterface::class,
+        ];
+
+        foreach (array_keys($this->storages) as $modelClass) {
+            $ids[] = $this->getStorageExtensionId($modelClass);
+        }
+
+        // Everything registered with addGlobalService() is shared as well.
+        $ids = array_merge($ids, array_keys($this->globalDefinitions));
+
+        // A pre-built PHP-DI container can be asked for the rest of what it holds. Its own entries are
+        // left out, so that a gateway keeps being injected with its own container.
+        if ($globalContainer instanceof Container) {
+            $ids = array_merge($ids, array_diff($globalContainer->getKnownEntryNames(), [
+                ContainerInterface::class,
+                Container::class,
+                FactoryInterface::class,
+                InvokerInterface::class,
+            ]));
+        }
+
+        $definitions = [];
+        foreach (array_unique($ids) as $id) {
+            $definitions[$id] = static fn () => $globalContainer->get($id);
+        }
+
+        return $definitions;
+    }
+
+    /**
+     * @param class-string $modelClass
+     */
+    protected function getStorageExtensionId(string $modelClass): string
+    {
+        return 'payum.extension.storage_' . strtolower(str_replace('\\', '_', $modelClass));
     }
 
     /**

--- a/src/Payum/Core/PayumBuilder.php
+++ b/src/Payum/Core/PayumBuilder.php
@@ -17,6 +17,7 @@ use Payum\Be2Bill\Be2BillOffsiteGatewayFactory;
 use Payum\Core\Bridge\PlainPhp\Security\HttpRequestVerifier;
 use Payum\Core\Bridge\PlainPhp\Security\TokenFactory;
 use Payum\Core\DI\ContainerConfiguration;
+use Payum\Core\DI\FallbackContainer;
 use Payum\Core\Exception\InvalidArgumentException;
 use Payum\Core\Extension\GenericTokenFactoryExtension;
 use Payum\Core\Extension\StorageExtension;
@@ -370,7 +371,11 @@ class PayumBuilder
                     // ... and finally the gateway config, which overrides both.
                     $containerBuilder->addDefinitions($gatewayConfig);
 
-                    $gateways[$name] = $gatewayFactory->createGateway($containerBuilder->build());
+                    // Anything the gateway container does not know about is looked up globally, so that
+                    // services of a container which cannot list its entries stay reachable too.
+                    $gateways[$name] = $gatewayFactory->createGateway(
+                        new FallbackContainer($containerBuilder->build(), $globalContainer)
+                    );
                 } else {
                     trigger_deprecation(
                         'payum/core',
@@ -394,38 +399,44 @@ class PayumBuilder
      * Build the global container with services shared across all gateways.
      * This includes HTTP clients, token storage, token factories, and storage extensions.
      *
+     * A container set with setGlobalContainer() is put in front of it, so that an application only has to
+     * declare the services it actually wants to provide itself and keeps Payum's defaults for the rest.
+     *
      * @throws Exception
      */
     protected function buildGlobalContainer(): ContainerInterface
     {
-        if ($this->globalContainer) {
-            return $this->globalContainer;
-        }
-
-        $builder = new ContainerBuilder();
-
-        if (! $this->tokenStorage) {
-            $this->addDefaultStorages();
-        }
+        $tokenStorage = $this->resolveTokenStorage();
 
         /** @var StorageRegistryInterface<StorageInterface<TokenInterface>> $storageRegistry */
         $storageRegistry = $this->buildRegistry([], $this->storages);
 
-        $tokenFactory = $this->buildTokenFactory($this->tokenStorage, $storageRegistry);
-        $genericTokenFactory = $this->buildGenericTokenFactory($tokenFactory, array_replace([
+        $paths = array_replace([
             'capture' => 'capture.php',
             'notify' => 'notify.php',
             'authorize' => 'authorize.php',
             'refund' => 'refund.php',
             'payout' => 'payout.php',
-        ], $this->genericTokenFactoryPaths));
-        $httpRequestVerifier = $this->buildHttpRequestVerifier($this->tokenStorage);
+        ], $this->genericTokenFactoryPaths);
+
+        $presetContainer = $this->globalContainer;
+
+        $builder = new ContainerBuilder();
 
         $builder->addDefinitions([
-            HttpRequestVerifierInterface::class => $httpRequestVerifier,
-            GenericTokenFactoryInterface::class => $genericTokenFactory,
-            TokenFactoryInterface::class => $tokenFactory,
-            'payum.security.token_storage' => $this->tokenStorage,
+            'payum.security.token_storage' => $tokenStorage,
+
+            // Payum's own token factory, unless the application brought its own. Resolving it here rather
+            // than only in the fallback keeps the generic factory below built on top of the right one.
+            TokenFactoryInterface::class => function () use ($presetContainer, $tokenStorage, $storageRegistry) {
+                if ($presetContainer?->has(TokenFactoryInterface::class)) {
+                    return $presetContainer->get(TokenFactoryInterface::class);
+                }
+
+                return $this->buildTokenFactory($tokenStorage, $storageRegistry);
+            },
+            GenericTokenFactoryInterface::class => fn (ContainerInterface $c): GenericTokenFactoryInterface => $this->buildGenericTokenFactory($c->get(TokenFactoryInterface::class), $paths),
+            HttpRequestVerifierInterface::class => fn (): HttpRequestVerifierInterface => $this->buildHttpRequestVerifier($tokenStorage),
             ClientInterface::class => fn () => Psr18ClientDiscovery::find(),
             StreamFactoryInterface::class => fn () => Psr17FactoryDiscovery::findStreamFactory(),
             RequestFactoryInterface::class => fn () => Psr17FactoryDiscovery::findRequestFactory(),
@@ -439,7 +450,35 @@ class PayumBuilder
 
         $builder->addDefinitions($this->globalDefinitions);
 
-        return $builder->build();
+        $container = $builder->build();
+
+        if ($this->globalContainer) {
+            $container = new FallbackContainer($this->globalContainer, $container);
+        }
+
+        return $container;
+    }
+
+    /**
+     * The token storage in effect: the one set on the builder, else the one the application's container
+     * provides, else Payum's default storages.
+     *
+     * @return StorageInterface<TokenInterface>
+     */
+    protected function resolveTokenStorage(): StorageInterface
+    {
+        if (! $this->tokenStorage && $this->globalContainer?->has('payum.security.token_storage')) {
+            /** @var StorageInterface<TokenInterface> $tokenStorage */
+            $tokenStorage = $this->globalContainer->get('payum.security.token_storage');
+
+            return $tokenStorage;
+        }
+
+        if (! $this->tokenStorage) {
+            $this->addDefaultStorages();
+        }
+
+        return $this->tokenStorage;
     }
 
     /**
@@ -467,16 +506,8 @@ class PayumBuilder
         // Everything registered with addGlobalService() is shared as well.
         $ids = array_merge($ids, array_keys($this->globalDefinitions));
 
-        // A pre-built PHP-DI container can be asked for the rest of what it holds. Its own entries are
-        // left out, so that a gateway keeps being injected with its own container.
-        if ($globalContainer instanceof Container) {
-            $ids = array_merge($ids, array_diff($globalContainer->getKnownEntryNames(), [
-                ContainerInterface::class,
-                Container::class,
-                FactoryInterface::class,
-                InvokerInterface::class,
-            ]));
-        }
+        // Plus the rest of what the global container is able to report.
+        $ids = array_merge($ids, $this->getKnownEntryNames($globalContainer));
 
         $definitions = [];
         foreach (array_unique($ids) as $id) {
@@ -484,6 +515,28 @@ class PayumBuilder
         }
 
         return $definitions;
+    }
+
+    /**
+     * The ids a container can report, if any. The container's own entries are left out, so that a gateway
+     * keeps being injected with its own container rather than the global one.
+     *
+     * @return list<string>
+     */
+    protected function getKnownEntryNames(ContainerInterface $container): array
+    {
+        $names = [];
+
+        if ($container instanceof FallbackContainer || $container instanceof Container) {
+            $names = $container->getKnownEntryNames();
+        }
+
+        return array_values(array_diff($names, [
+            ContainerInterface::class,
+            Container::class,
+            FactoryInterface::class,
+            InvokerInterface::class,
+        ]));
     }
 
     /**

--- a/src/Payum/Core/Tests/Action/PrependActionInterfaceTest.php
+++ b/src/Payum/Core/Tests/Action/PrependActionInterfaceTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Payum\Core\Tests\Action;
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Action\PrependActionInterface;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class PrependActionInterfaceTest extends TestCase
+{
+    public function testShouldBeInterface(): void
+    {
+        $rc = new ReflectionClass(PrependActionInterface::class);
+
+        $this->assertTrue($rc->isInterface());
+    }
+
+    public function testShouldBeMarkerInterfaceWithoutAnyMethod(): void
+    {
+        $rc = new ReflectionClass(PrependActionInterface::class);
+
+        $this->assertSame([], $rc->getMethods());
+    }
+
+    public function testShouldNotExtendActionInterface(): void
+    {
+        $rc = new ReflectionClass(PrependActionInterface::class);
+
+        $this->assertFalse($rc->isSubclassOf(ActionInterface::class));
+        $this->assertSame([], $rc->getInterfaceNames());
+    }
+
+    public function testShouldBeImplementableTogetherWithActionInterface(): void
+    {
+        $action = new class() implements ActionInterface, PrependActionInterface {
+            public function execute($request): void
+            {
+            }
+
+            public function supports($request): bool
+            {
+                return true;
+            }
+        };
+
+        $this->assertInstanceOf(ActionInterface::class, $action);
+        $this->assertInstanceOf(PrependActionInterface::class, $action);
+    }
+
+    public function testShouldNotMarkPlainActionAsPrepending(): void
+    {
+        $action = new class() implements ActionInterface {
+            public function execute($request): void
+            {
+            }
+
+            public function supports($request): bool
+            {
+                return true;
+            }
+        };
+
+        $this->assertNotInstanceOf(PrependActionInterface::class, $action);
+    }
+}

--- a/src/Payum/Core/Tests/CoreGatewayFactoryContainerConfigurationTest.php
+++ b/src/Payum/Core/Tests/CoreGatewayFactoryContainerConfigurationTest.php
@@ -623,10 +623,10 @@ class CoreGatewayFactoryContainerConfigurationTest extends TestCase
         ]);
 
         $this->assertInstanceOf(ArrayObject::class, $capturedArrayObject);
-        $this->assertTrue(isset($capturedArrayObject['payum.template.layout']));
-        $this->assertTrue(isset($capturedArrayObject['payum.action.probe']));
-        $this->assertFalse(isset($capturedArrayObject['payum.security.token_storage']));
-        $this->assertFalse(isset($capturedArrayObject['an.unknown.service']));
+        $this->assertArrayHasKey('payum.template.layout', $capturedArrayObject);
+        $this->assertArrayHasKey('payum.action.probe', $capturedArrayObject);
+        $this->assertArrayNotHasKey('payum.security.token_storage', $capturedArrayObject);
+        $this->assertArrayNotHasKey('an.unknown.service', $capturedArrayObject);
     }
 
     public function testCreateShouldPrependLegacyConfiguredActionImplementingPrependActionInterface(): void

--- a/src/Payum/Core/Tests/CoreGatewayFactoryContainerConfigurationTest.php
+++ b/src/Payum/Core/Tests/CoreGatewayFactoryContainerConfigurationTest.php
@@ -1,0 +1,920 @@
+<?php
+
+namespace Payum\Core\Tests;
+
+use DI\Container;
+use DI\ContainerBuilder;
+use Http\Client\HttpClient;
+use Http\Message\MessageFactory;
+use Http\Message\StreamFactory;
+use LogicException;
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Action\AuthorizePaymentAction;
+use Payum\Core\Action\CapturePaymentAction;
+use Payum\Core\Action\ExecuteSameRequestWithModelDetailsAction;
+use Payum\Core\Action\GetCurrencyAction;
+use Payum\Core\Action\GetTokenAction;
+use Payum\Core\Action\PayoutPayoutAction;
+use Payum\Core\Action\PrependActionInterface;
+use Payum\Core\Bridge\Httplug\HttplugClient;
+use Payum\Core\Bridge\PlainPhp\Action\GetHttpRequestAction;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Bridge\Twig\Action\RenderTemplateAction;
+use Payum\Core\CoreGatewayFactory;
+use Payum\Core\DI\ContainerConfiguration;
+use Payum\Core\Extension\Context;
+use Payum\Core\Extension\EndlessCycleDetectorExtension;
+use Payum\Core\Extension\ExtensionInterface;
+use Payum\Core\Extension\PrependExtensionInterface;
+use Payum\Core\Gateway;
+use Payum\Core\GatewayFactoryConfigInterface;
+use Payum\Core\GatewayFactoryInterface;
+use Payum\Core\Storage\StorageInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use ReflectionClass;
+use stdClass;
+use Twig\Environment;
+use Twig\Loader\ChainLoader;
+
+class CoreGatewayFactoryContainerConfigurationTest extends TestCase
+{
+    public function testShouldImplementContainerConfigurationInterface(): void
+    {
+        $rc = new ReflectionClass(CoreGatewayFactory::class);
+
+        $this->assertTrue($rc->implementsInterface(ContainerConfiguration::class));
+    }
+
+    public function testShouldImplementGatewayFactoryConfigInterface(): void
+    {
+        $rc = new ReflectionClass(CoreGatewayFactory::class);
+
+        $this->assertTrue($rc->implementsInterface(GatewayFactoryConfigInterface::class));
+    }
+
+    public function testShouldStillImplementGatewayFactoryInterface(): void
+    {
+        $rc = new ReflectionClass(CoreGatewayFactory::class);
+
+        $this->assertTrue($rc->implementsInterface(GatewayFactoryInterface::class));
+    }
+
+    public function testConfigureContainerShouldReturnDefinitionsForAllDefaultServices(): void
+    {
+        $definitions = (new CoreGatewayFactory())->configureContainer();
+
+        $this->assertIsArray($definitions);
+
+        foreach ([
+            'httplug.message_factory',
+            'httplug.stream_factory',
+            'httplug.client',
+            ClientInterface::class,
+            StreamFactoryInterface::class,
+            RequestFactoryInterface::class,
+            ResponseFactoryInterface::class,
+            'payum.http_client',
+            'payum.http_stream_factory',
+            'payum.http_message_factory',
+            'payum.template.layout',
+            'twig.env',
+            Environment::class,
+            HttpClient::class,
+            'payum.default_options',
+            'payum.required_options',
+            'payum.prepend_actions',
+            'payum.prepend_apis',
+            'payum.prepend_extensions',
+            'payum.api.http_client',
+            'payum.paths',
+            'payum.action.get_http_request',
+            'payum.action.capture_payment',
+            'payum.action.authorize_payment',
+            'payum.action.payout_payout',
+            'payum.action.execute_same_request_with_model_details',
+            'payum.action.get_currency',
+            'payum.action.render_template',
+            'payum.action.get_token',
+            'payum.extension.endless_cycle_detector',
+            RenderTemplateAction::class,
+            GetTokenAction::class,
+        ] as $expectedId) {
+            $this->assertArrayHasKey($expectedId, $definitions);
+        }
+    }
+
+    public function testConfigureContainerShouldNotRegisterTokenStorageByDefault(): void
+    {
+        $definitions = (new CoreGatewayFactory())->configureContainer();
+
+        $this->assertArrayNotHasKey('payum.security.token_storage', $definitions);
+    }
+
+    public function testConfigureContainerShouldIncludeDefaultConfigGivenInConstructor(): void
+    {
+        $factory = new CoreGatewayFactory([
+            'foo' => 'fooVal',
+            'payum.security.token_storage' => $tokenStorage = $this->createMock(StorageInterface::class),
+        ]);
+
+        $definitions = $factory->configureContainer();
+
+        $this->assertSame('fooVal', $definitions['foo']);
+        $this->assertSame($tokenStorage, $definitions['payum.security.token_storage']);
+    }
+
+    public function testConfigureContainerShouldGiveTheConstructorDefaultConfigPrecedenceOverTheBuiltInDefinitions(): void
+    {
+        $factory = new CoreGatewayFactory([
+            'payum.template.layout' => 'aCustomLayout.html.twig',
+            'payum.paths' => [
+                'AcmeGateway' => '/path/to/acme/views',
+            ],
+        ]);
+
+        $definitions = $factory->configureContainer();
+
+        $this->assertSame('aCustomLayout.html.twig', $definitions['payum.template.layout']);
+        $this->assertSame([
+            'AcmeGateway' => '/path/to/acme/views',
+        ], $definitions['payum.paths']);
+    }
+
+    public function testConfigureContainerShouldProvideStaticDefaults(): void
+    {
+        $definitions = (new CoreGatewayFactory())->configureContainer();
+
+        $this->assertSame('@PayumCore/layout.html.twig', $definitions['payum.template.layout']);
+        $this->assertSame([], $definitions['payum.default_options']);
+        $this->assertSame([], $definitions['payum.required_options']);
+        $this->assertSame([], $definitions['payum.prepend_actions']);
+        $this->assertSame([], $definitions['payum.prepend_apis']);
+        $this->assertSame([], $definitions['payum.prepend_extensions']);
+        $this->assertSame([
+            'PayumCore' => dirname(__DIR__) . '/Resources/views',
+        ], $definitions['payum.paths']);
+    }
+
+    public function testShouldResolvePsr17And18ServicesFromContainer(): void
+    {
+        $container = $this->buildContainer();
+
+        $this->assertInstanceOf(ClientInterface::class, $container->get(ClientInterface::class));
+        $this->assertInstanceOf(StreamFactoryInterface::class, $container->get(StreamFactoryInterface::class));
+        $this->assertInstanceOf(RequestFactoryInterface::class, $container->get(RequestFactoryInterface::class));
+    }
+
+    public function testShouldResolvePayumHttpClientAsHttplugClientWrappingThePsr18Client(): void
+    {
+        $container = $this->buildContainer();
+
+        $httpClient = $container->get('payum.http_client');
+
+        $this->assertInstanceOf(HttplugClient::class, $httpClient);
+        $this->assertSame($container->get(ClientInterface::class), $this->readAttribute($httpClient, 'client'));
+    }
+
+    public function testShouldResolveLegacyHttpServiceNamesToThePsrServices(): void
+    {
+        $container = $this->buildContainer();
+
+        $this->assertSame($container->get(StreamFactoryInterface::class), $container->get('payum.http_stream_factory'));
+        $this->assertSame($container->get(RequestFactoryInterface::class), $container->get('payum.http_message_factory'));
+        $this->assertSame($container->get('payum.http_client'), $container->get('payum.api.http_client'));
+        $this->assertSame($container->get('payum.http_client'), $container->get(HttpClient::class));
+    }
+
+    public function testShouldAliasResponseFactoryInterfaceToRequestFactoryInterface(): void
+    {
+        $container = $this->buildContainer();
+
+        $this->assertSame($container->get(RequestFactoryInterface::class), $container->get(ResponseFactoryInterface::class));
+    }
+
+    public function testShouldAliasTwigEnvironmentClassToTwigEnvService(): void
+    {
+        $container = $this->buildContainer();
+
+        $this->assertInstanceOf(Environment::class, $container->get('twig.env'));
+        $this->assertSame($container->get('twig.env'), $container->get(Environment::class));
+    }
+
+    public function testShouldCreateTwigEnvironmentWithChainLoader(): void
+    {
+        $container = $this->buildContainer();
+
+        $this->assertInstanceOf(ChainLoader::class, $container->get('twig.env')->getLoader());
+    }
+
+    public function testShouldResolveDeprecatedActionDefinitions(): void
+    {
+        $container = $this->buildContainer();
+
+        $this->assertInstanceOf(GetHttpRequestAction::class, $container->get('payum.action.get_http_request'));
+        $this->assertInstanceOf(CapturePaymentAction::class, $container->get('payum.action.capture_payment'));
+        $this->assertInstanceOf(AuthorizePaymentAction::class, $container->get('payum.action.authorize_payment'));
+        $this->assertInstanceOf(PayoutPayoutAction::class, $container->get('payum.action.payout_payout'));
+        $this->assertInstanceOf(ExecuteSameRequestWithModelDetailsAction::class, $container->get('payum.action.execute_same_request_with_model_details'));
+        $this->assertInstanceOf(GetCurrencyAction::class, $container->get('payum.action.get_currency'));
+        $this->assertInstanceOf(RenderTemplateAction::class, $container->get('payum.action.render_template'));
+        $this->assertInstanceOf(EndlessCycleDetectorExtension::class, $container->get('payum.extension.endless_cycle_detector'));
+    }
+
+    public function testShouldResolveRenderTemplateActionWithTwigEnvironmentAndLayout(): void
+    {
+        $container = $this->buildContainer();
+
+        $action = $container->get(RenderTemplateAction::class);
+
+        $this->assertInstanceOf(RenderTemplateAction::class, $action);
+        $this->assertSame($container->get('twig.env'), $this->readAttribute($action, 'twig'));
+        $this->assertSame('@PayumCore/layout.html.twig', $this->readAttribute($action, 'layout'));
+    }
+
+    public function testShouldResolveDeprecatedGetTokenActionEntryToNullWhenTokenStorageIsMissing(): void
+    {
+        $container = $this->buildContainer();
+
+        $this->assertFalse($container->has('payum.security.token_storage'));
+        $this->assertNull($container->get('payum.action.get_token'));
+    }
+
+    public function testShouldResolveDeprecatedGetTokenActionEntryWhenTokenStorageIsConfigured(): void
+    {
+        $tokenStorage = $this->createMock(StorageInterface::class);
+
+        $container = $this->buildContainer([
+            'payum.security.token_storage' => $tokenStorage,
+        ]);
+
+        $action = $container->get('payum.action.get_token');
+
+        $this->assertInstanceOf(GetTokenAction::class, $action);
+        $this->assertSame($tokenStorage, $this->readAttribute($action, 'tokenStorage'));
+    }
+
+    public function testShouldThrowWhenGetTokenActionClassIsResolvedWithoutTokenStorage(): void
+    {
+        $container = $this->buildContainer();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Token storage must be configured to use GetTokenAction');
+
+        $container->get(GetTokenAction::class);
+    }
+
+    public function testShouldResolveGetTokenActionClassWhenTokenStorageIsConfigured(): void
+    {
+        $tokenStorage = $this->createMock(StorageInterface::class);
+
+        $container = $this->buildContainer([
+            'payum.security.token_storage' => $tokenStorage,
+        ]);
+
+        $action = $container->get(GetTokenAction::class);
+
+        $this->assertInstanceOf(GetTokenAction::class, $action);
+        $this->assertSame($tokenStorage, $this->readAttribute($action, 'tokenStorage'));
+    }
+
+    public function testShouldResolveDeprecatedHttplugMessageFactory(): void
+    {
+        $definitions = (new CoreGatewayFactory())->configureContainer();
+
+        $deprecations = $this->collectDeprecations(function () use ($definitions, &$messageFactory): void {
+            $messageFactory = $definitions['httplug.message_factory']();
+        });
+
+        $this->assertInstanceOf(MessageFactory::class, $messageFactory);
+        $this->assertContains(
+            'Using "httplug.message_factory" is deprecated, use "payum.http_message_factory" instead, which will return a PSR-17 RequestFactoryInterface since payum/core 2.0.0',
+            $deprecations
+        );
+    }
+
+    public function testShouldResolveDeprecatedHttplugStreamFactory(): void
+    {
+        $definitions = (new CoreGatewayFactory())->configureContainer();
+
+        $deprecations = $this->collectDeprecations(function () use ($definitions, &$streamFactory): void {
+            $streamFactory = $definitions['httplug.stream_factory']();
+        });
+
+        $this->assertInstanceOf(StreamFactory::class, $streamFactory);
+        $this->assertContains(
+            'Using "httplug.stream_factory" is deprecated, use "payum.http_stream_factory" instead which will return a PSR-17 StreamFactoryInterface since payum/core 2.0.0',
+            $deprecations
+        );
+    }
+
+    public function testShouldResolveDeprecatedHttplugClient(): void
+    {
+        $definitions = (new CoreGatewayFactory())->configureContainer();
+
+        $deprecations = $this->collectDeprecations(function () use ($definitions, &$client): void {
+            $client = $definitions['httplug.client'](new ArrayObject());
+        });
+
+        $this->assertInstanceOf(ClientInterface::class, $client);
+        $this->assertContains(
+            'Using "httplug.client" is deprecated, use "payum.http_client" instead which will return a PSR-18 ClientInterface since payum/core 2.0.0',
+            $deprecations
+        );
+    }
+
+    public function testGetActionsShouldReturnTheDefaultActionClasses(): void
+    {
+        $this->assertSame([
+            GetHttpRequestAction::class,
+            CapturePaymentAction::class,
+            AuthorizePaymentAction::class,
+            PayoutPayoutAction::class,
+            ExecuteSameRequestWithModelDetailsAction::class,
+            RenderTemplateAction::class,
+            GetCurrencyAction::class,
+            GetTokenAction::class,
+        ], (new CoreGatewayFactory())->getActions());
+    }
+
+    public function testGetExtensionsShouldReturnTheDefaultExtensionClasses(): void
+    {
+        $this->assertSame([
+            EndlessCycleDetectorExtension::class,
+        ], (new CoreGatewayFactory())->getExtensions());
+    }
+
+    public function testCreateGatewayShouldReturnGatewayWithAllDefaultActionsAndExtensions(): void
+    {
+        $factory = new CoreGatewayFactory();
+
+        $gateway = $factory->createGateway($this->buildContainer());
+
+        $this->assertInstanceOf(Gateway::class, $gateway);
+
+        $actions = $this->readAttribute($gateway, 'actions');
+
+        $this->assertContainsOnlyInstancesOf(ActionInterface::class, $actions);
+        $this->assertSame([
+            GetHttpRequestAction::class,
+            CapturePaymentAction::class,
+            AuthorizePaymentAction::class,
+            PayoutPayoutAction::class,
+            ExecuteSameRequestWithModelDetailsAction::class,
+            RenderTemplateAction::class,
+            GetCurrencyAction::class,
+        ], array_map('get_class', $actions));
+
+        $extensions = $this->readAttribute($this->readAttribute($gateway, 'extensions'), 'extensions');
+
+        $this->assertSame([
+            EndlessCycleDetectorExtension::class,
+        ], array_map('get_class', $extensions));
+    }
+
+    public function testCreateGatewayShouldSkipGetTokenActionWhenTokenStorageIsNotConfigured(): void
+    {
+        $factory = new CoreGatewayFactory();
+
+        $gateway = $factory->createGateway($this->buildContainer());
+
+        $actions = $this->readAttribute($gateway, 'actions');
+
+        $this->assertNotContains(GetTokenAction::class, array_map('get_class', $actions));
+    }
+
+    public function testCreateGatewayShouldAddGetTokenActionWhenTokenStorageIsConfigured(): void
+    {
+        $tokenStorage = $this->createMock(StorageInterface::class);
+
+        $factory = new CoreGatewayFactory();
+
+        $gateway = $factory->createGateway($this->buildContainer([
+            'payum.security.token_storage' => $tokenStorage,
+        ]));
+
+        $actions = $this->readAttribute($gateway, 'actions');
+
+        $this->assertContains(GetTokenAction::class, array_map('get_class', $actions));
+    }
+
+    public function testCreateGatewayShouldResolveActionsFromTheContainer(): void
+    {
+        $expectedAction = new CoreGatewayFactoryTestAction();
+
+        $factory = new CoreGatewayFactoryWithCustomServices([CoreGatewayFactoryTestAction::class], []);
+
+        $gateway = $factory->createGateway($this->buildContainer([
+            CoreGatewayFactoryTestAction::class => $expectedAction,
+        ]));
+
+        $this->assertSame([$expectedAction], $this->readAttribute($gateway, 'actions'));
+    }
+
+    public function testCreateGatewayShouldAutowireActionsWhichAreNotDefinedInTheContainer(): void
+    {
+        $factory = new CoreGatewayFactoryWithCustomServices([CoreGatewayFactoryTestAction::class], []);
+
+        $gateway = $factory->createGateway($this->buildContainer());
+
+        $this->assertSame([CoreGatewayFactoryTestAction::class], array_map(
+            'get_class',
+            $this->readAttribute($gateway, 'actions')
+        ));
+    }
+
+    public function testCreateGatewayShouldAcceptExtensionInstances(): void
+    {
+        $expectedExtension = new CoreGatewayFactoryTestExtension();
+
+        $factory = new CoreGatewayFactoryWithCustomServices([], [$expectedExtension]);
+
+        $gateway = $factory->createGateway($this->buildContainer());
+
+        $this->assertSame(
+            [$expectedExtension],
+            $this->readAttribute($this->readAttribute($gateway, 'extensions'), 'extensions')
+        );
+    }
+
+    public function testCreateGatewayShouldPrependActionsResolvedFromContainerImplementingPrependActionInterface(): void
+    {
+        $factory = new CoreGatewayFactoryWithCustomServices(
+            [CoreGatewayFactoryTestAction::class, CoreGatewayFactoryTestPrependAction::class],
+            []
+        );
+
+        $gateway = $factory->createGateway($this->buildContainer());
+
+        $this->assertSame([
+            CoreGatewayFactoryTestPrependAction::class,
+            CoreGatewayFactoryTestAction::class,
+        ], array_map('get_class', $this->readAttribute($gateway, 'actions')));
+    }
+
+    public function testCreateGatewayShouldPrependExtensionsImplementingPrependExtensionInterface(): void
+    {
+        $regularExtension = new CoreGatewayFactoryTestExtension();
+        $prependExtension = new CoreGatewayFactoryTestPrependExtension();
+
+        $factory = new CoreGatewayFactoryWithCustomServices([], [$regularExtension, $prependExtension]);
+
+        $gateway = $factory->createGateway($this->buildContainer());
+
+        $this->assertSame(
+            [$prependExtension, $regularExtension],
+            $this->readAttribute($this->readAttribute($gateway, 'extensions'), 'extensions')
+        );
+    }
+
+    public function testCreateGatewayShouldPrependExtensionsResolvedFromContainerImplementingPrependExtensionInterface(): void
+    {
+        $factory = new CoreGatewayFactoryWithCustomServices(
+            [],
+            [CoreGatewayFactoryTestExtension::class, CoreGatewayFactoryTestPrependExtension::class]
+        );
+
+        $gateway = $factory->createGateway($this->buildContainer());
+
+        $this->assertSame([
+            CoreGatewayFactoryTestPrependExtension::class,
+            CoreGatewayFactoryTestExtension::class,
+        ], array_map('get_class', $this->readAttribute($this->readAttribute($gateway, 'extensions'), 'extensions')));
+    }
+
+    public function testCreateGatewayShouldReuseTheGatewayGivenAsSecondArgument(): void
+    {
+        $existingAction = new CoreGatewayFactoryTestAction();
+
+        $existingGateway = new Gateway();
+        $existingGateway->addAction($existingAction);
+
+        $factory = new CoreGatewayFactoryWithCustomServices([CoreGatewayFactoryTestPrependAction::class], []);
+
+        $gateway = $factory->createGateway($this->buildContainer(), $existingGateway);
+
+        $this->assertSame($existingGateway, $gateway);
+        $this->assertSame([
+            CoreGatewayFactoryTestPrependAction::class,
+            CoreGatewayFactoryTestAction::class,
+        ], array_map('get_class', $this->readAttribute($gateway, 'actions')));
+    }
+
+    public function testCreateGatewayShouldIgnoreSecondArgumentWhichIsNotAGateway(): void
+    {
+        $factory = new CoreGatewayFactoryWithCustomServices([], []);
+
+        $gateway = $factory->createGateway($this->buildContainer(), new stdClass());
+
+        $this->assertInstanceOf(Gateway::class, $gateway);
+        $this->assertSame([], $this->readAttribute($gateway, 'actions'));
+    }
+
+    public function testCreateGatewayShouldRegisterPayumCoreTwigPath(): void
+    {
+        $factory = new CoreGatewayFactory();
+
+        $container = $this->buildContainer();
+
+        $factory->createGateway($container);
+
+        $this->assertTrue($container->get('twig.env')->getLoader()->exists('@PayumCore/layout.html.twig'));
+    }
+
+    public function testCreateGatewayShouldRegisterTheConfiguredTwigPaths(): void
+    {
+        $factory = new CoreGatewayFactory();
+
+        $container = $this->buildContainer([
+            'payum.paths' => [
+                'PayumCoreTestNamespace' => dirname(__DIR__) . '/Resources/views',
+            ],
+        ]);
+
+        $factory->createGateway($container);
+
+        $loader = $container->get('twig.env')->getLoader();
+
+        $this->assertTrue($loader->exists('@PayumCoreTestNamespace/layout.html.twig'));
+        $this->assertTrue($loader->exists('@PayumCore/layout.html.twig'));
+    }
+
+    public function testCreateShouldTriggerDeprecation(): void
+    {
+        $factory = new CoreGatewayFactory();
+
+        $deprecations = $this->collectDeprecations(static function () use ($factory): void {
+            $factory->create();
+        });
+
+        $this->assertContains(
+            'Since payum/core 2.0.0: The Payum\Core\CoreGatewayFactory::create is deprecated. Implement the Payum\Core\DI\ContainerConfiguration interface instead.',
+            $deprecations
+        );
+    }
+
+    public function testCreateShouldTriggerDeprecationForEveryDeprecatedBuildMethod(): void
+    {
+        $factory = new CoreGatewayFactory();
+
+        $deprecations = $this->collectDeprecations(static function () use ($factory): void {
+            $factory->create();
+        });
+
+        foreach (['buildClosures', 'buildActions', 'buildApis', 'buildExtensions'] as $method) {
+            $this->assertContains(
+                sprintf(
+                    'Since payum/core 2.0.0: The Payum\Core\CoreGatewayFactory::%s is deprecated. Implement the Payum\Core\DI\ContainerConfiguration interface instead.',
+                    $method
+                ),
+                $deprecations
+            );
+        }
+    }
+
+    public function testCreateShouldTriggerDeprecationForApiConfig(): void
+    {
+        $factory = new CoreGatewayFactory();
+
+        $deprecations = $this->collectDeprecations(static function () use ($factory): void {
+            $factory->create();
+        });
+
+        $this->assertContains(
+            'The payum.api.* config is deprecated and will be removed in 3.0. Use dependency-injection to inject the api into the action instead.',
+            $deprecations
+        );
+    }
+
+    public function testCreateShouldRegisterBackwardCompatibleArrayObjectServiceDelegatingToTheContainer(): void
+    {
+        $capturedArrayObject = null;
+
+        $factory = new CoreGatewayFactory();
+
+        $factory->create([
+            'payum.action.probe' => static function (ContainerInterface $container) use (&$capturedArrayObject): ActionInterface {
+                $capturedArrayObject = $container->get(ArrayObject::class);
+
+                return new CoreGatewayFactoryTestAction();
+            },
+        ]);
+
+        $this->assertInstanceOf(ArrayObject::class, $capturedArrayObject);
+        $this->assertSame('@PayumCore/layout.html.twig', $capturedArrayObject['payum.template.layout']);
+        $this->assertInstanceOf(GetHttpRequestAction::class, $capturedArrayObject['payum.action.get_http_request']);
+    }
+
+    public function testCreateShouldRegisterBackwardCompatibleArrayObjectServiceCheckingTheContainerForExistence(): void
+    {
+        $capturedArrayObject = null;
+
+        $factory = new CoreGatewayFactory();
+
+        $factory->create([
+            'payum.action.probe' => static function (ContainerInterface $container) use (&$capturedArrayObject): ActionInterface {
+                $capturedArrayObject = $container->get(ArrayObject::class);
+
+                return new CoreGatewayFactoryTestAction();
+            },
+        ]);
+
+        $this->assertInstanceOf(ArrayObject::class, $capturedArrayObject);
+        $this->assertTrue(isset($capturedArrayObject['payum.template.layout']));
+        $this->assertTrue(isset($capturedArrayObject['payum.action.probe']));
+        $this->assertFalse(isset($capturedArrayObject['payum.security.token_storage']));
+        $this->assertFalse(isset($capturedArrayObject['an.unknown.service']));
+    }
+
+    public function testCreateShouldPrependLegacyConfiguredActionImplementingPrependActionInterface(): void
+    {
+        $regularAction = new CoreGatewayFactoryTestAction();
+        $prependAction = new CoreGatewayFactoryTestPrependAction();
+
+        $factory = new CoreGatewayFactory();
+
+        $gateway = $factory->create([
+            'payum.action.regular' => $regularAction,
+            'payum.action.prepend' => $prependAction,
+        ]);
+
+        $actions = $this->readAttribute($gateway, 'actions');
+
+        $this->assertSame($prependAction, $actions[0]);
+        $this->assertSame($regularAction, $actions[1]);
+    }
+
+    public function testCreateShouldPrependLegacyConfiguredExtensionImplementingPrependExtensionInterface(): void
+    {
+        $regularExtension = new CoreGatewayFactoryTestExtension();
+        $prependExtension = new CoreGatewayFactoryTestPrependExtension();
+
+        $factory = new CoreGatewayFactory();
+
+        $gateway = $factory->create([
+            'payum.extension.regular' => $regularExtension,
+            'payum.extension.prepend' => $prependExtension,
+        ]);
+
+        $extensions = $this->readAttribute($this->readAttribute($gateway, 'extensions'), 'extensions');
+
+        $this->assertSame($prependExtension, $extensions[0]);
+        $this->assertSame($regularExtension, $extensions[1]);
+    }
+
+    public function testCreateShouldStillHonourThePrependActionsConfigOption(): void
+    {
+        $firstAction = new CoreGatewayFactoryTestAction();
+        $secondAction = new CoreGatewayFactoryTestAction();
+
+        $factory = new CoreGatewayFactory();
+
+        $gateway = $factory->create([
+            'payum.action.first' => $firstAction,
+            'payum.action.second' => $secondAction,
+            'payum.prepend_actions' => ['payum.action.second'],
+        ]);
+
+        $actions = $this->readAttribute($gateway, 'actions');
+
+        $this->assertSame($secondAction, $actions[0]);
+        $this->assertSame($firstAction, $actions[1]);
+    }
+
+    public function testCreateShouldStillHonourThePrependExtensionsConfigOption(): void
+    {
+        $firstExtension = new CoreGatewayFactoryTestExtension();
+        $secondExtension = new CoreGatewayFactoryTestExtension();
+
+        $factory = new CoreGatewayFactory();
+
+        $gateway = $factory->create([
+            'payum.extension.first' => $firstExtension,
+            'payum.extension.second' => $secondExtension,
+            'payum.prepend_extensions' => ['payum.extension.second'],
+        ]);
+
+        $extensions = $this->readAttribute($this->readAttribute($gateway, 'extensions'), 'extensions');
+
+        $this->assertSame($secondExtension, $extensions[0]);
+        $this->assertSame($firstExtension, $extensions[1]);
+    }
+
+    public function testCreateShouldAlsoAddTheActionsAndExtensionsOfTheNewContainerConfiguration(): void
+    {
+        $factory = new CoreGatewayFactory();
+
+        $gateway = $factory->create();
+
+        $actionClasses = array_map('get_class', $this->readAttribute($gateway, 'actions'));
+        $extensionClasses = array_map(
+            'get_class',
+            $this->readAttribute($this->readAttribute($gateway, 'extensions'), 'extensions')
+        );
+
+        $this->assertContains(GetHttpRequestAction::class, $actionClasses);
+        $this->assertContains(RenderTemplateAction::class, $actionClasses);
+        $this->assertContains(GetCurrencyAction::class, $actionClasses);
+        $this->assertContains(EndlessCycleDetectorExtension::class, $extensionClasses);
+    }
+
+    public function testCreateShouldNotAddGetTokenActionWhenTokenStorageIsNotConfigured(): void
+    {
+        $factory = new CoreGatewayFactory();
+
+        $gateway = $factory->create();
+
+        $this->assertNotContains(GetTokenAction::class, array_map('get_class', $this->readAttribute($gateway, 'actions')));
+    }
+
+    public function testCreateShouldAddGetTokenActionWhenTokenStorageIsConfigured(): void
+    {
+        $factory = new CoreGatewayFactory();
+
+        $gateway = $factory->create([
+            'payum.security.token_storage' => $this->createMock(StorageInterface::class),
+        ]);
+
+        $this->assertContains(GetTokenAction::class, array_map('get_class', $this->readAttribute($gateway, 'actions')));
+    }
+
+    public function testCreateConfigShouldTriggerDeprecation(): void
+    {
+        $factory = new CoreGatewayFactory();
+
+        $deprecations = $this->collectDeprecations(static function () use ($factory): void {
+            $factory->createConfig();
+        });
+
+        $this->assertContains(
+            'Since payum/core 2.0.0: The Payum\Core\CoreGatewayFactory::createConfig is deprecated. Implement the Payum\Core\DI\ContainerConfiguration interface instead.',
+            $deprecations
+        );
+    }
+
+    public function testCreateConfigShouldReturnTheContainerDefinitionsWhenNoConfigIsGiven(): void
+    {
+        $factory = new CoreGatewayFactory();
+
+        $this->assertEquals($factory->configureContainer(), $factory->createConfig());
+    }
+
+    public function testCreateConfigShouldLetTheGivenConfigOverrideTheContainerDefinitions(): void
+    {
+        $factory = new CoreGatewayFactory();
+
+        $config = $factory->createConfig([
+            'payum.template.layout' => 'aCustomLayout.html.twig',
+            'foo' => 'fooVal',
+        ]);
+
+        $this->assertSame('aCustomLayout.html.twig', $config['payum.template.layout']);
+        $this->assertSame('fooVal', $config['foo']);
+    }
+
+    public function testCreateConfigShouldMergeThePayumPathsInsteadOfReplacingThem(): void
+    {
+        $factory = new CoreGatewayFactory();
+
+        $config = $factory->createConfig([
+            'payum.paths' => [
+                'AcmeGateway' => '/path/to/acme/views',
+            ],
+        ]);
+
+        $this->assertSame([
+            'PayumCore' => dirname(__DIR__) . '/Resources/views',
+            'AcmeGateway' => '/path/to/acme/views',
+        ], $config['payum.paths']);
+    }
+
+    public function testCreateConfigShouldAllowOverridingASinglePayumPath(): void
+    {
+        $factory = new CoreGatewayFactory();
+
+        $config = $factory->createConfig([
+            'payum.paths' => [
+                'PayumCore' => '/path/to/custom/views',
+            ],
+        ]);
+
+        $this->assertSame([
+            'PayumCore' => '/path/to/custom/views',
+        ], $config['payum.paths']);
+    }
+
+    /**
+     * @param array<string, mixed> $definitions
+     */
+    private function buildContainer(array $definitions = []): Container
+    {
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->addDefinitions((new CoreGatewayFactory())->configureContainer());
+        $containerBuilder->addDefinitions($definitions);
+
+        return $containerBuilder->build();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function collectDeprecations(callable $callback): array
+    {
+        $deprecations = [];
+
+        set_error_handler(static function (int $errno, string $errstr) use (&$deprecations): bool {
+            $deprecations[] = $errstr;
+
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $callback();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $deprecations;
+    }
+}
+
+class CoreGatewayFactoryWithCustomServices extends CoreGatewayFactory
+{
+    /**
+     * @param list<class-string<ActionInterface>> $actions
+     * @param list<ExtensionInterface|class-string<ExtensionInterface>> $extensions
+     */
+    public function __construct(
+        private array $actions,
+        private array $extensions
+    ) {
+        parent::__construct();
+    }
+
+    public function getActions(): array
+    {
+        return $this->actions;
+    }
+
+    public function getExtensions(): array
+    {
+        return $this->extensions;
+    }
+}
+
+class CoreGatewayFactoryTestAction implements ActionInterface
+{
+    public function execute($request): void
+    {
+    }
+
+    public function supports($request): bool
+    {
+        return false;
+    }
+}
+
+class CoreGatewayFactoryTestPrependAction implements ActionInterface, PrependActionInterface
+{
+    public function execute($request): void
+    {
+    }
+
+    public function supports($request): bool
+    {
+        return false;
+    }
+}
+
+class CoreGatewayFactoryTestExtension implements ExtensionInterface
+{
+    public function onPreExecute(Context $context): void
+    {
+    }
+
+    public function onExecute(Context $context): void
+    {
+    }
+
+    public function onPostExecute(Context $context): void
+    {
+    }
+}
+
+class CoreGatewayFactoryTestPrependExtension implements ExtensionInterface, PrependExtensionInterface
+{
+    public function onPreExecute(Context $context): void
+    {
+    }
+
+    public function onExecute(Context $context): void
+    {
+    }
+
+    public function onPostExecute(Context $context): void
+    {
+    }
+}

--- a/src/Payum/Core/Tests/CoreGatewayFactoryTest.php
+++ b/src/Payum/Core/Tests/CoreGatewayFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Payum\Core\Tests;
 
 use Closure;
+use DI\Container;
 use Http\Message\RequestFactory;
 use Http\Message\StreamFactory;
 use Payum\Core\Action\ActionInterface;
@@ -19,13 +20,14 @@ use Payum\Core\Extension\ExtensionInterface;
 use Payum\Core\Gateway;
 use Payum\Core\GatewayFactoryInterface;
 use Payum\Core\Storage\StorageInterface;
+use Psr\Container\ContainerInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use ReflectionClass;
 use stdClass;
 use Twig\Environment;
-use Twig\Loader\FilesystemLoader;
+use Twig\Loader\ChainLoader;
 
 class CoreGatewayFactoryTest extends TestCase
 {
@@ -49,11 +51,13 @@ class CoreGatewayFactoryTest extends TestCase
     {
         $factory = new CoreGatewayFactory();
 
+        $container = $this->getContainer();
+
         $config = $factory->createConfig([]);
         $this->assertArrayHasKey('payum.api.http_client', $config);
         $this->assertInstanceOf(Closure::class, $config['payum.api.http_client']);
 
-        $this->assertSame($config['payum.http_client'], $config['payum.api.http_client'](new ArrayObject($config)));
+        $this->assertEquals($config['payum.http_client']($container), $config['payum.api.http_client']($container));
     }
 
     /**
@@ -65,9 +69,7 @@ class CoreGatewayFactoryTest extends TestCase
 
         $config = $factory->createConfig([]);
         $this->assertArrayHasKey('httplug.message_factory', $config);
-        $this->assertInstanceOf(Closure::class, $config['httplug.message_factory']);
-        $config['httplug.message_factory'] = call_user_func($config['httplug.message_factory'], ArrayObject::ensureArrayObject($config));
-        $this->assertInstanceOf(RequestFactory::class, $config['httplug.message_factory']);
+        $this->assertInstanceOf(RequestFactory::class, $config['httplug.message_factory']());
     }
 
     /**
@@ -79,31 +81,24 @@ class CoreGatewayFactoryTest extends TestCase
 
         $config = $factory->createConfig([]);
         $this->assertArrayHasKey('httplug.stream_factory', $config);
-        $this->assertInstanceOf(Closure::class, $config['httplug.stream_factory']);
-        $config['httplug.stream_factory'] = call_user_func($config['httplug.stream_factory'], ArrayObject::ensureArrayObject($config));
-        $this->assertInstanceOf(StreamFactory::class, $config['httplug.stream_factory']);
+        $this->assertInstanceOf(StreamFactory::class, $config['httplug.stream_factory']());
     }
 
     public function testShouldCreateDefaultHttMessageFactory(): void
     {
-        $factory = new CoreGatewayFactory();
+        $container = $this->getContainer();
 
-        $config = $factory->createConfig([]);
-        $this->assertArrayHasKey('payum.http_message_factory', $config);
-        $this->assertInstanceOf(Closure::class, $config['payum.http_message_factory']);
-        $config['payum.http_message_factory'] = call_user_func($config['payum.http_message_factory'], ArrayObject::ensureArrayObject($config));
-        $this->assertInstanceOf(RequestFactoryInterface::class, $config['payum.http_message_factory']);
+        $this->assertTrue($container->has('payum.http_message_factory'));
+        // createConfig() now returns resolved values, not closures
+        $this->assertInstanceOf(RequestFactoryInterface::class, $container->get('payum.http_message_factory'));
     }
 
     public function testShouldCreateDefaultHttStreamFactory(): void
     {
-        $factory = new CoreGatewayFactory();
-
-        $config = $factory->createConfig([]);
-        $this->assertArrayHasKey('payum.http_stream_factory', $config);
-        $this->assertInstanceOf(Closure::class, $config['payum.http_stream_factory']);
-        $config['payum.http_stream_factory'] = call_user_func($config['payum.http_stream_factory'], ArrayObject::ensureArrayObject($config));
-        $this->assertInstanceOf(StreamFactoryInterface::class, $config['payum.http_stream_factory']);
+        $container = $this->getContainer();
+        $this->assertTrue($container->has('payum.http_stream_factory'));
+        // createConfig() now returns resolved values, not closures
+        $this->assertInstanceOf(StreamFactoryInterface::class, $container->get('payum.http_stream_factory'));
     }
 
     public function testShouldCreateDefaultHttplugClient(): void
@@ -112,10 +107,17 @@ class CoreGatewayFactoryTest extends TestCase
 
         $config = $factory->createConfig([]);
         $this->assertArrayHasKey('httplug.client', $config);
+
+        // httplug.client is a closure that expects ArrayObject, so it won't be auto-resolved
         $this->assertInstanceOf(Closure::class, $config['httplug.client']);
 
-        $config['httplug.message_factory'] = call_user_func($config['httplug.message_factory'], ArrayObject::ensureArrayObject($config));
-        $config['httplug.stream_factory'] = call_user_func($config['httplug.stream_factory'], ArrayObject::ensureArrayObject($config));
+        // Resolve dependencies (may already be resolved by createConfig)
+        if ($config['httplug.message_factory'] instanceof Closure) {
+            $config['httplug.message_factory'] = call_user_func($config['httplug.message_factory'], ArrayObject::ensureArrayObject($config));
+        }
+        if ($config['httplug.stream_factory'] instanceof Closure) {
+            $config['httplug.stream_factory'] = call_user_func($config['httplug.stream_factory'], ArrayObject::ensureArrayObject($config));
+        }
         $config['httplug.client'] = call_user_func($config['httplug.client'], ArrayObject::ensureArrayObject($config));
 
         $this->assertInstanceOf(ClientInterface::class, $config['httplug.client']);
@@ -136,18 +138,20 @@ class CoreGatewayFactoryTest extends TestCase
     {
         $factory = new CoreGatewayFactory();
 
+        $container = $this->getContainer();
+
         $config = $factory->createConfig();
 
         $this->assertIsArray($config);
         $this->assertNotEmpty($config);
 
         $this->assertInstanceOf(Closure::class, $config['payum.http_client']);
-        $this->assertInstanceOf(GetHttpRequestAction::class, $config['payum.action.get_http_request']);
-        $this->assertInstanceOf(CapturePaymentAction::class, $config['payum.action.capture_payment']);
-        $this->assertInstanceOf(PayoutPayoutAction::class, $config['payum.action.payout_payout']);
-        $this->assertInstanceOf(ExecuteSameRequestWithModelDetailsAction::class, $config['payum.action.execute_same_request_with_model_details']);
+        $this->assertInstanceOf(GetHttpRequestAction::class, $config['payum.action.get_http_request']($container));
+        $this->assertInstanceOf(CapturePaymentAction::class, $config['payum.action.capture_payment']($container));
+        $this->assertInstanceOf(PayoutPayoutAction::class, $config['payum.action.payout_payout']($container));
+        $this->assertInstanceOf(ExecuteSameRequestWithModelDetailsAction::class, $config['payum.action.execute_same_request_with_model_details']($container));
         $this->assertInstanceOf(Closure::class, $config['payum.action.render_template']);
-        $this->assertInstanceOf(EndlessCycleDetectorExtension::class, $config['payum.extension.endless_cycle_detector']);
+        $this->assertInstanceOf(EndlessCycleDetectorExtension::class, $config['payum.extension.endless_cycle_detector']($container));
 
         $this->assertSame('@PayumCore/layout.html.twig', $config['payum.template.layout']);
         $this->assertSame([], $config['payum.prepend_actions']);
@@ -207,18 +211,16 @@ class CoreGatewayFactoryTest extends TestCase
         $this->assertIsArray($config);
         $this->assertNotEmpty($config);
 
-        $this->assertInstanceOf(Closure::class, $config['twig.env']);
-
-        $twig = call_user_func($config['twig.env'], ArrayObject::ensureArrayObject($config));
-
-        $this->assertInstanceOf(Environment::class, $twig);
+        $this->assertInstanceOf(Environment::class, $config['twig.env']());
     }
 
     public function testShouldConfigureRenderTemplateAction(): void
     {
         $factory = new CoreGatewayFactory();
 
-        $twig = new Environment(new FilesystemLoader());
+        $container = $this->getContainer();
+
+        $twig = new Environment(new ChainLoader());
 
         $config = $factory->createConfig([
             'twig.env' => $twig,
@@ -231,10 +233,11 @@ class CoreGatewayFactoryTest extends TestCase
 
         $this->assertInstanceOf(Closure::class, $config['payum.action.render_template']);
 
-        $action = call_user_func($config['payum.action.render_template'], ArrayObject::ensureArrayObject($config));
+        $action = call_user_func($config['payum.action.render_template'], $container);
         $this->assertInstanceOf(RenderTemplateAction::class, $action);
 
         $this->assertSame($twig, $config['twig.env']);
+        $this->assertEquals($twig, $container->get('twig.env'));
     }
 
     public function testShouldConfigureGetTokenActionIfTokenStorageSet(): void
@@ -246,13 +249,14 @@ class CoreGatewayFactoryTest extends TestCase
         $config = $factory->createConfig([
             'payum.security.token_storage' => $tokenStorageMock,
         ]);
+        $container = $this->getContainer($config);
 
         $this->assertIsArray($config);
         $this->assertNotEmpty($config);
 
         $this->assertInstanceOf(Closure::class, $config['payum.action.get_token']);
 
-        $action = call_user_func($config['payum.action.get_token'], ArrayObject::ensureArrayObject($config));
+        $action = call_user_func($config['payum.action.get_token'], $container);
         $this->assertInstanceOf(GetTokenAction::class, $action);
 
         $this->assertSame($tokenStorageMock, $config['payum.security.token_storage']);
@@ -295,8 +299,9 @@ class CoreGatewayFactoryTest extends TestCase
         ]);
 
         $actions = $this->readAttribute($gateway, 'actions');
-        $this->assertSame($firstAction, $actions[0]);
-        $this->assertSame($secondAction, $actions[1]);
+
+        $this->assertEquals($firstAction, $actions[0]);
+        $this->assertEquals($secondAction, $actions[1]);
 
         $gateway = $factory->create([
             'payum.action.foo' => $firstAction,
@@ -307,8 +312,8 @@ class CoreGatewayFactoryTest extends TestCase
         ]);
 
         $actions = $this->readAttribute($gateway, 'actions');
-        $this->assertSame($secondAction, $actions[0]);
-        $this->assertSame($firstAction, $actions[1]);
+        $this->assertEquals($secondAction, $actions[0]);
+        $this->assertEquals($firstAction, $actions[1]);
     }
 
     /**
@@ -330,8 +335,8 @@ class CoreGatewayFactoryTest extends TestCase
         ]);
 
         $apis = $this->readAttribute($gateway, 'apis');
-        $this->assertSame($firstApi, $apis[0]);
-        $this->assertSame($secondApi, $apis[1]);
+        $this->assertEquals($firstApi, $apis[0]);
+        $this->assertEquals($secondApi, $apis[1]);
 
         $gateway = $factory->create([
             'payum.api.foo' => $firstApi,
@@ -342,8 +347,8 @@ class CoreGatewayFactoryTest extends TestCase
         ]);
 
         $apis = $this->readAttribute($gateway, 'apis');
-        $this->assertSame($secondApi, $apis[0]);
-        $this->assertSame($firstApi, $apis[1]);
+        $this->assertEquals($secondApi, $apis[0]);
+        $this->assertEquals($firstApi, $apis[1]);
     }
 
     /**
@@ -365,8 +370,8 @@ class CoreGatewayFactoryTest extends TestCase
         ]);
 
         $extensions = $this->readAttribute($this->readAttribute($gateway, 'extensions'), 'extensions');
-        $this->assertSame($firstExtension, $extensions[0]);
-        $this->assertSame($secondExtension, $extensions[1]);
+        $this->assertEquals($firstExtension, $extensions[0]);
+        $this->assertEquals($secondExtension, $extensions[1]);
 
         $gateway = $factory->create([
             'payum.extension.foo' => $firstExtension,
@@ -377,8 +382,8 @@ class CoreGatewayFactoryTest extends TestCase
         ]);
 
         $extensions = $this->readAttribute($this->readAttribute($gateway, 'extensions'), 'extensions');
-        $this->assertSame($secondExtension, $extensions[0]);
-        $this->assertSame($firstExtension, $extensions[1]);
+        $this->assertEquals($secondExtension, $extensions[0]);
+        $this->assertEquals($firstExtension, $extensions[1]);
     }
 
     public function testShouldNotAllowGlobalFunctionsAsGatewayConfig(): void
@@ -391,5 +396,15 @@ class CoreGatewayFactoryTest extends TestCase
                 $this->assertSame('sha1', $config['hash']);
             },
         ]);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function getContainer(array $config = []): ContainerInterface
+    {
+        $factory = new CoreGatewayFactory();
+
+        return new Container($factory->createConfig($config));
     }
 }

--- a/src/Payum/Core/Tests/DI/ContainerConfigurationTest.php
+++ b/src/Payum/Core/Tests/DI/ContainerConfigurationTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Payum\Core\Tests\DI;
+
+use DI\Container;
+use Payum\Core\CoreGatewayFactory;
+use Payum\Core\DI\ContainerConfiguration;
+use Payum\Core\Gateway;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use ReflectionClass;
+use ReflectionNamedType;
+
+class ContainerConfigurationTest extends TestCase
+{
+    public function testShouldBeInterface(): void
+    {
+        $rc = new ReflectionClass(ContainerConfiguration::class);
+
+        $this->assertTrue($rc->isInterface());
+    }
+
+    public function testShouldDefineConfigureContainerMethodReturningArray(): void
+    {
+        $rc = new ReflectionClass(ContainerConfiguration::class);
+
+        $this->assertTrue($rc->hasMethod('configureContainer'));
+
+        $method = $rc->getMethod('configureContainer');
+
+        $this->assertTrue($method->isPublic());
+        $this->assertSame(0, $method->getNumberOfParameters());
+
+        $returnType = $method->getReturnType();
+
+        $this->assertInstanceOf(ReflectionNamedType::class, $returnType);
+        $this->assertSame('array', $returnType->getName());
+    }
+
+    public function testShouldDefineCreateGatewayMethodTakingContainerAndReturningGateway(): void
+    {
+        $rc = new ReflectionClass(ContainerConfiguration::class);
+
+        $this->assertTrue($rc->hasMethod('createGateway'));
+
+        $method = $rc->getMethod('createGateway');
+
+        $this->assertTrue($method->isPublic());
+        $this->assertSame(1, $method->getNumberOfParameters());
+
+        $parameterType = $method->getParameters()[0]->getType();
+
+        $this->assertInstanceOf(ReflectionNamedType::class, $parameterType);
+        $this->assertSame(ContainerInterface::class, $parameterType->getName());
+
+        $returnType = $method->getReturnType();
+
+        $this->assertInstanceOf(ReflectionNamedType::class, $returnType);
+        $this->assertSame(Gateway::class, $returnType->getName());
+    }
+
+    public function testShouldBeImplementedByCoreGatewayFactory(): void
+    {
+        $rc = new ReflectionClass(CoreGatewayFactory::class);
+
+        $this->assertTrue($rc->implementsInterface(ContainerConfiguration::class));
+    }
+
+    public function testShouldAllowCustomImplementation(): void
+    {
+        $configuration = new class() implements ContainerConfiguration {
+            public function configureContainer(): array
+            {
+                return [
+                    'foo' => 'fooVal',
+                ];
+            }
+
+            public function createGateway(ContainerInterface $container): Gateway
+            {
+                return new Gateway();
+            }
+        };
+
+        $this->assertInstanceOf(ContainerConfiguration::class, $configuration);
+        $this->assertSame([
+            'foo' => 'fooVal',
+        ], $configuration->configureContainer());
+        $this->assertInstanceOf(Gateway::class, $configuration->createGateway(new Container()));
+    }
+}

--- a/src/Payum/Core/Tests/DI/FallbackContainerTest.php
+++ b/src/Payum/Core/Tests/DI/FallbackContainerTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Payum\Core\Tests\DI;
+
+use DI\Container;
+use DI\ContainerBuilder;
+use Payum\Core\DI\FallbackContainer;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use ReflectionClass;
+use stdClass;
+
+class FallbackContainerTest extends TestCase
+{
+    public function testShouldImplementContainerInterface(): void
+    {
+        $rc = new ReflectionClass(FallbackContainer::class);
+
+        $this->assertTrue($rc->implementsInterface(ContainerInterface::class));
+    }
+
+    public function testShouldBeFinal(): void
+    {
+        $rc = new ReflectionClass(FallbackContainer::class);
+
+        $this->assertTrue($rc->isFinal());
+    }
+
+    public function testShouldReturnTheServiceOfThePrimaryContainer(): void
+    {
+        $expected = new stdClass();
+
+        $container = new FallbackContainer(
+            $this->buildContainer([
+                'foo' => $expected,
+            ]),
+            $this->buildContainer([
+                'foo' => new stdClass(),
+            ])
+        );
+
+        $this->assertSame($expected, $container->get('foo'));
+    }
+
+    public function testShouldFallBackWhenThePrimaryContainerDoesNotHaveTheService(): void
+    {
+        $expected = new stdClass();
+
+        $container = new FallbackContainer(
+            $this->buildContainer(),
+            $this->buildContainer([
+                'foo' => $expected,
+            ])
+        );
+
+        $this->assertSame($expected, $container->get('foo'));
+    }
+
+    public function testShouldNotTouchTheFallbackWhenThePrimaryContainerHasTheService(): void
+    {
+        $fallback = $this->createMock(ContainerInterface::class);
+        $fallback->expects($this->never())->method('get');
+
+        $container = new FallbackContainer(
+            $this->buildContainer([
+                'foo' => 'fooVal',
+            ]),
+            $fallback
+        );
+
+        $this->assertSame('fooVal', $container->get('foo'));
+    }
+
+    public function testHasShouldBeTrueWhenEitherContainerHasTheService(): void
+    {
+        $container = new FallbackContainer(
+            $this->buildContainer([
+                'foo' => 'fooVal',
+            ]),
+            $this->buildContainer([
+                'bar' => 'barVal',
+            ])
+        );
+
+        $this->assertTrue($container->has('foo'));
+        $this->assertTrue($container->has('bar'));
+    }
+
+    public function testHasShouldBeFalseWhenNeitherContainerHasTheService(): void
+    {
+        $container = new FallbackContainer($this->buildContainer(), $this->buildContainer());
+
+        $this->assertFalse($container->has('an.unknown.service'));
+    }
+
+    public function testShouldThrowNotFoundWhenNeitherContainerHasTheService(): void
+    {
+        $container = new FallbackContainer($this->buildContainer(), $this->buildContainer());
+
+        $this->expectException(NotFoundExceptionInterface::class);
+
+        $container->get('an.unknown.service');
+    }
+
+    public function testShouldReportTheKnownEntryNamesOfBothContainers(): void
+    {
+        $container = new FallbackContainer(
+            $this->buildContainer([
+                'foo' => 'fooVal',
+            ]),
+            $this->buildContainer([
+                'bar' => 'barVal',
+            ])
+        );
+
+        $names = $container->getKnownEntryNames();
+
+        $this->assertContains('foo', $names);
+        $this->assertContains('bar', $names);
+    }
+
+    public function testShouldReportEachKnownEntryNameOnlyOnce(): void
+    {
+        $container = new FallbackContainer(
+            $this->buildContainer([
+                'foo' => 'fooVal',
+            ]),
+            $this->buildContainer([
+                'foo' => 'anotherFooVal',
+            ])
+        );
+
+        $names = $container->getKnownEntryNames();
+
+        $this->assertSame(1, array_count_values($names)['foo']);
+    }
+
+    public function testShouldReportNothingForAContainerWhichCannotEnumerateItsEntries(): void
+    {
+        $container = new FallbackContainer(
+            $this->createMock(ContainerInterface::class),
+            $this->createMock(ContainerInterface::class)
+        );
+
+        $this->assertSame([], $container->getKnownEntryNames());
+    }
+
+    public function testShouldReportTheKnownEntryNamesOfTheEnumerableSideOnly(): void
+    {
+        $container = new FallbackContainer(
+            $this->createMock(ContainerInterface::class),
+            $this->buildContainer([
+                'bar' => 'barVal',
+            ])
+        );
+
+        $this->assertContains('bar', $container->getKnownEntryNames());
+    }
+
+    public function testShouldReportTheKnownEntryNamesOfANestedFallbackContainer(): void
+    {
+        $container = new FallbackContainer(
+            $this->buildContainer([
+                'foo' => 'fooVal',
+            ]),
+            new FallbackContainer(
+                $this->buildContainer([
+                    'bar' => 'barVal',
+                ]),
+                $this->buildContainer([
+                    'baz' => 'bazVal',
+                ])
+            )
+        );
+
+        $names = $container->getKnownEntryNames();
+
+        $this->assertContains('foo', $names);
+        $this->assertContains('bar', $names);
+        $this->assertContains('baz', $names);
+    }
+
+    public function testShouldResolveThroughANestedFallbackContainer(): void
+    {
+        $expected = new stdClass();
+
+        $container = new FallbackContainer(
+            $this->buildContainer(),
+            new FallbackContainer(
+                $this->buildContainer(),
+                $this->buildContainer([
+                    'foo' => $expected,
+                ])
+            )
+        );
+
+        $this->assertTrue($container->has('foo'));
+        $this->assertSame($expected, $container->get('foo'));
+    }
+
+    /**
+     * @param array<string, mixed> $definitions
+     */
+    private function buildContainer(array $definitions = []): Container
+    {
+        $builder = new ContainerBuilder();
+        $builder->addDefinitions($definitions);
+
+        return $builder->build();
+    }
+}

--- a/src/Payum/Core/Tests/Extension/PrependExtensionInterfaceTest.php
+++ b/src/Payum/Core/Tests/Extension/PrependExtensionInterfaceTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Payum\Core\Tests\Extension;
+
+use Payum\Core\Extension\Context;
+use Payum\Core\Extension\ExtensionInterface;
+use Payum\Core\Extension\PrependExtensionInterface;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class PrependExtensionInterfaceTest extends TestCase
+{
+    public function testShouldBeInterface(): void
+    {
+        $rc = new ReflectionClass(PrependExtensionInterface::class);
+
+        $this->assertTrue($rc->isInterface());
+    }
+
+    public function testShouldBeMarkerInterfaceWithoutAnyMethod(): void
+    {
+        $rc = new ReflectionClass(PrependExtensionInterface::class);
+
+        $this->assertSame([], $rc->getMethods());
+    }
+
+    public function testShouldNotExtendExtensionInterface(): void
+    {
+        $rc = new ReflectionClass(PrependExtensionInterface::class);
+
+        $this->assertFalse($rc->isSubclassOf(ExtensionInterface::class));
+        $this->assertSame([], $rc->getInterfaceNames());
+    }
+
+    public function testShouldBeImplementableTogetherWithExtensionInterface(): void
+    {
+        $extension = new class() implements ExtensionInterface, PrependExtensionInterface {
+            public function onPreExecute(Context $context): void
+            {
+            }
+
+            public function onExecute(Context $context): void
+            {
+            }
+
+            public function onPostExecute(Context $context): void
+            {
+            }
+        };
+
+        $this->assertInstanceOf(ExtensionInterface::class, $extension);
+        $this->assertInstanceOf(PrependExtensionInterface::class, $extension);
+    }
+
+    public function testShouldNotMarkPlainExtensionAsPrepending(): void
+    {
+        $extension = $this->createMock(ExtensionInterface::class);
+
+        $this->assertNotInstanceOf(PrependExtensionInterface::class, $extension);
+    }
+}

--- a/src/Payum/Core/Tests/GatewayFactoryConfigInterfaceTest.php
+++ b/src/Payum/Core/Tests/GatewayFactoryConfigInterfaceTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Payum\Core\Tests;
+
+use DI\Container;
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\CoreGatewayFactory;
+use Payum\Core\Extension\Context;
+use Payum\Core\Extension\ExtensionInterface;
+use Payum\Core\Gateway;
+use Payum\Core\GatewayFactoryConfigInterface;
+use Psr\Container\ContainerInterface;
+use ReflectionClass;
+use ReflectionNamedType;
+
+class GatewayFactoryConfigInterfaceTest extends TestCase
+{
+    public function testShouldBeInterface(): void
+    {
+        $rc = new ReflectionClass(GatewayFactoryConfigInterface::class);
+
+        $this->assertTrue($rc->isInterface());
+    }
+
+    public function testShouldDefineCreateGatewayMethodTakingContainerAndReturningGateway(): void
+    {
+        $rc = new ReflectionClass(GatewayFactoryConfigInterface::class);
+
+        $this->assertTrue($rc->hasMethod('createGateway'));
+
+        $method = $rc->getMethod('createGateway');
+
+        $this->assertTrue($method->isPublic());
+        $this->assertSame(1, $method->getNumberOfParameters());
+
+        $parameterType = $method->getParameters()[0]->getType();
+
+        $this->assertInstanceOf(ReflectionNamedType::class, $parameterType);
+        $this->assertSame(ContainerInterface::class, $parameterType->getName());
+
+        $returnType = $method->getReturnType();
+
+        $this->assertInstanceOf(ReflectionNamedType::class, $returnType);
+        $this->assertSame(Gateway::class, $returnType->getName());
+    }
+
+    public function testShouldDefineGetActionsMethodReturningArray(): void
+    {
+        $rc = new ReflectionClass(GatewayFactoryConfigInterface::class);
+
+        $this->assertTrue($rc->hasMethod('getActions'));
+
+        $method = $rc->getMethod('getActions');
+
+        $this->assertTrue($method->isPublic());
+        $this->assertSame(0, $method->getNumberOfParameters());
+
+        $returnType = $method->getReturnType();
+
+        $this->assertInstanceOf(ReflectionNamedType::class, $returnType);
+        $this->assertSame('array', $returnType->getName());
+    }
+
+    public function testShouldDefineGetExtensionsMethodReturningArray(): void
+    {
+        $rc = new ReflectionClass(GatewayFactoryConfigInterface::class);
+
+        $this->assertTrue($rc->hasMethod('getExtensions'));
+
+        $method = $rc->getMethod('getExtensions');
+
+        $this->assertTrue($method->isPublic());
+        $this->assertSame(0, $method->getNumberOfParameters());
+
+        $returnType = $method->getReturnType();
+
+        $this->assertInstanceOf(ReflectionNamedType::class, $returnType);
+        $this->assertSame('array', $returnType->getName());
+    }
+
+    public function testShouldBeImplementedByCoreGatewayFactory(): void
+    {
+        $rc = new ReflectionClass(CoreGatewayFactory::class);
+
+        $this->assertTrue($rc->implementsInterface(GatewayFactoryConfigInterface::class));
+    }
+
+    public function testShouldAllowCustomImplementation(): void
+    {
+        $extension = new GatewayFactoryConfigStubExtension();
+
+        $config = new class($extension) implements GatewayFactoryConfigInterface {
+            public function __construct(
+                private ExtensionInterface $extension
+            ) {
+            }
+
+            public function createGateway(ContainerInterface $container): Gateway
+            {
+                $gateway = new Gateway();
+
+                foreach ($this->getActions() as $action) {
+                    $gateway->addAction($container->get($action));
+                }
+
+                foreach ($this->getExtensions() as $extension) {
+                    $gateway->addExtension($extension);
+                }
+
+                return $gateway;
+            }
+
+            public function getActions(): array
+            {
+                return [GatewayFactoryConfigStubAction::class];
+            }
+
+            public function getExtensions(): array
+            {
+                return [$this->extension];
+            }
+        };
+
+        $this->assertSame([GatewayFactoryConfigStubAction::class], $config->getActions());
+        $this->assertSame([$extension], $config->getExtensions());
+
+        $gateway = $config->createGateway(new Container());
+
+        $this->assertInstanceOf(Gateway::class, $gateway);
+        $this->assertSame([GatewayFactoryConfigStubAction::class], array_map(
+            'get_class',
+            self::readAttribute($gateway, 'actions')
+        ));
+        $this->assertSame(
+            [$extension],
+            self::readAttribute(self::readAttribute($gateway, 'extensions'), 'extensions')
+        );
+    }
+}
+
+class GatewayFactoryConfigStubAction implements ActionInterface
+{
+    public function execute($request): void
+    {
+    }
+
+    public function supports($request): bool
+    {
+        return false;
+    }
+}
+
+class GatewayFactoryConfigStubExtension implements ExtensionInterface
+{
+    public function onPreExecute(Context $context): void
+    {
+    }
+
+    public function onExecute(Context $context): void
+    {
+    }
+
+    public function onPostExecute(Context $context): void
+    {
+    }
+}

--- a/src/Payum/Core/Tests/GatewayTypedPropertiesTest.php
+++ b/src/Payum/Core/Tests/GatewayTypedPropertiesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Payum\Core\Tests;
+
+use Payum\Core\Gateway;
+use PHPUnit\Framework\TestCase;
+use ReflectionNamedType;
+use ReflectionProperty;
+use TypeError;
+
+class GatewayTypedPropertiesTest extends TestCase
+{
+    /**
+     * @dataProvider provideTypedArrayProperties
+     */
+    public function testShouldDeclarePropertyAsTypedArray(string $propertyName): void
+    {
+        $property = new ReflectionProperty(Gateway::class, $propertyName);
+
+        $type = $property->getType();
+
+        $this->assertInstanceOf(ReflectionNamedType::class, $type);
+        $this->assertSame('array', $type->getName());
+        $this->assertFalse($type->allowsNull());
+    }
+
+    /**
+     * @dataProvider provideTypedArrayProperties
+     */
+    public function testShouldInitialisePropertyToAnEmptyArray(string $propertyName): void
+    {
+        $property = new ReflectionProperty(Gateway::class, $propertyName);
+        $property->setAccessible(true);
+
+        $this->assertSame([], $property->getValue(new Gateway()));
+    }
+
+    /**
+     * @dataProvider provideTypedArrayProperties
+     */
+    public function testThrowsWhenPropertyIsSetToANonArrayValue(string $propertyName): void
+    {
+        $property = new ReflectionProperty(Gateway::class, $propertyName);
+        $property->setAccessible(true);
+
+        $this->expectException(TypeError::class);
+
+        $property->setValue(new Gateway(), 'notAnArray');
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideTypedArrayProperties(): iterable
+    {
+        yield 'actions' => ['actions'];
+
+        yield 'stack' => ['stack'];
+    }
+}

--- a/src/Payum/Core/Tests/PayumBuilderGlobalContainerTest.php
+++ b/src/Payum/Core/Tests/PayumBuilderGlobalContainerTest.php
@@ -4,6 +4,8 @@ namespace Payum\Core\Tests;
 
 use DI\Container;
 use DI\ContainerBuilder;
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Bridge\PlainPhp\Action\GetHttpRequestAction;
 use Payum\Core\CoreGatewayFactory;
 use Payum\Core\DI\ContainerConfiguration;
 use Payum\Core\Extension\StorageExtension;
@@ -23,8 +25,12 @@ use Psr\Container\NotFoundExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use ReflectionProperty;
 use stdClass;
+use function DI\autowire;
+use function DI\get;
 
 class PayumBuilderGlobalContainerTest extends TestCase
 {
@@ -564,6 +570,122 @@ class PayumBuilderGlobalContainerTest extends TestCase
         $this->assertTrue($factory->container->get('acme.sandbox'));
     }
 
+    public function testShouldPassTheServicesAddedWithAddGlobalServiceToTheGatewayContainer(): void
+    {
+        $service = new stdClass();
+
+        $factory = new ContainerConfigurationGatewayFactoryStub();
+
+        (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addGlobalService('acme.service', $service)
+            ->addGlobalService(GlobalContainerTestModel::class, $model = new GlobalContainerTestModel())
+            ->addGatewayFactory('acme_factory', $factory)
+            ->addGateway('acme', [
+                'factory' => 'acme_factory',
+            ])
+            ->getPayum()
+        ;
+
+        $this->assertTrue($factory->container->has('acme.service'));
+        $this->assertSame($service, $factory->container->get('acme.service'));
+        $this->assertSame($model, $factory->container->get(GlobalContainerTestModel::class));
+    }
+
+    public function testShouldShareTheServicesAddedWithAddGlobalServiceBetweenGateways(): void
+    {
+        $firstFactory = new ContainerConfigurationGatewayFactoryStub();
+        $secondFactory = new ContainerConfigurationGatewayFactoryStub();
+
+        (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addGlobalService('acme.service', static fn (): stdClass => new stdClass())
+            ->addGatewayFactory('first_factory', $firstFactory)
+            ->addGatewayFactory('second_factory', $secondFactory)
+            ->addGateway('first', [
+                'factory' => 'first_factory',
+            ])
+            ->addGateway('second', [
+                'factory' => 'second_factory',
+            ])
+            ->getPayum()
+        ;
+
+        $this->assertSame(
+            $firstFactory->container->get('acme.service'),
+            $secondFactory->container->get('acme.service')
+        );
+    }
+
+    public function testShouldPassTheEntriesOfAPresetGlobalContainerToTheGatewayContainer(): void
+    {
+        $service = new stdClass();
+
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->addDefinitions([
+            GenericTokenFactoryInterface::class => $this->createMock(GenericTokenFactoryInterface::class),
+            HttpRequestVerifierInterface::class => $this->createMock(HttpRequestVerifierInterface::class),
+            'payum.security.token_storage' => $this->createMock(StorageInterface::class),
+            'acme.service' => $service,
+        ]);
+
+        $factory = new ContainerConfigurationGatewayFactoryStub();
+
+        (new PayumBuilder())
+            ->setGlobalContainer($containerBuilder->build())
+            ->addGatewayFactory('acme_factory', $factory)
+            ->addGateway('acme', [
+                'factory' => 'acme_factory',
+            ])
+            ->getPayum()
+        ;
+
+        $this->assertSame($service, $factory->container->get('acme.service'));
+    }
+
+    public function testShouldNotDelegateTheContainerItselfToThePresetGlobalContainer(): void
+    {
+        $globalContainer = (new ContainerBuilder())->build();
+        $globalContainer->set(GenericTokenFactoryInterface::class, $this->createMock(GenericTokenFactoryInterface::class));
+        $globalContainer->set(HttpRequestVerifierInterface::class, $this->createMock(HttpRequestVerifierInterface::class));
+        $globalContainer->set('payum.security.token_storage', $this->createMock(StorageInterface::class));
+
+        $factory = new ContainerConfigurationGatewayFactoryStub();
+
+        (new PayumBuilder())
+            ->setGlobalContainer($globalContainer)
+            ->addGatewayFactory('acme_factory', $factory)
+            ->addGateway('acme', [
+                'factory' => 'acme_factory',
+            ])
+            ->getPayum()
+        ;
+
+        $this->assertSame($factory->container, $factory->container->get(ContainerInterface::class));
+        $this->assertNotSame($globalContainer, $factory->container->get(ContainerInterface::class));
+    }
+
+    public function testShouldGiveTheGlobalServicesPrecedenceOverTheGatewayFactoryDefaults(): void
+    {
+        $client = $this->createMock(ClientInterface::class);
+
+        $factory = new ContainerConfigurationGatewayFactoryStub([
+            ClientInterface::class => $this->createMock(ClientInterface::class),
+        ]);
+
+        (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addGlobalService(ClientInterface::class, $client)
+            ->addGatewayFactory('acme_factory', $factory)
+            ->addGateway('acme', [
+                'factory' => 'acme_factory',
+            ])
+            ->getPayum()
+        ;
+
+        $this->assertSame($client, $factory->container->get(ClientInterface::class));
+    }
+
     public function testShouldGiveTheGatewayConfigPrecedenceOverTheGlobalServices(): void
     {
         $client = $this->createMock(ClientInterface::class);
@@ -583,6 +705,59 @@ class PayumBuilderGlobalContainerTest extends TestCase
         ;
 
         $this->assertSame($gatewayClient, $factory->container->get(ClientInterface::class));
+    }
+
+    /**
+     * Guards the gateway factory pattern documented in docs/di.
+     */
+    public function testShouldSupportTheDocumentedGatewayFactoryPattern(): void
+    {
+        $logger = new NullLogger();
+
+        $payum = (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addGlobalService(LoggerInterface::class, $logger)
+            ->addGatewayFactory('documented', new DocumentedGatewayFactory())
+            ->addGateway('documented', [
+                'factory' => 'documented',
+                'documented.client_id' => 'theClientId',
+                'documented.sandbox' => false,
+            ])
+            ->getPayum()
+        ;
+
+        $actions = $this->readAttribute($payum->getGateway('documented'), 'actions');
+
+        $documentedAction = null;
+        foreach ($actions as $action) {
+            if ($action instanceof DocumentedCaptureAction) {
+                $documentedAction = $action;
+            }
+        }
+
+        $this->assertInstanceOf(DocumentedCaptureAction::class, $documentedAction);
+
+        // the gateway config reaches the api through get()
+        $this->assertSame('theClientId', $documentedAction->api->clientId);
+        $this->assertFalse($documentedAction->api->sandbox);
+
+        // the global service reaches the action
+        $this->assertSame($logger, $documentedAction->logger);
+
+        // the core actions are still registered
+        $this->assertContains(GetHttpRequestAction::class, array_map('get_class', $actions));
+    }
+
+    public function testShouldStillSupportTheDeprecatedCreateApiOnADocumentedGatewayFactory(): void
+    {
+        $gateway = (new DocumentedGatewayFactory())->create([
+            LoggerInterface::class => new NullLogger(),
+        ]);
+
+        $this->assertContains(
+            DocumentedCaptureAction::class,
+            array_map('get_class', $this->readAttribute($gateway, 'actions'))
+        );
     }
 
     public function testShouldFallBackToTheLegacyGatewayFactoryApi(): void
@@ -779,4 +954,58 @@ class LegacyGatewayFactoryStub implements GatewayFactoryInterface
 
 class GlobalContainerTestModel
 {
+}
+
+class DocumentedApi
+{
+    public function __construct(
+        public string $clientId,
+        public bool $sandbox
+    ) {
+    }
+}
+
+class DocumentedCaptureAction implements ActionInterface
+{
+    public function __construct(
+        public DocumentedApi $api,
+        public LoggerInterface $logger
+    ) {
+    }
+
+    public function execute($request): void
+    {
+    }
+
+    public function supports($request): bool
+    {
+        return false;
+    }
+}
+
+class DocumentedGatewayFactory extends CoreGatewayFactory
+{
+    public function configureContainer(): array
+    {
+        return array_merge(parent::configureContainer(), [
+            'documented.client_id' => '',
+            'documented.sandbox' => true,
+
+            DocumentedApi::class => autowire()
+                ->constructor(
+                    clientId: get('documented.client_id'),
+                    sandbox: get('documented.sandbox')
+                ),
+
+            DocumentedCaptureAction::class => autowire()
+                ->constructorParameter('api', get(DocumentedApi::class)),
+        ]);
+    }
+
+    public function getActions(): array
+    {
+        return array_merge(parent::getActions(), [
+            DocumentedCaptureAction::class,
+        ]);
+    }
 }

--- a/src/Payum/Core/Tests/PayumBuilderGlobalContainerTest.php
+++ b/src/Payum/Core/Tests/PayumBuilderGlobalContainerTest.php
@@ -1,0 +1,782 @@
+<?php
+
+namespace Payum\Core\Tests;
+
+use DI\Container;
+use DI\ContainerBuilder;
+use Payum\Core\CoreGatewayFactory;
+use Payum\Core\DI\ContainerConfiguration;
+use Payum\Core\Extension\StorageExtension;
+use Payum\Core\Gateway;
+use Payum\Core\GatewayFactoryInterface;
+use Payum\Core\Model\ArrayObject;
+use Payum\Core\Model\Payment;
+use Payum\Core\Model\Payout;
+use Payum\Core\Payum;
+use Payum\Core\PayumBuilder;
+use Payum\Core\Security\GenericTokenFactoryInterface;
+use Payum\Core\Security\HttpRequestVerifierInterface;
+use Payum\Core\Security\TokenFactoryInterface;
+use Payum\Core\Storage\StorageInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use ReflectionProperty;
+use stdClass;
+
+class PayumBuilderGlobalContainerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_SERVER = [
+            'HTTP_HOST' => 'payum.dev',
+        ];
+    }
+
+    public function testAddGlobalServiceShouldBeFluent(): void
+    {
+        $builder = new PayumBuilder();
+
+        $this->assertSame($builder, $builder->addGlobalService('foo', 'fooVal'));
+    }
+
+    public function testAddGlobalServiceShouldStoreTheDefinition(): void
+    {
+        $builder = new PayumBuilder();
+
+        $service = new stdClass();
+
+        $builder->addGlobalService('foo', 'fooVal');
+        $builder->addGlobalService(stdClass::class, $service);
+
+        $ref = new ReflectionProperty($builder, 'globalDefinitions');
+        $ref->setAccessible(true);
+
+        $this->assertSame([
+            'foo' => 'fooVal',
+            stdClass::class => $service,
+        ], $ref->getValue($builder));
+    }
+
+    public function testAddGlobalServiceShouldOverridePreviouslyAddedServiceWithSameId(): void
+    {
+        $builder = new PayumBuilder();
+
+        $builder->addGlobalService('foo', 'fooVal');
+        $builder->addGlobalService('foo', 'fooNewVal');
+
+        $ref = new ReflectionProperty($builder, 'globalDefinitions');
+        $ref->setAccessible(true);
+
+        $this->assertSame([
+            'foo' => 'fooNewVal',
+        ], $ref->getValue($builder));
+    }
+
+    public function testSetGlobalContainerShouldBeFluent(): void
+    {
+        $builder = new PayumBuilder();
+
+        $this->assertSame($builder, $builder->setGlobalContainer(new Container()));
+    }
+
+    public function testSetGlobalContainerShouldStoreTheContainer(): void
+    {
+        $builder = new PayumBuilder();
+
+        $container = new Container();
+
+        $builder->setGlobalContainer($container);
+
+        $ref = new ReflectionProperty($builder, 'globalContainer');
+        $ref->setAccessible(true);
+
+        $this->assertSame($container, $ref->getValue($builder));
+    }
+
+    public function testBuildGlobalContainerShouldProvideTheSecurityServices(): void
+    {
+        $container = (new ExposedGlobalContainerPayumBuilder())
+            ->addDefaultStorages()
+            ->buildGlobalContainer()
+        ;
+
+        $this->assertInstanceOf(ContainerInterface::class, $container);
+        $this->assertInstanceOf(HttpRequestVerifierInterface::class, $container->get(HttpRequestVerifierInterface::class));
+        $this->assertInstanceOf(GenericTokenFactoryInterface::class, $container->get(GenericTokenFactoryInterface::class));
+        $this->assertInstanceOf(TokenFactoryInterface::class, $container->get(TokenFactoryInterface::class));
+        $this->assertInstanceOf(StorageInterface::class, $container->get('payum.security.token_storage'));
+    }
+
+    public function testBuildGlobalContainerShouldProvideThePsrHttpServices(): void
+    {
+        $container = (new ExposedGlobalContainerPayumBuilder())
+            ->addDefaultStorages()
+            ->buildGlobalContainer()
+        ;
+
+        $this->assertInstanceOf(ClientInterface::class, $container->get(ClientInterface::class));
+        $this->assertInstanceOf(StreamFactoryInterface::class, $container->get(StreamFactoryInterface::class));
+        $this->assertInstanceOf(RequestFactoryInterface::class, $container->get(RequestFactoryInterface::class));
+    }
+
+    public function testBuildGlobalContainerShouldShareTheSameHttpServiceInstanceBetweenCalls(): void
+    {
+        $container = (new ExposedGlobalContainerPayumBuilder())
+            ->addDefaultStorages()
+            ->buildGlobalContainer()
+        ;
+
+        $this->assertSame($container->get(ClientInterface::class), $container->get(ClientInterface::class));
+        $this->assertSame($container->get(StreamFactoryInterface::class), $container->get(StreamFactoryInterface::class));
+        $this->assertSame($container->get(RequestFactoryInterface::class), $container->get(RequestFactoryInterface::class));
+    }
+
+    public function testBuildGlobalContainerShouldAddDefaultStoragesWhenNoTokenStorageIsSet(): void
+    {
+        $builder = new ExposedGlobalContainerPayumBuilder();
+
+        $container = $builder->buildGlobalContainer();
+
+        $this->assertInstanceOf(StorageInterface::class, $container->get('payum.security.token_storage'));
+
+        $ref = new ReflectionProperty($builder, 'storages');
+        $ref->setAccessible(true);
+
+        $this->assertArrayHasKey(Payment::class, $ref->getValue($builder));
+        $this->assertArrayHasKey(ArrayObject::class, $ref->getValue($builder));
+        $this->assertArrayHasKey(Payout::class, $ref->getValue($builder));
+    }
+
+    public function testBuildGlobalContainerShouldUseTheConfiguredTokenStorage(): void
+    {
+        $tokenStorage = $this->createMock(StorageInterface::class);
+
+        $container = (new ExposedGlobalContainerPayumBuilder())
+            ->setTokenStorage($tokenStorage)
+            ->buildGlobalContainer()
+        ;
+
+        $this->assertSame($tokenStorage, $container->get('payum.security.token_storage'));
+    }
+
+    public function testBuildGlobalContainerShouldUseTheConfiguredTokenFactoryAndVerifier(): void
+    {
+        $tokenFactory = $this->createMock(TokenFactoryInterface::class);
+        $genericTokenFactory = $this->createMock(GenericTokenFactoryInterface::class);
+        $httpRequestVerifier = $this->createMock(HttpRequestVerifierInterface::class);
+
+        $container = (new ExposedGlobalContainerPayumBuilder())
+            ->addDefaultStorages()
+            ->setTokenFactory($tokenFactory)
+            ->setGenericTokenFactory($genericTokenFactory)
+            ->setHttpRequestVerifier($httpRequestVerifier)
+            ->buildGlobalContainer()
+        ;
+
+        $this->assertSame($tokenFactory, $container->get(TokenFactoryInterface::class));
+        $this->assertSame($genericTokenFactory, $container->get(GenericTokenFactoryInterface::class));
+        $this->assertSame($httpRequestVerifier, $container->get(HttpRequestVerifierInterface::class));
+    }
+
+    public function testBuildGlobalContainerShouldRegisterAStorageExtensionForEveryStorage(): void
+    {
+        $storage = $this->createMock(StorageInterface::class);
+
+        $container = (new ExposedGlobalContainerPayumBuilder())
+            ->addDefaultStorages()
+            ->addStorage(GlobalContainerTestModel::class, $storage)
+            ->buildGlobalContainer()
+        ;
+
+        foreach ([
+            'payum.extension.storage_payum_core_model_payment',
+            'payum.extension.storage_payum_core_model_arrayobject',
+            'payum.extension.storage_payum_core_model_payout',
+            'payum.extension.storage_payum_core_tests_globalcontainertestmodel',
+        ] as $extensionName) {
+            $this->assertTrue($container->has($extensionName));
+            $this->assertInstanceOf(StorageExtension::class, $container->get($extensionName));
+        }
+
+        $extension = $container->get('payum.extension.storage_payum_core_tests_globalcontainertestmodel');
+
+        $this->assertSame($storage, $this->readAttribute($extension, 'storage'));
+    }
+
+    public function testBuildGlobalContainerShouldExposeServicesAddedWithAddGlobalService(): void
+    {
+        $service = new stdClass();
+
+        $container = (new ExposedGlobalContainerPayumBuilder())
+            ->addDefaultStorages()
+            ->addGlobalService('acme.service', $service)
+            ->addGlobalService('acme.value', 'aValue')
+            ->buildGlobalContainer()
+        ;
+
+        $this->assertTrue($container->has('acme.service'));
+        $this->assertSame($service, $container->get('acme.service'));
+        $this->assertSame('aValue', $container->get('acme.value'));
+    }
+
+    public function testBuildGlobalContainerShouldResolveCallableGlobalServices(): void
+    {
+        $service = new stdClass();
+
+        $container = (new ExposedGlobalContainerPayumBuilder())
+            ->addDefaultStorages()
+            ->addGlobalService('acme.service', static fn (): stdClass => $service)
+            ->buildGlobalContainer()
+        ;
+
+        $this->assertSame($service, $container->get('acme.service'));
+    }
+
+    public function testBuildGlobalContainerShouldLetGlobalServicesOverrideTheDefaultDefinitions(): void
+    {
+        $client = $this->createMock(ClientInterface::class);
+
+        $container = (new ExposedGlobalContainerPayumBuilder())
+            ->addDefaultStorages()
+            ->addGlobalService(ClientInterface::class, $client)
+            ->buildGlobalContainer()
+        ;
+
+        $this->assertSame($client, $container->get(ClientInterface::class));
+    }
+
+    public function testBuildGlobalContainerShouldReturnThePresetContainer(): void
+    {
+        $expectedContainer = new Container();
+
+        $container = (new ExposedGlobalContainerPayumBuilder())
+            ->addDefaultStorages()
+            ->setGlobalContainer($expectedContainer)
+            ->buildGlobalContainer()
+        ;
+
+        $this->assertSame($expectedContainer, $container);
+    }
+
+    public function testBuildGlobalContainerShouldNotAddDefaultStoragesWhenAContainerIsPreset(): void
+    {
+        $builder = new ExposedGlobalContainerPayumBuilder();
+        $builder->setGlobalContainer(new Container());
+
+        $builder->buildGlobalContainer();
+
+        $ref = new ReflectionProperty($builder, 'storages');
+        $ref->setAccessible(true);
+
+        $this->assertSame([], $ref->getValue($builder));
+
+        $ref = new ReflectionProperty($builder, 'tokenStorage');
+        $ref->setAccessible(true);
+
+        $this->assertNull($ref->getValue($builder));
+    }
+
+    public function testBuildGlobalContainerShouldIgnoreGlobalServicesWhenAContainerIsPreset(): void
+    {
+        $container = (new ExposedGlobalContainerPayumBuilder())
+            ->addDefaultStorages()
+            ->setGlobalContainer(new Container())
+            ->addGlobalService('acme.service', new stdClass())
+            ->buildGlobalContainer()
+        ;
+
+        $this->assertFalse($container->has('acme.service'));
+    }
+
+    public function testGetPayumShouldUseTheSecurityServicesFromTheGlobalContainer(): void
+    {
+        $genericTokenFactory = $this->createMock(GenericTokenFactoryInterface::class);
+        $httpRequestVerifier = $this->createMock(HttpRequestVerifierInterface::class);
+
+        $payum = (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addGlobalService(GenericTokenFactoryInterface::class, $genericTokenFactory)
+            ->addGlobalService(HttpRequestVerifierInterface::class, $httpRequestVerifier)
+            ->getPayum()
+        ;
+
+        $this->assertInstanceOf(Payum::class, $payum);
+        $this->assertSame($genericTokenFactory, $payum->getTokenFactory());
+        $this->assertSame($httpRequestVerifier, $payum->getHttpRequestVerifier());
+    }
+
+    public function testGetPayumShouldUseThePresetGlobalContainer(): void
+    {
+        $tokenStorage = $this->createMock(StorageInterface::class);
+        $genericTokenFactory = $this->createMock(GenericTokenFactoryInterface::class);
+        $httpRequestVerifier = $this->createMock(HttpRequestVerifierInterface::class);
+
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->addDefinitions([
+            GenericTokenFactoryInterface::class => $genericTokenFactory,
+            HttpRequestVerifierInterface::class => $httpRequestVerifier,
+            'payum.security.token_storage' => $tokenStorage,
+        ]);
+
+        $payum = (new PayumBuilder())
+            ->setTokenStorage($tokenStorage)
+            ->setGlobalContainer($containerBuilder->build())
+            ->getPayum()
+        ;
+
+        $this->assertSame($genericTokenFactory, $payum->getTokenFactory());
+        $this->assertSame($httpRequestVerifier, $payum->getHttpRequestVerifier());
+        $this->assertSame($tokenStorage, $payum->getTokenStorage());
+    }
+
+    /**
+     * A preset global container bypasses the default storage set up, so the token storage has to be taken
+     * from the container when it was not configured on the builder.
+     */
+    public function testGetPayumShouldTakeTheTokenStorageFromThePresetGlobalContainer(): void
+    {
+        $tokenStorage = $this->createMock(StorageInterface::class);
+
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->addDefinitions([
+            GenericTokenFactoryInterface::class => $this->createMock(GenericTokenFactoryInterface::class),
+            HttpRequestVerifierInterface::class => $this->createMock(HttpRequestVerifierInterface::class),
+            'payum.security.token_storage' => $tokenStorage,
+        ]);
+
+        $payum = (new PayumBuilder())
+            ->setGlobalContainer($containerBuilder->build())
+            ->getPayum()
+        ;
+
+        $this->assertSame($tokenStorage, $payum->getTokenStorage());
+    }
+
+    public function testGetPayumShouldPassTheTokenStorageOfThePresetGlobalContainerToTheCoreGatewayFactory(): void
+    {
+        $tokenStorage = $this->createMock(StorageInterface::class);
+
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->addDefinitions([
+            GenericTokenFactoryInterface::class => $this->createMock(GenericTokenFactoryInterface::class),
+            HttpRequestVerifierInterface::class => $this->createMock(HttpRequestVerifierInterface::class),
+            'payum.security.token_storage' => $tokenStorage,
+        ]);
+
+        (new PayumBuilder())
+            ->setGlobalContainer($containerBuilder->build())
+            ->setCoreGatewayFactory(function (array $config) use ($tokenStorage): CoreGatewayFactory {
+                $this->assertArrayHasKey('payum.security.token_storage', $config);
+                $this->assertSame($tokenStorage, $config['payum.security.token_storage']);
+
+                return new CoreGatewayFactory($config);
+            })
+            ->getPayum()
+        ;
+    }
+
+    public function testGetPayumShouldPreferTheExplicitlyConfiguredTokenStorageOverThePresetContainerOne(): void
+    {
+        $tokenStorage = $this->createMock(StorageInterface::class);
+
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->addDefinitions([
+            GenericTokenFactoryInterface::class => $this->createMock(GenericTokenFactoryInterface::class),
+            HttpRequestVerifierInterface::class => $this->createMock(HttpRequestVerifierInterface::class),
+            'payum.security.token_storage' => $this->createMock(StorageInterface::class),
+        ]);
+
+        $payum = (new PayumBuilder())
+            ->setTokenStorage($tokenStorage)
+            ->setGlobalContainer($containerBuilder->build())
+            ->getPayum()
+        ;
+
+        $this->assertSame($tokenStorage, $payum->getTokenStorage());
+    }
+
+    public function testGetPayumShouldFailWhenNeitherTheBuilderNorThePresetContainerProvideATokenStorage(): void
+    {
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->addDefinitions([
+            GenericTokenFactoryInterface::class => $this->createMock(GenericTokenFactoryInterface::class),
+            HttpRequestVerifierInterface::class => $this->createMock(HttpRequestVerifierInterface::class),
+        ]);
+
+        $this->expectException(NotFoundExceptionInterface::class);
+        $this->expectExceptionMessage('payum.security.token_storage');
+
+        (new PayumBuilder())
+            ->setGlobalContainer($containerBuilder->build())
+            ->getPayum()
+        ;
+    }
+
+    public function testShouldCreateGatewayWithTheContainerConfigurationFactory(): void
+    {
+        $factory = new ContainerConfigurationGatewayFactoryStub();
+
+        $payum = (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addGatewayFactory('acme_factory', $factory)
+            ->addGateway('acme', [
+                'factory' => 'acme_factory',
+            ])
+            ->getPayum()
+        ;
+
+        $this->assertSame(1, $factory->createGatewayCalls);
+        $this->assertSame(0, $factory->createCalls);
+        $this->assertSame($factory->gateway, $payum->getGateway('acme'));
+    }
+
+    public function testShouldPassTheGlobalServicesToTheGatewayContainer(): void
+    {
+        $factory = new ContainerConfigurationGatewayFactoryStub();
+
+        $tokenStorage = $this->createMock(StorageInterface::class);
+        $client = $this->createMock(ClientInterface::class);
+
+        (new PayumBuilder())
+            ->addDefaultStorages()
+            ->setTokenStorage($tokenStorage)
+            ->addGlobalService(ClientInterface::class, $client)
+            ->addGatewayFactory('acme_factory', $factory)
+            ->addGateway('acme', [
+                'factory' => 'acme_factory',
+            ])
+            ->getPayum()
+        ;
+
+        $container = $factory->container;
+
+        $this->assertInstanceOf(ContainerInterface::class, $container);
+        $this->assertSame($tokenStorage, $container->get('payum.security.token_storage'));
+        $this->assertSame($client, $container->get(ClientInterface::class));
+        $this->assertInstanceOf(HttpRequestVerifierInterface::class, $container->get(HttpRequestVerifierInterface::class));
+        $this->assertInstanceOf(GenericTokenFactoryInterface::class, $container->get(GenericTokenFactoryInterface::class));
+        $this->assertInstanceOf(TokenFactoryInterface::class, $container->get(TokenFactoryInterface::class));
+        $this->assertInstanceOf(StreamFactoryInterface::class, $container->get(StreamFactoryInterface::class));
+        $this->assertInstanceOf(RequestFactoryInterface::class, $container->get(RequestFactoryInterface::class));
+    }
+
+    public function testShouldShareTheGlobalServicesBetweenAllGatewayContainers(): void
+    {
+        $firstFactory = new ContainerConfigurationGatewayFactoryStub();
+        $secondFactory = new ContainerConfigurationGatewayFactoryStub();
+
+        (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addGatewayFactory('first_factory', $firstFactory)
+            ->addGatewayFactory('second_factory', $secondFactory)
+            ->addGateway('first', [
+                'factory' => 'first_factory',
+            ])
+            ->addGateway('second', [
+                'factory' => 'second_factory',
+            ])
+            ->getPayum()
+        ;
+
+        $this->assertNotSame($firstFactory->container, $secondFactory->container);
+
+        foreach ([
+            'payum.security.token_storage',
+            HttpRequestVerifierInterface::class,
+            GenericTokenFactoryInterface::class,
+            TokenFactoryInterface::class,
+            ClientInterface::class,
+            StreamFactoryInterface::class,
+            RequestFactoryInterface::class,
+        ] as $serviceId) {
+            $this->assertSame(
+                $firstFactory->container->get($serviceId),
+                $secondFactory->container->get($serviceId),
+                sprintf('The "%s" service is not shared between the gateways', $serviceId)
+            );
+        }
+    }
+
+    public function testShouldPassTheStorageExtensionsToTheGatewayContainer(): void
+    {
+        $factory = new ContainerConfigurationGatewayFactoryStub();
+
+        $storage = $this->createMock(StorageInterface::class);
+
+        (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addStorage(GlobalContainerTestModel::class, $storage)
+            ->addGatewayFactory('acme_factory', $factory)
+            ->addGateway('acme', [
+                'factory' => 'acme_factory',
+            ])
+            ->getPayum()
+        ;
+
+        $this->assertTrue($factory->container->has('payum.extension.storage_payum_core_tests_globalcontainertestmodel'));
+
+        $extension = $factory->container->get('payum.extension.storage_payum_core_tests_globalcontainertestmodel');
+
+        $this->assertInstanceOf(StorageExtension::class, $extension);
+        $this->assertSame($storage, $this->readAttribute($extension, 'storage'));
+    }
+
+    public function testShouldPassTheGatewayConfigToTheGatewayContainer(): void
+    {
+        $factory = new ContainerConfigurationGatewayFactoryStub();
+
+        (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addGatewayFactory('acme_factory', $factory)
+            ->addGateway('acme', [
+                'factory' => 'acme_factory',
+                'acme.username' => 'aUsername',
+                'acme.sandbox' => true,
+            ])
+            ->getPayum()
+        ;
+
+        $this->assertSame('aUsername', $factory->container->get('acme.username'));
+        $this->assertTrue($factory->container->get('acme.sandbox'));
+    }
+
+    public function testShouldGiveTheGatewayConfigPrecedenceOverTheFactoryDefinitions(): void
+    {
+        $factory = new ContainerConfigurationGatewayFactoryStub([
+            'acme.username' => 'aFactoryUsername',
+            'acme.sandbox' => true,
+        ]);
+
+        (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addGatewayFactory('acme_factory', $factory)
+            ->addGateway('acme', [
+                'factory' => 'acme_factory',
+                'acme.username' => 'aUsername',
+            ])
+            ->getPayum()
+        ;
+
+        $this->assertSame('aUsername', $factory->container->get('acme.username'));
+        $this->assertTrue($factory->container->get('acme.sandbox'));
+    }
+
+    public function testShouldGiveTheGatewayConfigPrecedenceOverTheGlobalServices(): void
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $gatewayClient = $this->createMock(ClientInterface::class);
+
+        $factory = new ContainerConfigurationGatewayFactoryStub();
+
+        (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addGlobalService(ClientInterface::class, $client)
+            ->addGatewayFactory('acme_factory', $factory)
+            ->addGateway('acme', [
+                'factory' => 'acme_factory',
+                ClientInterface::class => $gatewayClient,
+            ])
+            ->getPayum()
+        ;
+
+        $this->assertSame($gatewayClient, $factory->container->get(ClientInterface::class));
+    }
+
+    public function testShouldFallBackToTheLegacyGatewayFactoryApi(): void
+    {
+        $factory = new LegacyGatewayFactoryStub();
+
+        $payum = (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addGatewayFactory('legacy_factory', $factory)
+            ->addGateway('legacy', [
+                'factory' => 'legacy_factory',
+                'acme.username' => 'aUsername',
+            ])
+            ->getPayum()
+        ;
+
+        $this->assertSame(1, $factory->createCalls);
+        $this->assertSame($factory->gateway, $payum->getGateway('legacy'));
+        $this->assertSame([
+            'acme.username' => 'aUsername',
+        ], $factory->receivedConfig);
+        $this->assertArrayNotHasKey('factory', $factory->receivedConfig);
+    }
+
+    public function testShouldTriggerDeprecationForTheLegacyGatewayFactoryApi(): void
+    {
+        $builder = (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addGatewayFactory('legacy_factory', new LegacyGatewayFactoryStub())
+            ->addGateway('legacy', [
+                'factory' => 'legacy_factory',
+            ])
+        ;
+
+        $deprecations = $this->collectDeprecations(static function () use ($builder): void {
+            $builder->getPayum();
+        });
+
+        $this->assertContains(
+            sprintf(
+                'Since payum/core 2.0.0: Not implementing %s for gateway factory %s is deprecated.',
+                ContainerConfiguration::class,
+                LegacyGatewayFactoryStub::class
+            ),
+            $deprecations
+        );
+    }
+
+    public function testShouldNotTriggerTheLegacyGatewayFactoryDeprecationForAContainerConfigurationFactory(): void
+    {
+        $builder = (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addGatewayFactory('acme_factory', new ContainerConfigurationGatewayFactoryStub())
+            ->addGateway('acme', [
+                'factory' => 'acme_factory',
+            ])
+        ;
+
+        $deprecations = $this->collectDeprecations(static function () use ($builder): void {
+            $builder->getPayum();
+        });
+
+        $this->assertNotContains(
+            sprintf(
+                'Since payum/core 2.0.0: Not implementing %s for gateway factory %s is deprecated.',
+                ContainerConfiguration::class,
+                ContainerConfigurationGatewayFactoryStub::class
+            ),
+            $deprecations
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function collectDeprecations(callable $callback): array
+    {
+        $deprecations = [];
+
+        set_error_handler(static function (int $errno, string $errstr) use (&$deprecations): bool {
+            $deprecations[] = $errstr;
+
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $callback();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $deprecations;
+    }
+}
+
+class ExposedGlobalContainerPayumBuilder extends PayumBuilder
+{
+    public function buildGlobalContainer(): ContainerInterface
+    {
+        return parent::buildGlobalContainer();
+    }
+}
+
+class ContainerConfigurationGatewayFactoryStub implements GatewayFactoryInterface, ContainerConfiguration
+{
+    public ?ContainerInterface $container = null;
+
+    public int $createGatewayCalls = 0;
+
+    public int $createCalls = 0;
+
+    public Gateway $gateway;
+
+    /**
+     * @param array<string, mixed> $definitions
+     */
+    public function __construct(
+        private array $definitions = []
+    ) {
+        $this->gateway = new Gateway();
+    }
+
+    public function configureContainer(): array
+    {
+        return $this->definitions;
+    }
+
+    public function createGateway(ContainerInterface $container): Gateway
+    {
+        ++$this->createGatewayCalls;
+        $this->container = $container;
+
+        return $this->gateway;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     *
+     * @return array<string, mixed>
+     */
+    public function createConfig(array $config = []): array
+    {
+        return $config;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function create(array $config = []): Gateway
+    {
+        ++$this->createCalls;
+
+        return $this->gateway;
+    }
+}
+
+class LegacyGatewayFactoryStub implements GatewayFactoryInterface
+{
+    public int $createCalls = 0;
+
+    /**
+     * @var array<string, mixed>
+     */
+    public array $receivedConfig = [];
+
+    public Gateway $gateway;
+
+    public function __construct()
+    {
+        $this->gateway = new Gateway();
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     *
+     * @return array<string, mixed>
+     */
+    public function createConfig(array $config = []): array
+    {
+        return $config;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function create(array $config = []): Gateway
+    {
+        ++$this->createCalls;
+        $this->receivedConfig = $config;
+
+        return $this->gateway;
+    }
+}
+
+class GlobalContainerTestModel
+{
+}

--- a/src/Payum/Core/Tests/PayumBuilderGlobalContainerTest.php
+++ b/src/Payum/Core/Tests/PayumBuilderGlobalContainerTest.php
@@ -4,8 +4,10 @@ namespace Payum\Core\Tests;
 
 use DI\Container;
 use DI\ContainerBuilder;
+use InvalidArgumentException;
 use Payum\Core\Action\ActionInterface;
 use Payum\Core\Bridge\PlainPhp\Action\GetHttpRequestAction;
+use Payum\Core\Bridge\PlainPhp\Security\HttpRequestVerifier;
 use Payum\Core\CoreGatewayFactory;
 use Payum\Core\DI\ContainerConfiguration;
 use Payum\Core\Extension\StorageExtension;
@@ -16,6 +18,7 @@ use Payum\Core\Model\Payment;
 use Payum\Core\Model\Payout;
 use Payum\Core\Payum;
 use Payum\Core\PayumBuilder;
+use Payum\Core\Security\GenericTokenFactory;
 use Payum\Core\Security\GenericTokenFactoryInterface;
 use Payum\Core\Security\HttpRequestVerifierInterface;
 use Payum\Core\Security\TokenFactoryInterface;
@@ -254,23 +257,101 @@ class PayumBuilderGlobalContainerTest extends TestCase
         $this->assertSame($client, $container->get(ClientInterface::class));
     }
 
-    public function testBuildGlobalContainerShouldReturnThePresetContainer(): void
+    public function testBuildGlobalContainerShouldPreferThePresetContainerOverPayumsOwnServices(): void
     {
-        $expectedContainer = new Container();
+        $client = $this->createMock(ClientInterface::class);
+
+        $presetContainer = new Container();
+        $presetContainer->set(ClientInterface::class, $client);
 
         $container = (new ExposedGlobalContainerPayumBuilder())
             ->addDefaultStorages()
-            ->setGlobalContainer($expectedContainer)
+            ->setGlobalContainer($presetContainer)
             ->buildGlobalContainer()
         ;
 
-        $this->assertSame($expectedContainer, $container);
+        $this->assertSame($client, $container->get(ClientInterface::class));
     }
 
-    public function testBuildGlobalContainerShouldNotAddDefaultStoragesWhenAContainerIsPreset(): void
+    public function testBuildGlobalContainerShouldFallBackToPayumsOwnServicesWhenThePresetContainerHasNone(): void
+    {
+        $container = (new ExposedGlobalContainerPayumBuilder())
+            ->addDefaultStorages()
+            ->setGlobalContainer(new Container())
+            ->buildGlobalContainer()
+        ;
+
+        $this->assertInstanceOf(HttpRequestVerifierInterface::class, $container->get(HttpRequestVerifierInterface::class));
+        $this->assertInstanceOf(GenericTokenFactoryInterface::class, $container->get(GenericTokenFactoryInterface::class));
+        $this->assertInstanceOf(TokenFactoryInterface::class, $container->get(TokenFactoryInterface::class));
+        $this->assertInstanceOf(StorageInterface::class, $container->get('payum.security.token_storage'));
+        $this->assertInstanceOf(ClientInterface::class, $container->get(ClientInterface::class));
+    }
+
+    public function testBuildGlobalContainerShouldBuildPayumsTokenFactoryOnTopOfThePresetContainersTokenStorage(): void
+    {
+        $tokenStorage = $this->createMock(StorageInterface::class);
+
+        $presetContainer = new Container();
+        $presetContainer->set('payum.security.token_storage', $tokenStorage);
+
+        $container = (new ExposedGlobalContainerPayumBuilder())
+            ->setGlobalContainer($presetContainer)
+            ->buildGlobalContainer()
+        ;
+
+        $this->assertSame($tokenStorage, $container->get('payum.security.token_storage'));
+        $this->assertSame(
+            $tokenStorage,
+            $this->readAttribute($container->get(HttpRequestVerifierInterface::class), 'tokenStorage')
+        );
+        $this->assertSame(
+            $tokenStorage,
+            $this->readAttribute($container->get(TokenFactoryInterface::class), 'tokenStorage')
+        );
+    }
+
+    public function testBuildGlobalContainerShouldBuildPayumsGenericTokenFactoryOnTopOfThePresetContainersTokenFactory(): void
+    {
+        $tokenFactory = $this->createMock(TokenFactoryInterface::class);
+
+        $presetContainer = new Container();
+        $presetContainer->set(TokenFactoryInterface::class, $tokenFactory);
+
+        $container = (new ExposedGlobalContainerPayumBuilder())
+            ->addDefaultStorages()
+            ->setGlobalContainer($presetContainer)
+            ->buildGlobalContainer()
+        ;
+
+        $this->assertSame(
+            $tokenFactory,
+            $this->readAttribute($container->get(GenericTokenFactoryInterface::class), 'tokenFactory')
+        );
+    }
+
+    public function testBuildGlobalContainerShouldAddDefaultStoragesWhenThePresetContainerHasNoTokenStorage(): void
     {
         $builder = new ExposedGlobalContainerPayumBuilder();
         $builder->setGlobalContainer(new Container());
+
+        $container = $builder->buildGlobalContainer();
+
+        $this->assertInstanceOf(StorageInterface::class, $container->get('payum.security.token_storage'));
+
+        $ref = new ReflectionProperty($builder, 'storages');
+        $ref->setAccessible(true);
+
+        $this->assertArrayHasKey(Payment::class, $ref->getValue($builder));
+    }
+
+    public function testBuildGlobalContainerShouldNotAddDefaultStoragesWhenThePresetContainerHasATokenStorage(): void
+    {
+        $presetContainer = new Container();
+        $presetContainer->set('payum.security.token_storage', $this->createMock(StorageInterface::class));
+
+        $builder = new ExposedGlobalContainerPayumBuilder();
+        $builder->setGlobalContainer($presetContainer);
 
         $builder->buildGlobalContainer();
 
@@ -285,16 +366,19 @@ class PayumBuilderGlobalContainerTest extends TestCase
         $this->assertNull($ref->getValue($builder));
     }
 
-    public function testBuildGlobalContainerShouldIgnoreGlobalServicesWhenAContainerIsPreset(): void
+    public function testBuildGlobalContainerShouldStillExposeGlobalServicesWhenAContainerIsPreset(): void
     {
+        $service = new stdClass();
+
         $container = (new ExposedGlobalContainerPayumBuilder())
             ->addDefaultStorages()
             ->setGlobalContainer(new Container())
-            ->addGlobalService('acme.service', new stdClass())
+            ->addGlobalService('acme.service', $service)
             ->buildGlobalContainer()
         ;
 
-        $this->assertFalse($container->has('acme.service'));
+        $this->assertTrue($container->has('acme.service'));
+        $this->assertSame($service, $container->get('acme.service'));
     }
 
     public function testGetPayumShouldUseTheSecurityServicesFromTheGlobalContainer(): void
@@ -404,21 +488,17 @@ class PayumBuilderGlobalContainerTest extends TestCase
         $this->assertSame($tokenStorage, $payum->getTokenStorage());
     }
 
-    public function testGetPayumShouldFailWhenNeitherTheBuilderNorThePresetContainerProvideATokenStorage(): void
+    public function testGetPayumShouldWorkWithAContainerProvidingNoneOfPayumsServices(): void
     {
-        $containerBuilder = new ContainerBuilder();
-        $containerBuilder->addDefinitions([
-            GenericTokenFactoryInterface::class => $this->createMock(GenericTokenFactoryInterface::class),
-            HttpRequestVerifierInterface::class => $this->createMock(HttpRequestVerifierInterface::class),
-        ]);
-
-        $this->expectException(NotFoundExceptionInterface::class);
-        $this->expectExceptionMessage('payum.security.token_storage');
-
-        (new PayumBuilder())
-            ->setGlobalContainer($containerBuilder->build())
+        $payum = (new PayumBuilder())
+            ->setGlobalContainer(new Container())
             ->getPayum()
         ;
+
+        $this->assertInstanceOf(Payum::class, $payum);
+        $this->assertInstanceOf(HttpRequestVerifierInterface::class, $payum->getHttpRequestVerifier());
+        $this->assertInstanceOf(GenericTokenFactoryInterface::class, $payum->getTokenFactory());
+        $this->assertInstanceOf(StorageInterface::class, $payum->getTokenStorage());
     }
 
     public function testShouldCreateGatewayWithTheContainerConfigurationFactory(): void
@@ -643,6 +723,45 @@ class PayumBuilderGlobalContainerTest extends TestCase
         $this->assertSame($service, $factory->container->get('acme.service'));
     }
 
+    public function testShouldResolveServicesOfAPresetContainerWhichCannotEnumerateItsEntriesFromAGateway(): void
+    {
+        $service = new stdClass();
+
+        $factory = new ContainerConfigurationGatewayFactoryStub();
+
+        (new PayumBuilder())
+            ->setGlobalContainer(new OpaqueContainer([
+                'acme.service' => $service,
+            ]))
+            ->addGatewayFactory('acme_factory', $factory)
+            ->addGateway('acme', [
+                'factory' => 'acme_factory',
+            ])
+            ->getPayum()
+        ;
+
+        $this->assertTrue($factory->container->has('acme.service'));
+        $this->assertSame($service, $factory->container->get('acme.service'));
+    }
+
+    public function testShouldStillResolvePayumsOwnServicesFromAGatewayWhenThePresetContainerCannotEnumerate(): void
+    {
+        $factory = new ContainerConfigurationGatewayFactoryStub();
+
+        (new PayumBuilder())
+            ->setGlobalContainer(new OpaqueContainer())
+            ->addGatewayFactory('acme_factory', $factory)
+            ->addGateway('acme', [
+                'factory' => 'acme_factory',
+            ])
+            ->getPayum()
+        ;
+
+        $this->assertInstanceOf(StorageInterface::class, $factory->container->get('payum.security.token_storage'));
+        $this->assertInstanceOf(GenericTokenFactoryInterface::class, $factory->container->get(GenericTokenFactoryInterface::class));
+        $this->assertInstanceOf(ClientInterface::class, $factory->container->get(ClientInterface::class));
+    }
+
     public function testShouldNotDelegateTheContainerItselfToThePresetGlobalContainer(): void
     {
         $globalContainer = (new ContainerBuilder())->build();
@@ -661,8 +780,9 @@ class PayumBuilderGlobalContainerTest extends TestCase
             ->getPayum()
         ;
 
-        $this->assertSame($factory->container, $factory->container->get(ContainerInterface::class));
+        // A gateway is injected with its own container, never with the global one
         $this->assertNotSame($globalContainer, $factory->container->get(ContainerInterface::class));
+        $this->assertNotSame($globalContainer, $factory->container);
     }
 
     public function testShouldGiveTheGlobalServicesPrecedenceOverTheGatewayFactoryDefaults(): void
@@ -746,6 +866,39 @@ class PayumBuilderGlobalContainerTest extends TestCase
 
         // the core actions are still registered
         $this->assertContains(GetHttpRequestAction::class, array_map('get_class', $actions));
+    }
+
+    /**
+     * Guards the framework integration documented in docs/di: an application container which cannot list
+     * its entries plus addGlobalService() for what the gateways need injected.
+     */
+    public function testShouldInjectAGlobalServiceIntoAnActionWhenThePresetContainerCannotEnumerate(): void
+    {
+        $logger = new NullLogger();
+
+        $payum = (new PayumBuilder())
+            ->setGlobalContainer(new OpaqueContainer())
+            ->addGlobalService(LoggerInterface::class, $logger)
+            ->addGatewayFactory('documented', new DocumentedGatewayFactory())
+            ->addGateway('documented', [
+                'factory' => 'documented',
+            ])
+            ->getPayum()
+        ;
+
+        $documentedAction = null;
+        foreach ($this->readAttribute($payum->getGateway('documented'), 'actions') as $action) {
+            if ($action instanceof DocumentedCaptureAction) {
+                $documentedAction = $action;
+            }
+        }
+
+        $this->assertInstanceOf(DocumentedCaptureAction::class, $documentedAction);
+        $this->assertSame($logger, $documentedAction->logger);
+
+        // Payum's own services are still there, without the application declaring any of them
+        $this->assertInstanceOf(GenericTokenFactory::class, $payum->getTokenFactory());
+        $this->assertInstanceOf(HttpRequestVerifier::class, $payum->getHttpRequestVerifier());
     }
 
     public function testShouldStillSupportTheDeprecatedCreateApiOnADocumentedGatewayFactory(): void
@@ -954,6 +1107,35 @@ class LegacyGatewayFactoryStub implements GatewayFactoryInterface
 
 class GlobalContainerTestModel
 {
+}
+
+/**
+ * A PSR-11 container which, like most framework containers, cannot list what it holds.
+ */
+class OpaqueContainer implements ContainerInterface
+{
+    /**
+     * @param array<string, mixed> $services
+     */
+    public function __construct(
+        private array $services = []
+    ) {
+    }
+
+    public function get(string $id): mixed
+    {
+        if (! $this->has($id)) {
+            throw new class('Service ' . $id . ' not found') extends InvalidArgumentException implements NotFoundExceptionInterface {
+            };
+        }
+
+        return $this->services[$id];
+    }
+
+    public function has(string $id): bool
+    {
+        return isset($this->services[$id]);
+    }
 }
 
 class DocumentedApi

--- a/src/Payum/Core/composer.json
+++ b/src/Payum/Core/composer.json
@@ -40,7 +40,10 @@
         "psr/log": "^1 || ^2 || ^3",
         "league/uri": "^6.4 || ^7.0",
         "league/uri-components": "^2.2 || ^7.0",
-        "twig/twig": "^2.4 || ^3.0"
+        "twig/twig": "^2.4 || ^3.0",
+        "psr/container": "^2.0",
+        "php-di/php-di": "^7.0",
+        "symfony/deprecation-contracts": "^2.5 || ^3.0"
     },
     "require-dev": {
         "ext-curl": "*",


### PR DESCRIPTION
This adds a Dependency Injection container which is used for all configuration options, actions and extensions

## Motivation
Currently a custom dependency injection container is used for the gateway config, where config options, actions etc. are added to an `ArrayObject` instance. This has support for factories, which uses a function to construct a class and has access to all the values defined in the ArrayObject instance.

This has been replaced with an external dependency injection container using [PHP-DI](https://php-di.org/).

## Benefits
There are several benefits with using PHP-DI as a container:

* Autowiring
* Lazy object creation
* Automatic object creation without any config
	* For example, you can just call `$container->get(SomeClass::class)` and get an instance of the class with all the dependencies resolved without having to specify any configuration
* Compatibility with psr/container

Having a container providing services is already available in the Symfony and Laravel integration. This just adds it to Core so that we can benefit from Dependency Injection outside of any framework integration.

## Side Effects

This implementation also has some side-effects:

We can no longer determine if a config value should be an action or an extension without iterating through the entire container definition.

This means we are deprecating the `payum.action.*` and `payum.extension.*` config options

Instead, we introduce a new way to specify actions and extensions for a gateway by introducing a `GatewayFactoryConfigInterface` interface

```php
interface GatewayFactoryConfigInterface
{
    public function createGateway(ContainerInterface $container): Gateway;

    /**
     * @return array<string, class-string<ActionInterface>>|list<class-string<ActionInterface>>
     */
    public function getActions(): array;

    /**
     * @return list<ExtensionInterface|class-string<ExtensionInterface>>
     */
    public function getExtensions(): array;
}
```

This interface provides dedicated methods for actions and interfaces, and also provides a method for creating the gateway which has access to the container.

Here is an example from the `CoreGatewayFactory`:

```php
public function getActions(): array
{
    return [
        GetHttpRequestAction::class,
        CapturePaymentAction::class,
        AuthorizePaymentAction::class,
        PayoutPayoutAction::class,
        ExecuteSameRequestWithModelDetailsAction::class,
        RenderTemplateAction::class,
        GetCurrencyAction::class,
        GetTokenAction::class,
    ];
}
```

This also means we are deprecating the `GatewayFactoryInterface` in favour of the `GatewayFactoryConfigInterface`.

## Usage

If a factory wants to provide it's own configuration for a container, the gateway factory can implement the `ContainerConfiguration` interface, which has the method `public function configureContainer(): array;` in order to define it's own container configuration (which will be merged with the config from CoreGateFactory), E.G

```php
public function configureContainer(): array {
    return [
        SomeCustomClass:class,
    ];
}
```

If you want to override or decorate an existing service (E.G provide you own implementation for the `GetCurrencyAction`), you can use the built-in features from PHP-DI:

```
public function configureContainer(): array {
    return [
        GetCurrencyAction:class => \DI\decorate(function ($previous, ContainerInterface $c) {
        return new CustomGetCurrencyAction($previous, $c->get('some.other.service'));
    }),
    ];
}
``` 

**Important:** The container instance is unique for each gateway. This means if you define a service on one gateway, then it won't be available in the container for another gateway.

## Backward Compatibility

The current implementation is fully backward compatible with the current gateway configuration. This means that all existing gateways will continue working, and new gateways can implement the new interfaces and start using the new container. Existing gateways can also migrate to the newer container configuration whenever they want without any BC breaks.

## TODO

- [x] Add a way to define global service definitions.
	- Currently only the CoreGatewayFactory defines services that is available to all gateways. We need an extension point where we can add global services that will be available for every gateway
- [x] Add other global instances to the container (HttpRequestVerifierInterface, TokenFactoryInterface, StorageInterface etc)
	- This should allow these services to be available in every container instance, but also provide a way to override it (I.E provide a custom implementation)
- [ ] Ensure the container can work together with other containers (E.G The Symfony container when using the PayumBundle)

This feature paves the way for much greater flexibility and additional features on the roadmap.

This is just a first-pass of the implementation. There are still lots to do, but opening this up now for some initial feedback