### PR TITLE
Allow ^7.0 for league/uri and league/uri-components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,8 +44,8 @@
         "payum/iso4217": "~1.0",
         "php-http/message": "^1.0",
         "php-http/client-implementation": "^1.0",
-        "league/uri": "^6.4",
-        "league/uri-components": "^2.2",
+        "league/uri": "^6.4 || ^7.0",
+        "league/uri-components": "^2.2 || ^7.0",
         "twig/twig": "^1.34 || ^2.4 || ^3.0"
     },
     "require-dev": {

--- a/src/Payum/Core/Bridge/PlainPhp/Security/TokenFactory.php
+++ b/src/Payum/Core/Bridge/PlainPhp/Security/TokenFactory.php
@@ -35,7 +35,13 @@ class TokenFactory extends AbstractTokenFactory
     {
         $hierarchicalPath = HierarchicalPath::createFromUri($this->baseUrl);
         if ('php' === pathinfo($hierarchicalPath->getBasename(), PATHINFO_EXTENSION)) {
-            $newPath = UriModifier::replaceBasename($this->baseUrl, (new Path($path))->withoutLeadingSlash())->getPath();
+            if(method_exists(Path::class, 'new')) {
+                $pathComponent = Path::new($path);
+            } else {
+                $pathComponent = new Path($path);
+            }
+
+            $newPath = UriModifier::replaceBasename($this->baseUrl, $pathComponent->withoutLeadingSlash())->getPath();
         } else {
             $newPath = UriModifier::appendSegment($this->baseUrl, $path)->getPath();
         }

--- a/src/Payum/Core/Bridge/PlainPhp/Security/TokenFactory.php
+++ b/src/Payum/Core/Bridge/PlainPhp/Security/TokenFactory.php
@@ -35,7 +35,7 @@ class TokenFactory extends AbstractTokenFactory
     {
         $hierarchicalPath = HierarchicalPath::createFromUri($this->baseUrl);
         if ('php' === pathinfo($hierarchicalPath->getBasename(), PATHINFO_EXTENSION)) {
-            if(method_exists(Path::class, 'new')) {
+            if (method_exists(Path::class, 'new')) {
                 $pathComponent = Path::new($path);
             } else {
                 $pathComponent = new Path($path);


### PR DESCRIPTION
According to the changelog none of the functions that got dropped in 7.0 version were used by payum/payum but some are seemingly missing from the changelog because the Path constructor being changed to private was not mentioned
https://github.com/thephpleague/uri/blob/master/CHANGELOG.md
https://github.com/thephpleague/uri-components/blob/master/CHANGELOG.md

If I were to make a similar pull request into 1.7.x would it be possible to accept it and make a new patch version or the fact it's a major version bump for a dependency would forbide that ?