### PR TITLE
Explicitly mark null parameters as nullable

### DIFF
--- a/src/Payum/Core/Bridge/Psr/Log/LogExecutedActionsExtension.php
+++ b/src/Payum/Core/Bridge/Psr/Log/LogExecutedActionsExtension.php
@@ -18,7 +18,7 @@ class LogExecutedActionsExtension implements ExtensionInterface, LoggerAwareInte
     /**
      * @param LoggerInterface $logger
      */
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         $this->logger = $logger ?: new NullLogger();
     }

--- a/src/Payum/Core/Bridge/Psr/Log/LoggerExtension.php
+++ b/src/Payum/Core/Bridge/Psr/Log/LoggerExtension.php
@@ -22,7 +22,7 @@ class LoggerExtension implements ExtensionInterface, LoggerAwareInterface
     /**
      * @param LoggerInterface $logger
      */
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         $this->nullLogger = new NullLogger();
         $this->logger = $logger ?: $this->nullLogger;

--- a/src/Payum/Core/PayumBuilder.php
+++ b/src/Payum/Core/PayumBuilder.php
@@ -282,7 +282,7 @@ class PayumBuilder
      *
      * @return static
      */
-    public function setTokenStorage(StorageInterface $tokenStorage = null)
+    public function setTokenStorage(?StorageInterface $tokenStorage = null)
     {
         $this->tokenStorage = $tokenStorage;
 
@@ -313,7 +313,7 @@ class PayumBuilder
      *
      * @return static
      */
-    public function setCoreGatewayFactoryConfig(array $config = null)
+    public function setCoreGatewayFactoryConfig(?array $config = null)
     {
         $this->coreGatewayFactoryConfig = $config;
 
@@ -338,7 +338,7 @@ class PayumBuilder
      *
      * @return static
      */
-    public function setGatewayConfigStorage(StorageInterface $gatewayConfigStorage = null)
+    public function setGatewayConfigStorage(?StorageInterface $gatewayConfigStorage = null)
     {
         $this->gatewayConfigStorage = $gatewayConfigStorage;
 
@@ -350,7 +350,7 @@ class PayumBuilder
      *
      * @return static
      */
-    public function setMainRegistry(RegistryInterface $mainRegistry = null)
+    public function setMainRegistry(?RegistryInterface $mainRegistry = null)
     {
         $this->mainRegistry = $mainRegistry;
 
@@ -364,7 +364,7 @@ class PayumBuilder
      *
      * @return static
      */
-    public function setHttpClient(HttpClientInterface $httpClient = null)
+    public function setHttpClient(?HttpClientInterface $httpClient = null)
     {
         $this->httpClient = $httpClient;
 


### PR DESCRIPTION
Ensure PHP 8.4 compatibility by marking null parameters explicitly as nullable