### PR TITLE
Middleware pipeline for command execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.0.0 (TBD)
 
+* Add a middleware pipeline around command execution. `Payum\Core\Middleware\MiddlewareInterface` wraps a command, `PayumBuilder::addMiddleware()` registers one for every gateway, and a gateway declares its own through `Payum\Core\Gateway\DeclaresMiddleware`
+* Extensions registered on a gateway now run for commands too, through `Payum\Core\Middleware\LegacyExtensionMiddleware`
 * Add a command/handler model for gateways. A gateway describes itself and ships handlers that answer typed commands and return a result, instead of being assembled by a factory and interrupted by thrown replies. See the Gateways chapter in the docs
 * Add `Payum\Core\Gateway\GatewayInterface`, which a gateway implements to declare its name, logo, website, config class and handlers. It replaces the gateway factory
 * Add `Payum\Core\Config\GatewayConfig` for typed, self-validating gateway credentials, and `PayumBuilder::registerGateway()` to register one

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -12,6 +12,7 @@
   * [Handlers](gateways/handlers.md)
   * [Results](gateways/results.md)
   * [Services](gateways/services.md)
+  * [Middleware](gateways/middleware.md)
   * [Migrating a gateway from 1.x](gateways/migrating-from-v1.md)
 * [Dependency Injection](di/README.md)
   * [Getting started](di/getting-started.md)

--- a/docs/gateways/README.md
+++ b/docs/gateways/README.md
@@ -45,4 +45,5 @@ Two rules keep the boundaries honest:
 * [Handlers](handlers.md) — answering a command, and the re-entrant capture
 * [Results](results.md) — what comes back
 * [Services](services.md) — the container, autowiring, and overriding
+* [Middleware](middleware.md) — wrapping command execution
 * [Migrating a gateway from 1.x](migrating-from-v1.md)

--- a/docs/gateways/middleware.md
+++ b/docs/gateways/middleware.md
@@ -1,0 +1,121 @@
+# Middleware
+
+Middleware wraps the execution of a command. It runs around the handler rather than instead of it, so it sees the command going in and the result coming back.
+
+```php
+<?php
+namespace Acme\Payum\Middleware;
+
+use Payum\Core\Command\CommandInterface;
+use Payum\Core\Handler\Context;
+use Payum\Core\Middleware\MiddlewareInterface;
+use Payum\Core\Result\Result;
+use Psr\Log\LoggerInterface;
+
+final class LoggingMiddleware implements MiddlewareInterface
+{
+    public function __construct(private readonly LoggerInterface $logger)
+    {
+    }
+
+    public function process(CommandInterface $command, Context $context, callable $next): Result
+    {
+        $this->logger->info('Dispatching {command}', ['command' => $command::class]);
+
+        $result = $next($command, $context);
+
+        $this->logger->info('Got {status}', ['status' => $result->status->value]);
+
+        return $result;
+    }
+}
+```
+
+Call `$next` to continue. Return without calling it and the handler never runs, which is how a guard or a cache would work. Wrap it in `try`/`finally` for anything that has to happen even when the handler throws.
+
+`$next` takes a command and a context, so middleware can pass different ones on — a command is immutable, so this is how you would amend one.
+
+### Registering it
+
+Most middleware has nothing to do with any particular gateway. Logging, locking and idempotency apply to every command whoever handles it, so they belong on the builder, where they are registered once and wrap every gateway:
+
+```php
+$payum = (new PayumBuilder())
+    ->addDefaultStorages()
+    ->addMiddleware(new LoggingMiddleware($logger))
+    ->registerGateway('acme', new AcmeConfig('sk_…'))
+    ->getPayum();
+```
+
+You can register a container id instead of an instance, and it is resolved from the gateway's container when the pipeline is built:
+
+```php
+->addMiddleware(LoggingMiddleware::class)
+```
+
+### Order
+
+Higher priority runs further out: first on the way in, last on the way back.
+
+```php
+->addMiddleware(new OutermostMiddleware(), 1000)
+->addMiddleware(new InnermostMiddleware(), -100)
+```
+
+Middleware that does not say otherwise sits at 0, and registration order breaks ties. A middleware can carry its own default instead of relying on whoever registers it:
+
+```php
+use Payum\Core\Middleware\HasPriority;
+
+final class LoggingMiddleware implements MiddlewareInterface, HasPriority
+{
+    public static function priority(): int
+    {
+        return 200;
+    }
+}
+```
+
+An explicit priority passed to `addMiddleware()` overrides that.
+
+What core registers, outermost first:
+
+| Middleware | Priority | Does |
+| :--- | :--- | :--- |
+| `EndlessCycleDetectorMiddleware` | 1000 | Stops a handler that dispatches its way into a loop |
+| `LegacyExtensionMiddleware` | 500 | Runs the gateway's registered extensions |
+| `PersistStateMiddleware` | 100 | Writes the PSP state back onto the payment |
+
+So anything you register at the default 0 runs inside all three, closest to the handler.
+
+### Middleware belonging to one gateway
+
+A gateway can declare its own, which is registered only for that gateway:
+
+```php
+<?php
+use Payum\Core\Gateway\DeclaresMiddleware;
+use Payum\Core\Gateway\GatewayInterface;
+
+final class AcmeGateway implements GatewayInterface, DeclaresMiddleware
+{
+    public function middleware(): array
+    {
+        return [AcmeAuditMiddleware::class];
+    }
+}
+```
+
+These are container ids, resolved from the gateway's own container, and they run inside anything the application registered.
+
+Reach for this rarely. If the concern would make sense for another gateway, it belongs on the builder instead. Obtaining an access token, for instance, looks like a candidate but is not one: it is a property of talking to that PSP, not of executing a command, so it belongs in the api — cached there, or handled by a PSR-18 decorator around the HTTP client. Putting it in middleware would fire it for commands that never call the PSP, and tie authentication to dispatch.
+
+### Shipping middleware in a package
+
+Nothing about middleware is tied to a gateway, so a package can ship one and let the application register it. Publish a class implementing `MiddlewareInterface`, and either document `addMiddleware()` or have your framework integration call it.
+
+### Extensions
+
+Extensions registered on a gateway still run for commands, through `LegacyExtensionMiddleware`. The bridge is one-way: an extension observes the command and can abort by throwing, but it cannot swap the result — a `Result` is not a `ReplyInterface`, so `Context::setReply()` has nothing to accept — and `getAction()` is always null, because a command is answered by a handler.
+
+New code should use middleware.

--- a/docs/gateways/services.md
+++ b/docs/gateways/services.md
@@ -131,4 +131,4 @@ $payum = (new PayumBuilder())
 
 `setGlobalContainer()` puts an application's own container in front of Payum's defaults, so a framework declares only what it wants to override. See [Framework integration](../di/framework-integration.md).
 
-Next: [Migrating a gateway from 1.x](migrating-from-v1.md).
+Next: [Middleware](middleware.md).

--- a/src/Payum/Core/CoreGatewayFactory.php
+++ b/src/Payum/Core/CoreGatewayFactory.php
@@ -42,6 +42,11 @@ use Payum\Core\Extension\EndlessCycleDetectorExtension;
 use Payum\Core\Extension\PrependExtensionInterface;
 use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
 use Payum\Core\Handler\HandlerMap;
+use Payum\Core\Middleware\EndlessCycleDetectorMiddleware;
+use Payum\Core\Middleware\LegacyExtensionMiddleware;
+use Payum\Core\Middleware\MiddlewareCollection;
+use Payum\Core\Middleware\PersistStateMiddleware;
+use Payum\Core\Registry\StorageRegistryInterface;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -251,6 +256,16 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
                 StreamFactoryInterface::class => Psr17FactoryDiscovery::findStreamFactory(...),
                 RequestFactoryInterface::class => Psr17FactoryDiscovery::findRequestFactory(...),
                 ServerRequestFactoryInterface::class => Psr17FactoryDiscovery::findServerRequestFactory(...),
+
+                // Middleware wrapping command execution. The collection is what decides the order;
+                // PayumBuilder replaces it with the defaults plus whatever the application and the
+                // gateway registered.
+                MiddlewareCollection::class => static fn (): MiddlewareCollection => self::defaultMiddleware(),
+                EndlessCycleDetectorMiddleware::class => static fn (): EndlessCycleDetectorMiddleware => new EndlessCycleDetectorMiddleware(),
+                LegacyExtensionMiddleware::class => static fn (): LegacyExtensionMiddleware => new LegacyExtensionMiddleware(),
+                PersistStateMiddleware::class => static fn (ContainerInterface $c): PersistStateMiddleware => new PersistStateMiddleware(
+                    $c->has(StorageRegistryInterface::class) ? $c->get(StorageRegistryInterface::class) : null,
+                ),
                 ServerRequestInterface::class => static fn (ContainerInterface $c): ServerRequestInterface => $c
                     ->get(ServerRequestFactoryInterface::class)
                     ->createServerRequest($_SERVER['REQUEST_METHOD'] ?? 'GET', $_SERVER['REQUEST_URI'] ?? '/', $_SERVER)
@@ -317,6 +332,17 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
     /**
      * @throws ContainerExceptionInterface|NotFoundExceptionInterface|LoaderError
      */
+    /**
+     * The middleware every gateway gets, before anything the application or the gateway adds.
+     */
+    public static function defaultMiddleware(): MiddlewareCollection
+    {
+        return (new MiddlewareCollection())
+            ->with(EndlessCycleDetectorMiddleware::class)
+            ->with(LegacyExtensionMiddleware::class)
+            ->with(PersistStateMiddleware::class);
+    }
+
     public function createGateway(ContainerInterface $container): Gateway
     {
         if (2 === func_num_args() && func_get_args()[1] instanceof Gateway) {

--- a/src/Payum/Core/CoreGatewayFactory.php
+++ b/src/Payum/Core/CoreGatewayFactory.php
@@ -61,7 +61,6 @@ use ReflectionNamedType;
 use ReflectionType;
 use Symfony\Component\HttpClient\HttplugClient as SymfonyHttplugClient;
 use Twig\Environment;
-use Twig\Error\LoaderError;
 use Twig\Loader\ChainLoader;
 use function array_combine;
 use function array_map;
@@ -260,7 +259,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
                 // Middleware wrapping command execution. The collection is what decides the order;
                 // PayumBuilder replaces it with the defaults plus whatever the application and the
                 // gateway registered.
-                MiddlewareCollection::class => static fn (): MiddlewareCollection => self::defaultMiddleware(),
+                MiddlewareCollection::class => self::defaultMiddleware(...),
                 EndlessCycleDetectorMiddleware::class => static fn (): EndlessCycleDetectorMiddleware => new EndlessCycleDetectorMiddleware(),
                 LegacyExtensionMiddleware::class => static fn (): LegacyExtensionMiddleware => new LegacyExtensionMiddleware(),
                 PersistStateMiddleware::class => static fn (ContainerInterface $c): PersistStateMiddleware => new PersistStateMiddleware(

--- a/src/Payum/Core/Gateway.php
+++ b/src/Payum/Core/Gateway.php
@@ -4,7 +4,6 @@ namespace Payum\Core;
 
 use Exception;
 use Payum\Core\Action\ActionInterface;
-use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Command\CommandInterface;
 use Payum\Core\Exception\CommandNotSupportedException;
 use Payum\Core\Exception\LogicException;
@@ -17,12 +16,13 @@ use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
 use Payum\Core\Handler\Context as HandlerContext;
 use Payum\Core\Handler\HandlerInterface;
 use Payum\Core\Handler\HandlerMap;
+use Payum\Core\Middleware\MiddlewareCollection;
+use Payum\Core\Middleware\Pipeline;
 use Payum\Core\Model\PaymentInterface;
 use Payum\Core\Registry\StorageRegistryInterface;
 use Payum\Core\Reply\ReplyInterface;
 use Payum\Core\Result\Result;
 use Payum\Core\Security\GenericTokenFactoryInterface;
-use Payum\Core\Security\TokenInterface;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -58,6 +58,8 @@ class Gateway implements GatewayInterface
     protected ContainerInterface $container;
 
     protected ?HandlerMap $handlerMap = null;
+
+    protected ?Pipeline $pipeline = null;
 
     /**
      * The name this gateway is registered under. Set by the builder; null when built by hand.
@@ -111,6 +113,11 @@ class Gateway implements GatewayInterface
     public function addExtension(ExtensionInterface $extension, $forcePrepend = false): void
     {
         $this->extensions->addExtension($extension, $forcePrepend);
+    }
+
+    public function getExtensions(): ExtensionCollection
+    {
+        return $this->extensions;
     }
 
     public function execute(/* CommandInterface */ $request, $catchReply = false)
@@ -312,30 +319,64 @@ class Gateway implements GatewayInterface
             );
         }
 
+        $context = $this->buildContext($command);
+        $this->commandStack[] = $context;
+
+        try {
+            return $this->pipeline()->process(
+                $command,
+                $context,
+                fn (CommandInterface $c, HandlerContext $ctx): Result => $this->handle($serviceId, $c, $ctx),
+            );
+        } finally {
+            array_pop($this->commandStack);
+        }
+    }
+
+    /**
+     * @param class-string<HandlerInterface> $serviceId
+     * @param CommandInterface<Result> $command
+     */
+    private function handle(string $serviceId, CommandInterface $command, HandlerContext $context): Result
+    {
         $handler = $this->container->get($serviceId);
 
         if (! $handler instanceof HandlerInterface || ! method_exists($handler, 'handle')) {
             throw new LogicException(sprintf('%s must be a handler declaring handle().', $serviceId));
         }
 
-        $context = $this->buildContext($command);
-        $this->commandStack[] = $context;
+        $result = $handler->handle($command, $context);
 
-        try {
-            $result = $handler->handle($command, $context);
-
-            if (! $result instanceof Result) {
-                throw new LogicException(sprintf('%s::handle() must return a %s.', $handler::class, Result::class));
-            }
-
-            return $result;
-        } finally {
-            array_pop($this->commandStack);
-
-            // In finally rather than on success: a PSP token written before a later failure still has to
-            // survive, or the retry opens a second checkout.
-            $this->persistState($command, $context);
+        if (! $result instanceof Result) {
+            throw new LogicException(sprintf('%s::handle() must return a %s.', $handler::class, Result::class));
         }
+
+        return $result;
+    }
+
+    /**
+     * Built once and reused. A sub-command dispatched from a handler comes back through the same pipeline,
+     * which is what makes nesting work.
+     */
+    private function pipeline(): Pipeline
+    {
+        if ($this->pipeline instanceof Pipeline) {
+            return $this->pipeline;
+        }
+
+        $collection = $this->container->has(MiddlewareCollection::class)
+            ? $this->container->get(MiddlewareCollection::class)
+            : new MiddlewareCollection();
+
+        $middleware = $collection->resolve($this->container);
+
+        foreach ($middleware as $one) {
+            if ($one instanceof GatewayAwareInterface) {
+                $one->setGateway($this);
+            }
+        }
+
+        return $this->pipeline = new Pipeline($middleware);
     }
 
     /**
@@ -381,33 +422,5 @@ class Gateway implements GatewayInterface
             ->find($identity);
 
         return $model instanceof PaymentInterface ? $model : null;
-    }
-
-    /**
-     * @param CommandInterface<Result> $command
-     *
-     * @throws ContainerExceptionInterface
-     * @throws NotFoundExceptionInterface
-     */
-    private function persistState(CommandInterface $command, HandlerContext $context): void
-    {
-        $payment = $context->payment();
-        $state = $context->pendingState();
-
-        if (! $payment instanceof PaymentInterface || ! $state instanceof ArrayObject) {
-            return;
-        }
-
-        $payment->setDetails($state);
-
-        // Core writes back only what it loaded. A payment handed to the command directly belongs to the
-        // caller, who persists it on their own terms.
-        if (! $command->token() instanceof TokenInterface || ! $this->container->has(StorageRegistryInterface::class)) {
-            return;
-        }
-
-        $this->container->get(StorageRegistryInterface::class)
-            ->getStorage($payment::class)
-            ->update($payment);
     }
 }

--- a/src/Payum/Core/Gateway/DeclaresMiddleware.php
+++ b/src/Payum/Core/Gateway/DeclaresMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Gateway;
+
+use Payum\Core\Middleware\MiddlewareInterface;
+
+/**
+ * Optional. Implement when a gateway needs middleware of its own.
+ *
+ * Most middleware is not gateway-specific — logging, locking and idempotency apply to every command
+ * regardless of who handles it — and belongs on the builder instead, where it is registered once. Reach
+ * for this only when the concern genuinely does not exist outside this gateway.
+ */
+interface DeclaresMiddleware
+{
+    /**
+     * Container ids, resolved from the gateway's own container.
+     *
+     * @return list<class-string<MiddlewareInterface>>
+     */
+    public function middleware(): array;
+}

--- a/src/Payum/Core/Middleware/EndlessCycleDetectorMiddleware.php
+++ b/src/Payum/Core/Middleware/EndlessCycleDetectorMiddleware.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Middleware;
+
+use Payum\Core\Command\CommandInterface;
+use Payum\Core\Exception\LogicException;
+use Payum\Core\Handler\Context;
+use Payum\Core\Result\Result;
+use function count;
+use function sprintf;
+
+/**
+ * Stops a handler that dispatches its way into a loop.
+ *
+ * A handler can dispatch a sub-command, and that sub-command's handler can dispatch another. Nothing
+ * stops that recursing until the process dies, so this puts a ceiling on the depth.
+ */
+final class EndlessCycleDetectorMiddleware implements MiddlewareInterface, HasPriority
+{
+    public function __construct(
+        private readonly int $limit = 100
+    ) {
+    }
+
+    /**
+     * Outermost, so the depth is checked before anything else does work.
+     */
+    public static function priority(): int
+    {
+        return 1000;
+    }
+
+    public function process(CommandInterface $command, Context $context, callable $next): Result
+    {
+        $depth = count($context->previous());
+
+        if ($depth >= $this->limit) {
+            throw new LogicException(sprintf(
+                'Possible endless cycle detected: %s was dispatched %d levels deep, which reaches the limit of %d.',
+                $command::class,
+                $depth,
+                $this->limit,
+            ));
+        }
+
+        return $next($command, $context);
+    }
+}

--- a/src/Payum/Core/Middleware/HasPriority.php
+++ b/src/Payum/Core/Middleware/HasPriority.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Middleware;
+
+/**
+ * Optional. Implement to say where a middleware belongs in the pipeline without the registering code
+ * having to know.
+ *
+ * Higher runs further out: first on the way in, last on the way back. Middleware that does not implement
+ * this sits at 0, and registration order breaks ties.
+ */
+interface HasPriority
+{
+    public static function priority(): int;
+}

--- a/src/Payum/Core/Middleware/LegacyExtensionMiddleware.php
+++ b/src/Payum/Core/Middleware/LegacyExtensionMiddleware.php
@@ -49,7 +49,7 @@ final class LegacyExtensionMiddleware implements MiddlewareInterface, GatewayAwa
 
     public function process(CommandInterface $command, Context $context, callable $next): Result
     {
-        if (null === $this->gateway) {
+        if (! $this->gateway instanceof Gateway) {
             return $next($command, $context);
         }
 

--- a/src/Payum/Core/Middleware/LegacyExtensionMiddleware.php
+++ b/src/Payum/Core/Middleware/LegacyExtensionMiddleware.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Middleware;
+
+use Exception;
+use Payum\Core\Command\CommandInterface;
+use Payum\Core\Extension\Context as ExtensionContext;
+use Payum\Core\Gateway;
+use Payum\Core\GatewayAwareInterface;
+use Payum\Core\GatewayInterface;
+use Payum\Core\Handler\Context;
+use Payum\Core\Result\Result;
+use function array_pop;
+
+/**
+ * Runs the gateway's registered extensions around a command.
+ *
+ * Extensions predate commands, so the bridge is one-way: they observe, and they can abort by throwing,
+ * but they cannot swap the result the way they can swap a reply — a Result is not a ReplyInterface, so
+ * Context::setReply() has nothing to accept. getAction() is likewise always null, since a command is
+ * answered by a handler.
+ *
+ * The collection is read on every execution rather than captured once, because extensions are added to a
+ * gateway after it is built — the registry adds a storage extension when the gateway is first fetched.
+ */
+final class LegacyExtensionMiddleware implements MiddlewareInterface, GatewayAwareInterface, HasPriority
+{
+    private ?Gateway $gateway = null;
+
+    /**
+     * Mirrors the nesting an extension would see on the action path. Held here because these contexts are
+     * this middleware's own, not the executor's.
+     *
+     * @var list<ExtensionContext>
+     */
+    private array $stack = [];
+
+    public static function priority(): int
+    {
+        return 500;
+    }
+
+    public function setGateway(GatewayInterface $gateway): void
+    {
+        $this->gateway = $gateway instanceof Gateway ? $gateway : null;
+    }
+
+    public function process(CommandInterface $command, Context $context, callable $next): Result
+    {
+        if (null === $this->gateway) {
+            return $next($command, $context);
+        }
+
+        $extensions = $this->gateway->getExtensions();
+        $legacyContext = new ExtensionContext($this->gateway, $command, $this->stack);
+        $this->stack[] = $legacyContext;
+
+        try {
+            $extensions->onPreExecute($legacyContext);
+            $extensions->onExecute($legacyContext);
+
+            $result = $next($command, $context);
+
+            $extensions->onPostExecute($legacyContext);
+
+            return $result;
+        } catch (Exception $exception) {
+            $legacyContext->setException($exception);
+            $extensions->onPostExecute($legacyContext);
+
+            throw $exception;
+        } finally {
+            array_pop($this->stack);
+        }
+    }
+}

--- a/src/Payum/Core/Middleware/MiddlewareCollection.php
+++ b/src/Payum/Core/Middleware/MiddlewareCollection.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Middleware;
+
+use Payum\Core\Exception\LogicException;
+use Psr\Container\ContainerInterface;
+use function is_a;
+use function is_string;
+use function sprintf;
+use function usort;
+
+/**
+ * What is registered, and in what order it should run.
+ *
+ * Immutable: every method returns a new collection, so the global set can be layered with a gateway's own
+ * without either being able to disturb the other.
+ */
+final class MiddlewareCollection
+{
+    /**
+     * @var list<array{middleware: class-string<MiddlewareInterface>|MiddlewareInterface, priority: int|null}>
+     */
+    private readonly array $entries;
+
+    /**
+     * @param list<array{middleware: class-string<MiddlewareInterface>|MiddlewareInterface, priority: int|null}> $entries
+     */
+    public function __construct(array $entries = [])
+    {
+        $this->entries = $entries;
+    }
+
+    /**
+     * @param class-string<MiddlewareInterface>|MiddlewareInterface $middleware a container id or an instance
+     * @param int|null $priority overrides {@see HasPriority}, which in turn overrides the default of 0
+     */
+    public function with(string | MiddlewareInterface $middleware, ?int $priority = null): self
+    {
+        return new self([...$this->entries, [
+            'middleware' => $middleware,
+            'priority' => $priority,
+        ]]);
+    }
+
+    /**
+     * Entries from $other are appended, so on equal priority they run inside the ones already here.
+     */
+    public function merge(self $other): self
+    {
+        return new self([...$this->entries, ...$other->entries]);
+    }
+
+    public function isEmpty(): bool
+    {
+        return [] === $this->entries;
+    }
+
+    /**
+     * Resolves every entry and orders it, outermost first.
+     *
+     * @return list<MiddlewareInterface>
+     */
+    public function resolve(ContainerInterface $container): array
+    {
+        $resolved = [];
+
+        foreach ($this->entries as $index => $entry) {
+            $middleware = $entry['middleware'];
+
+            if (is_string($middleware)) {
+                $middleware = $container->get($middleware);
+            }
+
+            if (! $middleware instanceof MiddlewareInterface) {
+                throw new LogicException(sprintf(
+                    '%s must be a %s.',
+                    is_string($entry['middleware']) ? $entry['middleware'] : $entry['middleware']::class,
+                    MiddlewareInterface::class,
+                ));
+            }
+
+            $resolved[] = [
+                'middleware' => $middleware,
+                'priority' => $entry['priority'] ?? self::declaredPriorityOf($entry['middleware']),
+                // Registration order breaks ties. usort is stable on PHP 8, but being explicit costs
+                // nothing and does not rely on that.
+                'index' => $index,
+            ];
+        }
+
+        usort(
+            $resolved,
+            static fn (array $a, array $b): int => [$b['priority'], $a['index']] <=> [$a['priority'], $b['index']],
+        );
+
+        return array_column($resolved, 'middleware');
+    }
+
+    /**
+     * @param class-string<MiddlewareInterface>|MiddlewareInterface $middleware
+     */
+    private static function declaredPriorityOf(string | MiddlewareInterface $middleware): int
+    {
+        $class = is_string($middleware) ? $middleware : $middleware::class;
+
+        return is_a($class, HasPriority::class, true) ? $class::priority() : 0;
+    }
+}

--- a/src/Payum/Core/Middleware/MiddlewareInterface.php
+++ b/src/Payum/Core/Middleware/MiddlewareInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Middleware;
+
+use Payum\Core\Command\CommandInterface;
+use Payum\Core\Handler\Context;
+use Payum\Core\Result\Result;
+
+/**
+ * Wraps the execution of a command.
+ *
+ * Middleware runs around the handler, not instead of it: call $next to continue, and what you do before
+ * and after that call is your concern. Returning without calling $next short-circuits the command, which
+ * is how a cache or a guard would work.
+ */
+interface MiddlewareInterface
+{
+    /**
+     * @param CommandInterface<Result> $command
+     * @param callable(CommandInterface<Result>, Context): Result $next
+     */
+    public function process(CommandInterface $command, Context $context, callable $next): Result;
+}

--- a/src/Payum/Core/Middleware/PersistStateMiddleware.php
+++ b/src/Payum/Core/Middleware/PersistStateMiddleware.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Middleware;
+
+use Payum\Core\Command\CommandInterface;
+use Payum\Core\Handler\Context;
+use Payum\Core\Registry\StorageRegistryInterface;
+use Payum\Core\Result\Result;
+
+/**
+ * Writes the PSP state a handler produced back onto the payment.
+ */
+final class PersistStateMiddleware implements MiddlewareInterface, HasPriority
+{
+    /**
+     * @param StorageRegistryInterface<object>|null $storages
+     */
+    public function __construct(
+        private readonly ?StorageRegistryInterface $storages = null
+    ) {
+    }
+
+    /**
+     * Innermost of the middleware core registers, so the state is written before anything outside it sees
+     * the result.
+     */
+    public static function priority(): int
+    {
+        return 100;
+    }
+
+    public function process(CommandInterface $command, Context $context, callable $next): Result
+    {
+        try {
+            return $next($command, $context);
+        } finally {
+            // In finally rather than on success: a PSP token written before a later failure still has to
+            // survive, or the retry opens a second checkout.
+            $this->persist($command, $context);
+        }
+    }
+
+    /**
+     * @param CommandInterface<Result> $command
+     */
+    private function persist(CommandInterface $command, Context $context): void
+    {
+        $payment = $context->payment();
+        $state = $context->pendingState();
+
+        if (null === $payment || null === $state) {
+            return;
+        }
+
+        $payment->setDetails($state);
+
+        // Core writes back only what it loaded. A payment handed to the command directly belongs to the
+        // caller, who persists it on their own terms.
+        if (null === $command->token() || null === $this->storages) {
+            return;
+        }
+
+        $this->storages->getStorage($payment::class)->update($payment);
+    }
+}

--- a/src/Payum/Core/Middleware/PersistStateMiddleware.php
+++ b/src/Payum/Core/Middleware/PersistStateMiddleware.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Payum\Core\Middleware;
 
+use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Command\CommandInterface;
 use Payum\Core\Handler\Context;
+use Payum\Core\Model\PaymentInterface;
 use Payum\Core\Registry\StorageRegistryInterface;
 use Payum\Core\Result\Result;
+use Payum\Core\Security\TokenInterface;
 
 /**
  * Writes the PSP state a handler produced back onto the payment.
@@ -50,7 +53,7 @@ final class PersistStateMiddleware implements MiddlewareInterface, HasPriority
         $payment = $context->payment();
         $state = $context->pendingState();
 
-        if (null === $payment || null === $state) {
+        if (! $payment instanceof PaymentInterface || ! $state instanceof ArrayObject) {
             return;
         }
 
@@ -58,7 +61,7 @@ final class PersistStateMiddleware implements MiddlewareInterface, HasPriority
 
         // Core writes back only what it loaded. A payment handed to the command directly belongs to the
         // caller, who persists it on their own terms.
-        if (null === $command->token() || null === $this->storages) {
+        if (! $command->token() instanceof TokenInterface || ! $this->storages instanceof StorageRegistryInterface) {
             return;
         }
 

--- a/src/Payum/Core/Middleware/Pipeline.php
+++ b/src/Payum/Core/Middleware/Pipeline.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Middleware;
+
+use Payum\Core\Command\CommandInterface;
+use Payum\Core\Handler\Context;
+use Payum\Core\Result\Result;
+use function array_reverse;
+
+/**
+ * Runs a command through the middleware and into the handler.
+ *
+ * Built once per gateway and reused, so it holds no per-execution state. Nesting works because a
+ * sub-command dispatched from a handler goes back through the same pipeline.
+ */
+final class Pipeline
+{
+    /**
+     * @param list<MiddlewareInterface> $middleware outermost first
+     */
+    public function __construct(
+        private readonly array $middleware = []
+    ) {
+    }
+
+    /**
+     * @param CommandInterface<Result> $command
+     * @param callable(CommandInterface<Result>, Context): Result $handler
+     */
+    public function process(CommandInterface $command, Context $context, callable $handler): Result
+    {
+        $next = $handler;
+
+        // Wrapped from the inside out, so the first entry ends up outermost.
+        foreach (array_reverse($this->middleware) as $middleware) {
+            $next = static fn (CommandInterface $c, Context $ctx): Result => $middleware->process($c, $ctx, $next);
+        }
+
+        return $next($command, $context);
+    }
+}

--- a/src/Payum/Core/PayumBuilder.php
+++ b/src/Payum/Core/PayumBuilder.php
@@ -24,8 +24,11 @@ use Payum\Core\DI\FallbackContainer;
 use Payum\Core\Exception\InvalidArgumentException;
 use Payum\Core\Extension\GenericTokenFactoryExtension;
 use Payum\Core\Extension\StorageExtension;
+use Payum\Core\Gateway\DeclaresMiddleware;
 use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
 use Payum\Core\Handler\HandlerMap;
+use Payum\Core\Middleware\MiddlewareCollection;
+use Payum\Core\Middleware\MiddlewareInterface;
 use Payum\Core\Model\ArrayObject;
 use Payum\Core\Model\GatewayConfigInterface;
 use Payum\Core\Model\Payment;
@@ -144,12 +147,19 @@ class PayumBuilder
      */
     protected ?RegistryInterface $mainRegistry = null;
 
+    protected MiddlewareCollection $middleware;
+
     protected ?ContainerInterface $globalContainer = null;
 
     /**
      * @var array<string, mixed>
      */
     protected array $globalDefinitions = [];
+
+    public function __construct()
+    {
+        $this->middleware = new MiddlewareCollection();
+    }
 
     public function addDefaultStorages(): static
     {
@@ -319,10 +329,25 @@ class PayumBuilder
     /**
      * Add a global service definition that will be available to all gateways.
      * This allows sharing services (like HTTP clients, loggers) across all gateway instances.
-     *
-     * @param class-string|string $id The service identifier (can be a class name or custom string)
-     * @param mixed $service The service instance or callable factory
      */
+    /**
+     * Registers middleware that wraps every command, on every gateway.
+     *
+     * This is where most middleware belongs: logging, locking and idempotency are not specific to any one
+     * gateway. A package shipping middleware registers it here too, or contributes the container id and
+     * lets the integration add it.
+     *
+     * @param class-string<MiddlewareInterface>|MiddlewareInterface $middleware a container id or an instance
+     * @param int|null $priority higher runs further out. Defaults to what the middleware declares through
+     *                           Payum\Core\Middleware\HasPriority, or 0
+     */
+    public function addMiddleware(string | MiddlewareInterface $middleware, ?int $priority = null): static
+    {
+        $this->middleware = $this->middleware->with($middleware, $priority);
+
+        return $this;
+    }
+
     public function addGlobalService(string $id, mixed $service): static
     {
         $this->globalDefinitions[$id] = $service;
@@ -393,7 +418,20 @@ class PayumBuilder
 
             $handlerDefinitions = array_map(autowire(...), HandlerMap::fromHandlers($gateway->handlers())->bindings());
 
+            // Core defaults first, then what the application registered, then the gateway's own, so a
+            // gateway's middleware runs innermost on equal priority.
+            $middleware = CoreGatewayFactory::defaultMiddleware()->merge($this->middleware);
+
+            if ($gateway instanceof DeclaresMiddleware) {
+                foreach ($gateway->middleware() as $gatewayMiddleware) {
+                    $middleware = $middleware->with($gatewayMiddleware);
+                }
+            }
+
             $containerBuilder->addDefinitions($handlerDefinitions);
+            $containerBuilder->addDefinitions([
+                MiddlewareCollection::class => $middleware,
+            ]);
             $containerBuilder->addDefinitions([
                 $config::class => $config,
                 GatewayConfig::class => $config,

--- a/src/Payum/Core/Tests/Middleware/MiddlewareCollectionTest.php
+++ b/src/Payum/Core/Tests/Middleware/MiddlewareCollectionTest.php
@@ -14,6 +14,7 @@ use Payum\Core\Middleware\MiddlewareInterface;
 use Payum\Core\Result\CaptureResult;
 use Payum\Core\Result\Result;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 final class MiddlewareCollectionTest extends TestCase
 {
@@ -133,7 +134,7 @@ final class MiddlewareCollectionTest extends TestCase
     public function testShouldThrowWhenAnEntryIsNotMiddleware(): void
     {
         $container = new Container([
-            'not_middleware' => new \stdClass(),
+            'not_middleware' => new stdClass(),
         ]);
 
         $this->expectException(LogicException::class);

--- a/src/Payum/Core/Tests/Middleware/MiddlewareCollectionTest.php
+++ b/src/Payum/Core/Tests/Middleware/MiddlewareCollectionTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests\Middleware;
+
+use DI\Container;
+use Payum\Core\Command\CommandInterface;
+use Payum\Core\Exception\LogicException;
+use Payum\Core\Handler\Context;
+use Payum\Core\Middleware\HasPriority;
+use Payum\Core\Middleware\MiddlewareCollection;
+use Payum\Core\Middleware\MiddlewareInterface;
+use Payum\Core\Result\CaptureResult;
+use Payum\Core\Result\Result;
+use PHPUnit\Framework\TestCase;
+
+final class MiddlewareCollectionTest extends TestCase
+{
+    public function testShouldStartEmpty(): void
+    {
+        $collection = new MiddlewareCollection();
+
+        $this->assertTrue($collection->isEmpty());
+        $this->assertSame([], $collection->resolve(new Container()));
+    }
+
+    public function testShouldNotMutateWhenAddingTo(): void
+    {
+        $collection = new MiddlewareCollection();
+        $with = $collection->with(new LowMiddleware());
+
+        $this->assertTrue($collection->isEmpty());
+        $this->assertFalse($with->isEmpty());
+    }
+
+    public function testShouldOrderByPriorityHighestFirst(): void
+    {
+        $high = new HighMiddleware();
+        $low = new LowMiddleware();
+
+        $resolved = (new MiddlewareCollection())
+            ->with($low)
+            ->with($high)
+            ->resolve(new Container());
+
+        $this->assertSame([$high, $low], $resolved);
+    }
+
+    public function testShouldTakeThePriorityAMiddlewareDeclares(): void
+    {
+        $declared = new HighMiddleware();
+        $undeclared = new PlainMiddleware();
+
+        $resolved = (new MiddlewareCollection())
+            ->with($undeclared)
+            ->with($declared)
+            ->resolve(new Container());
+
+        // HighMiddleware declares 100 through HasPriority; PlainMiddleware defaults to 0.
+        $this->assertSame([$declared, $undeclared], $resolved);
+    }
+
+    public function testShouldLetAnExplicitPriorityOverrideTheDeclaredOne(): void
+    {
+        $declared = new HighMiddleware();
+        $plain = new PlainMiddleware();
+
+        $resolved = (new MiddlewareCollection())
+            ->with($plain, 500)
+            ->with($declared)
+            ->resolve(new Container());
+
+        $this->assertSame([$plain, $declared], $resolved);
+    }
+
+    public function testShouldKeepRegistrationOrderOnEqualPriority(): void
+    {
+        $first = new PlainMiddleware();
+        $second = new PlainMiddleware();
+        $third = new PlainMiddleware();
+
+        $resolved = (new MiddlewareCollection())
+            ->with($first)
+            ->with($second)
+            ->with($third)
+            ->resolve(new Container());
+
+        $this->assertSame([$first, $second, $third], $resolved);
+    }
+
+    public function testShouldResolveAContainerIdToItsService(): void
+    {
+        $middleware = new PlainMiddleware();
+        $container = new Container([
+            PlainMiddleware::class => $middleware,
+        ]);
+
+        $resolved = (new MiddlewareCollection())->with(PlainMiddleware::class)->resolve($container);
+
+        $this->assertSame([$middleware], $resolved);
+    }
+
+    public function testShouldReadThePriorityOfAMiddlewareRegisteredByIdWithoutBuildingIt(): void
+    {
+        $container = new Container([
+            HighMiddleware::class => new HighMiddleware(),
+            PlainMiddleware::class => new PlainMiddleware(),
+        ]);
+
+        $resolved = (new MiddlewareCollection())
+            ->with(PlainMiddleware::class)
+            ->with(HighMiddleware::class)
+            ->resolve($container);
+
+        $this->assertInstanceOf(HighMiddleware::class, $resolved[0]);
+        $this->assertInstanceOf(PlainMiddleware::class, $resolved[1]);
+    }
+
+    public function testShouldAppendWhatIsMergedIn(): void
+    {
+        $first = new PlainMiddleware();
+        $second = new PlainMiddleware();
+
+        $resolved = (new MiddlewareCollection())
+            ->with($first)
+            ->merge((new MiddlewareCollection())->with($second))
+            ->resolve(new Container());
+
+        $this->assertSame([$first, $second], $resolved);
+    }
+
+    public function testShouldThrowWhenAnEntryIsNotMiddleware(): void
+    {
+        $container = new Container([
+            'not_middleware' => new \stdClass(),
+        ]);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(MiddlewareInterface::class);
+
+        /** @phpstan-ignore argument.type */
+        (new MiddlewareCollection())->with('not_middleware')->resolve($container);
+    }
+}
+
+final class PlainMiddleware implements MiddlewareInterface
+{
+    public function process(CommandInterface $command, Context $context, callable $next): Result
+    {
+        return CaptureResult::captured();
+    }
+}
+
+final class HighMiddleware implements MiddlewareInterface, HasPriority
+{
+    public static function priority(): int
+    {
+        return 100;
+    }
+
+    public function process(CommandInterface $command, Context $context, callable $next): Result
+    {
+        return CaptureResult::captured();
+    }
+}
+
+final class LowMiddleware implements MiddlewareInterface, HasPriority
+{
+    public static function priority(): int
+    {
+        return -100;
+    }
+
+    public function process(CommandInterface $command, Context $context, callable $next): Result
+    {
+        return CaptureResult::captured();
+    }
+}

--- a/src/Payum/Core/Tests/Middleware/PipelineTest.php
+++ b/src/Payum/Core/Tests/Middleware/PipelineTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests\Middleware;
+
+use Payum\Core\Command\CaptureCommand;
+use Payum\Core\Command\CommandInterface;
+use Payum\Core\Gateway;
+use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
+use Payum\Core\Handler\Context;
+use Payum\Core\Middleware\MiddlewareInterface;
+use Payum\Core\Middleware\Pipeline;
+use Payum\Core\Model\Payment;
+use Payum\Core\Result\CaptureResult;
+use Payum\Core\Result\Result;
+use Payum\Core\Security\GenericTokenFactoryInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class PipelineTest extends TestCase
+{
+    public function testShouldCallTheHandlerWhenThereIsNoMiddleware(): void
+    {
+        $result = (new Pipeline())->process(
+            $this->command(),
+            $this->context(),
+            static fn (): CaptureResult => CaptureResult::captured('txn_1'),
+        );
+
+        $this->assertSame('txn_1', $result->transactionId);
+    }
+
+    public function testShouldRunMiddlewareOutermostFirstAndUnwindInReverse(): void
+    {
+        $log = new CallLog();
+
+        (new Pipeline([
+            new SpyMiddleware('outer', $log),
+            new SpyMiddleware('inner', $log),
+        ]))->process($this->command(), $this->context(), static function () use ($log): CaptureResult {
+            $log->calls[] = 'handler';
+
+            return CaptureResult::captured();
+        });
+
+        $this->assertSame(
+            ['outer:before', 'inner:before', 'handler', 'inner:after', 'outer:after'],
+            $log->calls,
+        );
+    }
+
+    public function testShouldLetMiddlewareShortCircuitTheHandler(): void
+    {
+        $reached = false;
+
+        $result = (new Pipeline([new ShortCircuitMiddleware()]))->process(
+            $this->command(),
+            $this->context(),
+            static function () use (&$reached): CaptureResult {
+                $reached = true;
+
+                return CaptureResult::captured('from_handler');
+            },
+        );
+
+        $this->assertFalse($reached);
+        $this->assertSame('short_circuited', $result->transactionId);
+    }
+
+    public function testShouldLetMiddlewareReplaceTheCommandPassedOn(): void
+    {
+        $seen = null;
+
+        (new Pipeline([new ReplaceCommandMiddleware()]))->process(
+            $this->command(),
+            $this->context(),
+            static function (CommandInterface $command) use (&$seen): CaptureResult {
+                $seen = $command;
+
+                return CaptureResult::captured();
+            },
+        );
+
+        $this->assertInstanceOf(CaptureCommand::class, $seen);
+        $this->assertSame(999, $seen->amount);
+    }
+
+    public function testShouldLetMiddlewareSeeAnExceptionFromFurtherIn(): void
+    {
+        $middleware = new RecordingFailureMiddleware();
+
+        try {
+            (new Pipeline([$middleware]))->process(
+                $this->command(),
+                $this->context(),
+                static fn () => throw new \RuntimeException('psp exploded'),
+            );
+
+            $this->fail('Expected the exception to propagate.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('psp exploded', $e->getMessage());
+            $this->assertSame('psp exploded', $middleware->seen?->getMessage());
+        }
+    }
+
+    private function command(): CaptureCommand
+    {
+        return CaptureCommand::forPayment(new Payment());
+    }
+
+    private function context(): Context
+    {
+        return new Context(
+            $this->createMock(Gateway::class),
+            $this->command(),
+            $this->createMock(PaymentGateway::class),
+            $this->createMock(ServerRequestInterface::class),
+            $this->createMock(GenericTokenFactoryInterface::class),
+        );
+    }
+}
+
+final class CallLog
+{
+    /**
+     * @var list<string>
+     */
+    public array $calls = [];
+}
+
+final class SpyMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private readonly string $name,
+        private readonly CallLog $log
+    ) {
+    }
+
+    public function process(CommandInterface $command, Context $context, callable $next): Result
+    {
+        $this->log->calls[] = $this->name . ':before';
+
+        $result = $next($command, $context);
+
+        $this->log->calls[] = $this->name . ':after';
+
+        return $result;
+    }
+}
+
+final class ShortCircuitMiddleware implements MiddlewareInterface
+{
+    public function process(CommandInterface $command, Context $context, callable $next): Result
+    {
+        return CaptureResult::captured('short_circuited');
+    }
+}
+
+final class ReplaceCommandMiddleware implements MiddlewareInterface
+{
+    public function process(CommandInterface $command, Context $context, callable $next): Result
+    {
+        return $next(CaptureCommand::forPayment(new Payment(), 999), $context);
+    }
+}
+
+final class RecordingFailureMiddleware implements MiddlewareInterface
+{
+    public ?\Throwable $seen = null;
+
+    public function process(CommandInterface $command, Context $context, callable $next): Result
+    {
+        try {
+            return $next($command, $context);
+        } catch (\Throwable $e) {
+            $this->seen = $e;
+
+            throw $e;
+        }
+    }
+}

--- a/src/Payum/Core/Tests/Middleware/PipelineTest.php
+++ b/src/Payum/Core/Tests/Middleware/PipelineTest.php
@@ -17,6 +17,8 @@ use Payum\Core\Result\Result;
 use Payum\Core\Security\GenericTokenFactoryInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
+use Throwable;
 
 final class PipelineTest extends TestCase
 {
@@ -94,11 +96,11 @@ final class PipelineTest extends TestCase
             (new Pipeline([$middleware]))->process(
                 $this->command(),
                 $this->context(),
-                static fn () => throw new \RuntimeException('psp exploded'),
+                static fn () => throw new RuntimeException('psp exploded'),
             );
 
             $this->fail('Expected the exception to propagate.');
-        } catch (\RuntimeException $e) {
+        } catch (RuntimeException $e) {
             $this->assertSame('psp exploded', $e->getMessage());
             $this->assertSame('psp exploded', $middleware->seen?->getMessage());
         }
@@ -167,13 +169,13 @@ final class ReplaceCommandMiddleware implements MiddlewareInterface
 
 final class RecordingFailureMiddleware implements MiddlewareInterface
 {
-    public ?\Throwable $seen = null;
+    public ?Throwable $seen = null;
 
     public function process(CommandInterface $command, Context $context, callable $next): Result
     {
         try {
             return $next($command, $context);
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->seen = $e;
 
             throw $e;

--- a/src/Payum/Core/Tests/MiddlewarePipelineTest.php
+++ b/src/Payum/Core/Tests/MiddlewarePipelineTest.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests;
+
+use League\Uri\Uri;
+use Payum\Core\Command\CaptureCommand;
+use Payum\Core\Command\CommandInterface;
+use Payum\Core\Config\GatewayConfig;
+use Payum\Core\Exception\LogicException;
+use Payum\Core\Extension\Context as ExtensionContext;
+use Payum\Core\Extension\ExtensionInterface;
+use Payum\Core\Gateway;
+use Payum\Core\Gateway\DeclaresMiddleware;
+use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
+use Payum\Core\Handler\CaptureHandlerInterface;
+use Payum\Core\Handler\Context;
+use Payum\Core\Metadata\Logo;
+use Payum\Core\Middleware\MiddlewareInterface;
+use Payum\Core\Model\Payment;
+use Payum\Core\Payum;
+use Payum\Core\PayumBuilder;
+use Payum\Core\Registry\StorageRegistryInterface;
+use Payum\Core\Result\CaptureResult;
+use Payum\Core\Result\Result;
+use Payum\Core\Security\TokenInterface;
+use Payum\Core\Storage\StorageInterface;
+use PHPUnit\Framework\TestCase;
+
+final class MiddlewarePipelineTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_SERVER = [
+            'HTTP_HOST' => 'payum.dev',
+        ];
+
+        Recorder::$calls = [];
+    }
+
+    public function testShouldRunMiddlewareTheApplicationRegistered(): void
+    {
+        $this->buildPayum()->getGateway('acme')->execute(CaptureCommand::forPayment(new Payment()));
+
+        $this->assertContains('global:before', Recorder::$calls);
+        $this->assertContains('global:after', Recorder::$calls);
+    }
+
+    public function testShouldRunMiddlewareTheGatewayDeclared(): void
+    {
+        $this->buildPayum()->getGateway('acme')->execute(CaptureCommand::forPayment(new Payment()));
+
+        $this->assertContains('gateway:before', Recorder::$calls);
+        $this->assertContains('gateway:after', Recorder::$calls);
+    }
+
+    public function testShouldRunApplicationMiddlewareOutsideTheGatewaysOwn(): void
+    {
+        $this->buildPayum()->getGateway('acme')->execute(CaptureCommand::forPayment(new Payment()));
+
+        $this->assertSame(
+            ['global:before', 'gateway:before', 'handler', 'gateway:after', 'global:after'],
+            Recorder::$calls,
+        );
+    }
+
+    public function testShouldHonourPriorityOverRegistrationOrder(): void
+    {
+        $payum = (new PayumBuilder())
+            ->addDefaultStorages()
+            // Registered first, but asks to sit further in.
+            ->addMiddleware(new RecordingMiddleware('inner'), -100)
+            ->addMiddleware(new RecordingMiddleware('outer'), 100)
+            ->registerGateway('acme', new PipelineConfig())
+            ->getPayum();
+
+        $payum->getGateway('acme')->execute(CaptureCommand::forPayment(new Payment()));
+
+        $order = array_values(array_filter(
+            Recorder::$calls,
+            static fn (string $call): bool => str_starts_with($call, 'outer') || str_starts_with($call, 'inner'),
+        ));
+
+        $this->assertSame(['outer:before', 'inner:before', 'inner:after', 'outer:after'], $order);
+    }
+
+    public function testShouldStillWriteStateOntoThePayment(): void
+    {
+        $payment = new Payment();
+
+        $this->buildPayum()->getGateway('acme')->execute(CaptureCommand::forPayment($payment));
+
+        // PersistStateMiddleware took over what the executor used to do inline.
+        $this->assertSame([
+            'checkout_id' => 'chk_1',
+        ], $payment->getDetails());
+    }
+
+    public function testShouldWriteStateEvenWhenTheHandlerThrows(): void
+    {
+        $payment = new Payment();
+        $payment->setDetails([
+            'explode' => true,
+        ]);
+
+        try {
+            $this->buildPayum()->getGateway('acme')->execute(CaptureCommand::forPayment($payment));
+
+            $this->fail('Expected the handler to throw.');
+        } catch (\RuntimeException) {
+            // A checkout id written before the failure has to survive, or the retry opens a second one.
+            $this->assertSame('chk_1', $payment->getDetails()['checkout_id']);
+        }
+    }
+
+    public function testShouldRunRegisteredExtensionsThroughTheBridge(): void
+    {
+        $gateway = $this->buildPayum()->getGateway('acme');
+        $extension = new RecordingExtension();
+
+        $this->assertInstanceOf(Gateway::class, $gateway);
+        $gateway->addExtension($extension);
+        $gateway->execute(CaptureCommand::forPayment(new Payment()));
+
+        $this->assertSame(['onPreExecute', 'onExecute', 'onPostExecute'], $extension->calls);
+        $this->assertInstanceOf(CaptureCommand::class, $extension->seenRequest);
+    }
+
+    public function testShouldGiveAnExtensionTheExceptionAHandlerThrew(): void
+    {
+        $payment = new Payment();
+        $payment->setDetails([
+            'explode' => true,
+        ]);
+
+        $gateway = $this->buildPayum()->getGateway('acme');
+        $extension = new RecordingExtension();
+
+        $this->assertInstanceOf(Gateway::class, $gateway);
+        $gateway->addExtension($extension);
+
+        try {
+            $gateway->execute(CaptureCommand::forPayment($payment));
+
+            $this->fail('Expected the handler to throw.');
+        } catch (\RuntimeException) {
+            $this->assertContains('onPostExecute', $extension->calls);
+            $this->assertInstanceOf(\RuntimeException::class, $extension->seenException);
+        }
+    }
+
+    public function testShouldStopAHandlerThatDispatchesItsWayIntoALoop(): void
+    {
+        $payment = new Payment();
+        $payment->setDetails([
+            'recurse' => true,
+        ]);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Possible endless cycle detected');
+
+        $this->buildPayum()->getGateway('acme')->execute(CaptureCommand::forPayment($payment));
+    }
+
+    /**
+     * @return Payum<StorageRegistryInterface<StorageInterface<TokenInterface>>>
+     */
+    private function buildPayum(): Payum
+    {
+        return (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addMiddleware(new RecordingMiddleware('global'))
+            ->registerGateway('acme', new PipelineConfig())
+            ->getPayum();
+    }
+}
+
+final class Recorder
+{
+    /**
+     * @var list<string>
+     */
+    public static array $calls = [];
+}
+
+final class RecordingMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private readonly string $name
+    ) {
+    }
+
+    public function process(CommandInterface $command, Context $context, callable $next): Result
+    {
+        Recorder::$calls[] = $this->name . ':before';
+
+        try {
+            return $next($command, $context);
+        } finally {
+            Recorder::$calls[] = $this->name . ':after';
+        }
+    }
+}
+
+final class RecordingExtension implements ExtensionInterface
+{
+    /**
+     * @var list<string>
+     */
+    public array $calls = [];
+
+    public mixed $seenRequest = null;
+
+    public ?\Exception $seenException = null;
+
+    public function onPreExecute(ExtensionContext $context): void
+    {
+        $this->calls[] = 'onPreExecute';
+        $this->seenRequest = $context->getRequest();
+    }
+
+    public function onExecute(ExtensionContext $context): void
+    {
+        $this->calls[] = 'onExecute';
+    }
+
+    public function onPostExecute(ExtensionContext $context): void
+    {
+        $this->calls[] = 'onPostExecute';
+        $this->seenException = $context->getException();
+    }
+}
+
+final class PipelineConfig implements GatewayConfig
+{
+    public function getGatewayClass(): string
+    {
+        return PipelineGateway::class;
+    }
+}
+
+final class PipelineGateway implements PaymentGateway, DeclaresMiddleware
+{
+    public function configClass(): string
+    {
+        return PipelineConfig::class;
+    }
+
+    public function handlers(): array
+    {
+        return [PipelineCaptureHandler::class];
+    }
+
+    public function middleware(): array
+    {
+        return [GatewayMiddleware::class];
+    }
+
+    public function logo(): Logo
+    {
+        return Logo\Url::create('https://acme.test/logo.svg');
+    }
+
+    public function name(): string
+    {
+        return 'Acme Payments';
+    }
+
+    public function websiteUrl(): Uri
+    {
+        return Uri::new('https://acme.test');
+    }
+}
+
+final class GatewayMiddleware implements MiddlewareInterface
+{
+    public function process(CommandInterface $command, Context $context, callable $next): Result
+    {
+        Recorder::$calls[] = 'gateway:before';
+
+        try {
+            return $next($command, $context);
+        } finally {
+            Recorder::$calls[] = 'gateway:after';
+        }
+    }
+}
+
+final class PipelineCaptureHandler implements CaptureHandlerInterface
+{
+    public function handle(CaptureCommand $command, Context $context): CaptureResult
+    {
+        Recorder::$calls[] = 'handler';
+
+        $state = $context->state();
+        $state['checkout_id'] = 'chk_1';
+
+        if ($state['recurse']) {
+            $context->execute(CaptureCommand::forPayment($context->payment()));
+        }
+
+        if ($state['explode']) {
+            throw new \RuntimeException('psp exploded');
+        }
+
+        return CaptureResult::captured('txn_1');
+    }
+}

--- a/src/Payum/Core/Tests/MiddlewarePipelineTest.php
+++ b/src/Payum/Core/Tests/MiddlewarePipelineTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Payum\Core\Tests;
 
+use Exception;
 use League\Uri\Uri;
 use Payum\Core\Command\CaptureCommand;
 use Payum\Core\Command\CommandInterface;
@@ -17,6 +18,7 @@ use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
 use Payum\Core\Handler\CaptureHandlerInterface;
 use Payum\Core\Handler\Context;
 use Payum\Core\Metadata\Logo;
+use Payum\Core\Metadata\Logo\Url;
 use Payum\Core\Middleware\MiddlewareInterface;
 use Payum\Core\Model\Payment;
 use Payum\Core\Payum;
@@ -27,6 +29,7 @@ use Payum\Core\Result\Result;
 use Payum\Core\Security\TokenInterface;
 use Payum\Core\Storage\StorageInterface;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 final class MiddlewarePipelineTest extends TestCase
 {
@@ -108,7 +111,7 @@ final class MiddlewarePipelineTest extends TestCase
             $this->buildPayum()->getGateway('acme')->execute(CaptureCommand::forPayment($payment));
 
             $this->fail('Expected the handler to throw.');
-        } catch (\RuntimeException) {
+        } catch (RuntimeException) {
             // A checkout id written before the failure has to survive, or the retry opens a second one.
             $this->assertSame('chk_1', $payment->getDetails()['checkout_id']);
         }
@@ -144,9 +147,9 @@ final class MiddlewarePipelineTest extends TestCase
             $gateway->execute(CaptureCommand::forPayment($payment));
 
             $this->fail('Expected the handler to throw.');
-        } catch (\RuntimeException) {
+        } catch (RuntimeException) {
             $this->assertContains('onPostExecute', $extension->calls);
-            $this->assertInstanceOf(\RuntimeException::class, $extension->seenException);
+            $this->assertInstanceOf(RuntimeException::class, $extension->seenException);
         }
     }
 
@@ -212,7 +215,7 @@ final class RecordingExtension implements ExtensionInterface
 
     public mixed $seenRequest = null;
 
-    public ?\Exception $seenException = null;
+    public ?Exception $seenException = null;
 
     public function onPreExecute(ExtensionContext $context): void
     {
@@ -259,7 +262,7 @@ final class PipelineGateway implements PaymentGateway, DeclaresMiddleware
 
     public function logo(): Logo
     {
-        return Logo\Url::create('https://acme.test/logo.svg');
+        return Url::create('https://acme.test/logo.svg');
     }
 
     public function name(): string
@@ -301,7 +304,7 @@ final class PipelineCaptureHandler implements CaptureHandlerInterface
         }
 
         if ($state['explode']) {
-            throw new \RuntimeException('psp exploded');
+            throw new RuntimeException('psp exploded');
         }
 
         return CaptureResult::captured('txn_1');


### PR DESCRIPTION
Middleware wraps the execution of a command. It runs around the handler rather than instead of it, so it sees the command going in and the result coming back.

```php
final class LoggingMiddleware implements MiddlewareInterface
{
    public function __construct(private readonly LoggerInterface $logger) {}

    public function process(CommandInterface $command, Context $context, callable $next): Result
    {
        $this->logger->info('Dispatching {command}', ['command' => $command::class]);

        $result = $next($command, $context);

        $this->logger->info('Got {status}', ['status' => $result->status->value]);

        return $result;
    }
}
```

Call `$next` to continue. Return without calling it and the handler never runs, which is how a guard or a cache works. `$next` takes a command and a context, so middleware can pass different ones on.

## Registering it

Most middleware has nothing to do with any one gateway — logging, locking and idempotency apply to every command whoever handles it — so it goes on the builder and wraps every gateway:

```php
$payum = (new PayumBuilder())
    ->addDefaultStorages()
    ->addMiddleware(new LoggingMiddleware($logger))
    ->addMiddleware(IdempotencyMiddleware::class)   // or a container id
    ->registerGateway('acme', new AcmeConfig('sk_…'))
    ->getPayum();
```

A package shipping middleware needs nothing beyond publishing the class; the application or the framework integration registers it.

## Order

Higher priority runs further out — first on the way in, last on the way back.

```php
->addMiddleware(new OutermostMiddleware(), 1000)
->addMiddleware(new InnermostMiddleware(), -100)
```

Middleware that says nothing sits at 0, and registration order breaks ties. It can carry its own default instead of relying on whoever registers it:

```php
final class LoggingMiddleware implements MiddlewareInterface, HasPriority
{
    public static function priority(): int { return 200; }
}
```

An explicit priority passed to `addMiddleware()` wins over that.

What core registers, outermost first:

| Middleware | Priority | Does |
| :--- | :--- | :--- |
| `EndlessCycleDetectorMiddleware` | 1000 | Stops a handler that dispatches its way into a loop |
| `LegacyExtensionMiddleware` | 500 | Runs the gateway's registered extensions |
| `PersistStateMiddleware` | 100 | Writes the PSP state back onto the payment |

`PersistStateMiddleware` takes over what the executor did inline. It writes in a `finally`, so a checkout id recorded just before a failure survives rather than the retry opening a second checkout.

## Middleware belonging to one gateway

```php
final class AcmeGateway implements GatewayInterface, DeclaresMiddleware
{
    public function middleware(): array
    {
        return [AcmeAuditMiddleware::class];
    }
}
```

Container ids, resolved from that gateway's own container, running inside anything the application registered.

## Extensions

Extensions registered on a gateway now run for commands, through `LegacyExtensionMiddleware`. The bridge is one-way: an extension observes the command and can abort by throwing, but cannot swap the result — a `Result` is not a `ReplyInterface`, so `Context::setReply()` has nothing to accept — and `getAction()` is always null, because a command is answered by a handler.

The collection is read on every execution rather than captured once, because the registry adds a storage extension to a gateway after it is built.

## Nesting

The pipeline is built once per gateway and reused. A sub-command dispatched from a handler with `$context->execute()` goes back through the same pipeline, which is what makes nesting work and what the cycle detector measures.
