### PR TITLE
Update Payment.php - PHP7.4 warning

### DIFF
--- a/src/Payum/Core/Model/Payment.php
+++ b/src/Payum/Core/Model/Payment.php
@@ -158,7 +158,7 @@ class Payment implements PaymentInterface, DirectDebitPaymentInterface
         return $this->creditCard;
     }
 
-    public function setCreditCard(CreditCardInterface $creditCard = null): void
+    public function setCreditCard(?CreditCardInterface $creditCard = null): void
     {
         $this->creditCard = $creditCard;
     }


### PR DESCRIPTION
Implicitly marking parameter $creditCard as nullable is deprecated, the explicit nullable type must be used instead in vendor/payum/payum/src/Payum/Core/Model/Payment.php line 185