### PR TITLE
Allow ^7.0 for league/uri and league/uri-components in core

### DIFF
--- a/src/Payum/Core/composer.json
+++ b/src/Payum/Core/composer.json
@@ -37,8 +37,8 @@
         "php-http/message": "^1.0",
         "php-http/client-implementation": "^1.0",
         "psr/log": "^1 || ^2 || ^3",
-        "league/uri": "^6.4",
-        "league/uri-components": "^2.2",
+        "league/uri": "^6.4 || ^7.0",
+        "league/uri-components": "^2.2 || ^7.0",
         "twig/twig": "^1.34|^2.4|^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Complementary to changes from this PR:

https://github.com/Payum/Payum/pull/1004

Allowing 7.0 for league/uri and league/uri-components in Composer.json in Core