### PR TITLE
Keep the payment's status current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.0.0 (TBD)
 
+* Add `Payum\Core\Model\HasPaymentStatus`. A payment implementing it has its status kept current by Payum after every command, which makes it readable without a gateway and queryable in storage. Read it through `Payum\Core\Model\PaymentStatuses`
+* `Result::$status` is now null when an operation concluded nothing about the payment, so a declined refund no longer reads as a failed payment. `failed()` takes an optional status for a failure that really is terminal
 * Add a middleware pipeline around command execution. `Payum\Core\Middleware\MiddlewareInterface` wraps a command, `PayumBuilder::addMiddleware()` registers one for every gateway, and a gateway declares its own through `Payum\Core\Gateway\DeclaresMiddleware`
 * Extensions registered on a gateway now run for commands too, through `Payum\Core\Middleware\LegacyExtensionMiddleware`
 * Add a command/handler model for gateways. A gateway describes itself and ships handlers that answer typed commands and return a result, instead of being assembled by a factory and interrupted by thrown replies. See the Gateways chapter in the docs

--- a/docs/gateways/middleware.md
+++ b/docs/gateways/middleware.md
@@ -85,8 +85,11 @@ What core registers, outermost first:
 | `EndlessCycleDetectorMiddleware` | 1000 | Stops a handler that dispatches its way into a loop |
 | `LegacyExtensionMiddleware` | 500 | Runs the gateway's registered extensions |
 | `PersistStateMiddleware` | 100 | Writes the PSP state back onto the payment |
+| `RecordPaymentStatusMiddleware` | 50 | Commits the status the handler declared, when the payment tracks one |
 
-So anything you register at the default 0 runs inside all three, closest to the handler.
+So anything you register at the default 0 runs inside all four, closest to the handler.
+
+Two of them behave deliberately differently when a handler throws, and it is worth knowing which is which. `PersistStateMiddleware` writes anyway — a PSP token recorded just before a failure has to survive, or the retry opens a second checkout. `RecordPaymentStatusMiddleware` writes nothing, because an exception means nobody learned what the status is.
 
 ### Middleware belonging to one gateway
 

--- a/docs/gateways/results.md
+++ b/docs/gateways/results.md
@@ -75,11 +75,59 @@ match (true) {
 
 ### Status
 
-`$result->status` is a `PaymentStatus`:
+`$result->status` is the payment's state after this operation:
 
 `New`, `Pending`, `Authorized`, `Captured`, `Refunded`, `PartiallyRefunded`, `Canceled`, `Failed`, `Expired`, `Suspended`, `PaidOut`, `Unknown`.
 
 It is string-backed, so it can be persisted or sent as JSON. One backing value does not match its case name — `PaidOut` is backed by `'payedout'` — so compare the case rather than the spelling.
+
+**It is null when the operation concluded nothing about the payment.** A refund that was declined leaves a captured payment captured; a capture that was declined leaves the payment where it was, so the customer can try another card. Say otherwise only when the failure really is terminal:
+
+```php
+RefundResult::failed($failure);                          // the payment is unchanged
+CaptureResult::failed($failure, PaymentStatus::Failed);  // this payment is finished
+```
+
+A handler never writes to the payment. It declares the payment's new state as part of its answer, the same way it declares what the customer must do next, and Payum commits it.
+
+### Keeping the status on the payment
+
+Implement `Payum\Core\Model\HasPaymentStatus` on your payment and Payum keeps it current after every command:
+
+```php
+use Payum\Core\Model\HasPaymentStatus;
+use Payum\Core\Model\PaymentInterface;
+use Payum\Core\Result\PaymentStatus;
+
+class Payment implements PaymentInterface, HasPaymentStatus
+{
+    #[ORM\Column(enumType: PaymentStatus::class)]
+    private PaymentStatus $status = PaymentStatus::New;
+
+    public function getStatus(): PaymentStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(PaymentStatus $status): void
+    {
+        $this->status = $status;
+    }
+}
+```
+
+The status is then readable without going near a gateway, and queryable in whatever the payment is stored in — "every pending payment older than an hour" becomes an ordinary query.
+
+Read it through `PaymentStatuses`, which returns null for a payment that does not track one — meaning nobody knows, which is not the same as `New`:
+
+```php
+use Payum\Core\Model\PaymentStatuses;
+
+PaymentStatuses::of($payment);        // ?PaymentStatus
+PaymentStatuses::isTracked($payment); // bool
+```
+
+A payment that does not implement the interface has no status stored, exactly as before.
 
 ### Failures and exceptions
 

--- a/src/Payum/Core/CoreGatewayFactory.php
+++ b/src/Payum/Core/CoreGatewayFactory.php
@@ -46,6 +46,7 @@ use Payum\Core\Middleware\EndlessCycleDetectorMiddleware;
 use Payum\Core\Middleware\LegacyExtensionMiddleware;
 use Payum\Core\Middleware\MiddlewareCollection;
 use Payum\Core\Middleware\PersistStateMiddleware;
+use Payum\Core\Middleware\RecordPaymentStatusMiddleware;
 use Payum\Core\Registry\StorageRegistryInterface;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
@@ -262,6 +263,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
                 MiddlewareCollection::class => self::defaultMiddleware(...),
                 EndlessCycleDetectorMiddleware::class => static fn (): EndlessCycleDetectorMiddleware => new EndlessCycleDetectorMiddleware(),
                 LegacyExtensionMiddleware::class => static fn (): LegacyExtensionMiddleware => new LegacyExtensionMiddleware(),
+                RecordPaymentStatusMiddleware::class => static fn (): RecordPaymentStatusMiddleware => new RecordPaymentStatusMiddleware(),
                 PersistStateMiddleware::class => static fn (ContainerInterface $c): PersistStateMiddleware => new PersistStateMiddleware(
                     $c->has(StorageRegistryInterface::class) ? $c->get(StorageRegistryInterface::class) : null,
                 ),
@@ -339,7 +341,8 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
         return (new MiddlewareCollection())
             ->with(EndlessCycleDetectorMiddleware::class)
             ->with(LegacyExtensionMiddleware::class)
-            ->with(PersistStateMiddleware::class);
+            ->with(PersistStateMiddleware::class)
+            ->with(RecordPaymentStatusMiddleware::class);
     }
 
     public function createGateway(ContainerInterface $container): Gateway

--- a/src/Payum/Core/Middleware/RecordPaymentStatusMiddleware.php
+++ b/src/Payum/Core/Middleware/RecordPaymentStatusMiddleware.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Middleware;
+
+use Payum\Core\Command\CommandInterface;
+use Payum\Core\Handler\Context;
+use Payum\Core\Model\PaymentStatuses;
+use Payum\Core\Result\PaymentStatus;
+use Payum\Core\Result\Result;
+
+/**
+ * Commits the status a handler declared onto the payment.
+ *
+ * A handler never touches the payment: it owns the PSP state bag and describes what happened. This is what
+ * turns that description into a change, and it is the seam the state machine replaces — applying a
+ * transition towards the declared status rather than assigning it, so an illegal move can be rejected.
+ */
+final class RecordPaymentStatusMiddleware implements MiddlewareInterface, HasPriority
+{
+    /**
+     * Inside PersistStateMiddleware, so the status is set before the payment is written away. Recording it
+     * further out would persist it one command late.
+     */
+    public static function priority(): int
+    {
+        return 50;
+    }
+
+    public function process(CommandInterface $command, Context $context, callable $next): Result
+    {
+        // Deliberately not in a finally, unlike the state write outside this. An exception means we did
+        // not learn what the payment's status is, and guessing would be worse than leaving it.
+        $result = $next($command, $context);
+
+        $payment = $context->payment();
+
+        // A null status means the operation concluded nothing about the payment — a declined refund
+        // leaves a captured payment captured.
+        if (null !== $payment && $result->status instanceof PaymentStatus) {
+            PaymentStatuses::set($payment, $result->status);
+        }
+
+        return $result;
+    }
+}

--- a/src/Payum/Core/Middleware/RecordPaymentStatusMiddleware.php
+++ b/src/Payum/Core/Middleware/RecordPaymentStatusMiddleware.php
@@ -6,6 +6,7 @@ namespace Payum\Core\Middleware;
 
 use Payum\Core\Command\CommandInterface;
 use Payum\Core\Handler\Context;
+use Payum\Core\Model\PaymentInterface;
 use Payum\Core\Model\PaymentStatuses;
 use Payum\Core\Result\PaymentStatus;
 use Payum\Core\Result\Result;
@@ -38,7 +39,7 @@ final class RecordPaymentStatusMiddleware implements MiddlewareInterface, HasPri
 
         // A null status means the operation concluded nothing about the payment — a declined refund
         // leaves a captured payment captured.
-        if (null !== $payment && $result->status instanceof PaymentStatus) {
+        if ($payment instanceof PaymentInterface && $result->status instanceof PaymentStatus) {
             PaymentStatuses::set($payment, $result->status);
         }
 

--- a/src/Payum/Core/Model/HasPaymentStatus.php
+++ b/src/Payum/Core/Model/HasPaymentStatus.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Model;
+
+use Payum\Core\Result\PaymentStatus;
+
+/**
+ * Opt in to have Payum keep the payment's status current.
+ *
+ * A payment that implements this has its status written after every command that concludes something
+ * about it, which makes the status readable without asking a gateway and queryable in whatever the model
+ * is stored in. A payment that does not implement this has no status tracked at all.
+ *
+ * Implementations should start at {@see PaymentStatus::New}.
+ */
+interface HasPaymentStatus
+{
+    public function getStatus(): PaymentStatus;
+
+    public function setStatus(PaymentStatus $status): void;
+}

--- a/src/Payum/Core/Model/PaymentStatuses.php
+++ b/src/Payum/Core/Model/PaymentStatuses.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Model;
+
+use Payum\Core\Result\PaymentStatus;
+
+/**
+ * Reads and writes the status of a payment, whether or not it tracks one.
+ *
+ * The single place that knows how a payment's status is stored. When the state machine arrives, reading a
+ * status becomes reading a workflow marking, and this is the seam where that changes.
+ */
+final class PaymentStatuses
+{
+    /**
+     * Null when the payment does not track a status, which is not the same as {@see PaymentStatus::New} —
+     * it means nobody knows, not that nothing has happened.
+     */
+    public static function of(object $payment): ?PaymentStatus
+    {
+        return $payment instanceof HasPaymentStatus ? $payment->getStatus() : null;
+    }
+
+    /**
+     * @return bool whether the payment tracks a status and was therefore updated
+     */
+    public static function set(object $payment, PaymentStatus $status): bool
+    {
+        if (! $payment instanceof HasPaymentStatus) {
+            return false;
+        }
+
+        $payment->setStatus($status);
+
+        return true;
+    }
+
+    public static function isTracked(object $payment): bool
+    {
+        return $payment instanceof HasPaymentStatus;
+    }
+}

--- a/src/Payum/Core/Result/AuthorizeResult.php
+++ b/src/Payum/Core/Result/AuthorizeResult.php
@@ -17,7 +17,7 @@ final class AuthorizeResult extends Result
      * @param DateTimeImmutable|null $expiresAt when the hold lapses, if the PSP says
      */
     public function __construct(
-        PaymentStatus $status,
+        ?PaymentStatus $status,
         ?NextAction $next = null,
         ?string $transactionId = null,
         ?Failure $failure = null,
@@ -37,11 +37,16 @@ final class AuthorizeResult extends Result
     }
 
     /**
+     * The operation did not succeed. By default this says nothing about the payment's status: a declined
+     * authorization leaves it where it was, which is what lets a customer try again.
+     *
+     * Pass $status when the failure is terminal and the payment really has moved.
+     *
      * @param array<string, mixed> $raw
      */
-    public static function failed(Failure $failure, array $raw = []): self
+    public static function failed(Failure $failure, ?PaymentStatus $status = null, array $raw = []): self
     {
-        return new self(PaymentStatus::Failed, failure: $failure, raw: $raw);
+        return new self($status, failure: $failure, raw: $raw);
     }
 
     /**

--- a/src/Payum/Core/Result/CaptureResult.php
+++ b/src/Payum/Core/Result/CaptureResult.php
@@ -18,7 +18,7 @@ final class CaptureResult extends Result
      * @param int|null $capturedAmount in minor units; null means the payment's full amount
      */
     public function __construct(
-        PaymentStatus $status,
+        ?PaymentStatus $status,
         ?NextAction $next = null,
         ?string $transactionId = null,
         ?Failure $failure = null,
@@ -45,11 +45,16 @@ final class CaptureResult extends Result
     }
 
     /**
+     * The operation did not succeed. By default this says nothing about the payment's status: a declined
+     * capture leaves it where it was, which is what lets a customer try again.
+     *
+     * Pass $status when the failure is terminal and the payment really has moved.
+     *
      * @param array<string, mixed> $raw
      */
-    public static function failed(Failure $failure, array $raw = []): self
+    public static function failed(Failure $failure, ?PaymentStatus $status = null, array $raw = []): self
     {
-        return new self(PaymentStatus::Failed, failure: $failure, raw: $raw);
+        return new self($status, failure: $failure, raw: $raw);
     }
 
     /**

--- a/src/Payum/Core/Result/RefundResult.php
+++ b/src/Payum/Core/Result/RefundResult.php
@@ -17,7 +17,7 @@ final class RefundResult extends Result
      * @param int|null $refundedAmount in minor units
      */
     public function __construct(
-        PaymentStatus $status,
+        ?PaymentStatus $status,
         ?NextAction $next = null,
         ?string $transactionId = null,
         ?Failure $failure = null,
@@ -28,11 +28,16 @@ final class RefundResult extends Result
     }
 
     /**
+     * The operation did not succeed. By default this says nothing about the payment's status: a declined
+     * refund leaves it where it was, which is what lets a customer try again.
+     *
+     * Pass $status when the failure is terminal and the payment really has moved.
+     *
      * @param array<string, mixed> $raw
      */
-    public static function failed(Failure $failure, array $raw = []): self
+    public static function failed(Failure $failure, ?PaymentStatus $status = null, array $raw = []): self
     {
-        return new self(PaymentStatus::Failed, failure: $failure, raw: $raw);
+        return new self($status, failure: $failure, raw: $raw);
     }
 
     /**

--- a/src/Payum/Core/Result/Result.php
+++ b/src/Payum/Core/Result/Result.php
@@ -17,10 +17,13 @@ namespace Payum\Core\Result;
 abstract class Result
 {
     /**
+     * @param PaymentStatus|null $status the payment's state after this operation. Null when the operation
+     *                                  concluded nothing about it — a refund that was declined leaves the
+     *                                  payment exactly as it was
      * @param array<string, mixed> $raw the PSP's own payload, kept for the application's use
      */
     public function __construct(
-        public readonly PaymentStatus $status,
+        public readonly ?PaymentStatus $status,
         public readonly ?NextAction $next = null,
         public readonly ?string $transactionId = null,
         public readonly ?Failure $failure = null,

--- a/src/Payum/Core/Tests/Middleware/RecordPaymentStatusMiddlewareTest.php
+++ b/src/Payum/Core/Tests/Middleware/RecordPaymentStatusMiddlewareTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Payum\Core\Tests\Middleware;
 
+use DI\Container;
 use Payum\Core\Command\CaptureCommand;
 use Payum\Core\Exception\LogicException;
 use Payum\Core\Gateway;
@@ -27,6 +28,7 @@ use Payum\Core\Storage\IdentityInterface;
 use Payum\Core\Storage\StorageInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
 
 final class RecordPaymentStatusMiddlewareTest extends TestCase
 {
@@ -70,10 +72,10 @@ final class RecordPaymentStatusMiddlewareTest extends TestCase
         $payment->setStatus(PaymentStatus::Pending);
 
         try {
-            $this->dispatch($payment, static fn () => throw new \RuntimeException('psp exploded'));
+            $this->dispatch($payment, static fn () => throw new RuntimeException('psp exploded'));
 
             $this->fail('Expected the exception to propagate.');
-        } catch (\RuntimeException) {
+        } catch (RuntimeException) {
             // An exception means we did not learn the status, which is not the same as learning it failed.
             $this->assertSame(PaymentStatus::Pending, $payment->getStatus());
         }
@@ -95,7 +97,7 @@ final class RecordPaymentStatusMiddlewareTest extends TestCase
 
         // Resolved through the collection, so this exercises the real priorities rather than an order
         // written by hand here.
-        $middleware = CoreDefaults::statusAndPersistence($storage)->resolve(new \DI\Container());
+        $middleware = CoreDefaults::statusAndPersistence($storage)->resolve(new Container());
 
         (new Pipeline($middleware))->process(
             CaptureCommand::forToken($this->createMock(TokenInterface::class)),

--- a/src/Payum/Core/Tests/Middleware/RecordPaymentStatusMiddlewareTest.php
+++ b/src/Payum/Core/Tests/Middleware/RecordPaymentStatusMiddlewareTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests\Middleware;
+
+use Payum\Core\Command\CaptureCommand;
+use Payum\Core\Exception\LogicException;
+use Payum\Core\Gateway;
+use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
+use Payum\Core\Handler\Context;
+use Payum\Core\Middleware\MiddlewareCollection;
+use Payum\Core\Middleware\PersistStateMiddleware;
+use Payum\Core\Middleware\Pipeline;
+use Payum\Core\Middleware\RecordPaymentStatusMiddleware;
+use Payum\Core\Model\HasPaymentStatus;
+use Payum\Core\Model\Payment;
+use Payum\Core\Registry\StorageRegistryInterface;
+use Payum\Core\Result\CaptureResult;
+use Payum\Core\Result\Failure;
+use Payum\Core\Result\FailureReason;
+use Payum\Core\Result\PaymentStatus;
+use Payum\Core\Result\RefundResult;
+use Payum\Core\Security\GenericTokenFactoryInterface;
+use Payum\Core\Security\TokenInterface;
+use Payum\Core\Storage\IdentityInterface;
+use Payum\Core\Storage\StorageInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class RecordPaymentStatusMiddlewareTest extends TestCase
+{
+    public function testShouldRecordTheStatusTheHandlerDeclared(): void
+    {
+        $payment = new TrackedPayment();
+
+        $this->dispatch($payment, static fn (): CaptureResult => CaptureResult::captured('txn_1'));
+
+        $this->assertSame(PaymentStatus::Captured, $payment->getStatus());
+    }
+
+    public function testShouldLeaveTheStatusAloneWhenAnOperationConcludedNothing(): void
+    {
+        $payment = new TrackedPayment();
+        $payment->setStatus(PaymentStatus::Captured);
+
+        // A refund that was declined says nothing about the payment.
+        $this->dispatch($payment, static fn (): RefundResult => RefundResult::failed(
+            new Failure(FailureReason::Declined, 'refund_declined'),
+        ));
+
+        $this->assertSame(PaymentStatus::Captured, $payment->getStatus());
+    }
+
+    public function testShouldRecordATerminalFailureWhenTheHandlerSaysSo(): void
+    {
+        $payment = new TrackedPayment();
+
+        $this->dispatch($payment, static fn (): CaptureResult => CaptureResult::failed(
+            new Failure(FailureReason::Fraud, 'blocked'),
+            PaymentStatus::Failed,
+        ));
+
+        $this->assertSame(PaymentStatus::Failed, $payment->getStatus());
+    }
+
+    public function testShouldNotRecordAnythingWhenTheHandlerThrows(): void
+    {
+        $payment = new TrackedPayment();
+        $payment->setStatus(PaymentStatus::Pending);
+
+        try {
+            $this->dispatch($payment, static fn () => throw new \RuntimeException('psp exploded'));
+
+            $this->fail('Expected the exception to propagate.');
+        } catch (\RuntimeException) {
+            // An exception means we did not learn the status, which is not the same as learning it failed.
+            $this->assertSame(PaymentStatus::Pending, $payment->getStatus());
+        }
+    }
+
+    public function testShouldDoNothingForAPaymentThatDoesNotTrackAStatus(): void
+    {
+        $payment = new Payment();
+
+        $result = $this->dispatch($payment, static fn (): CaptureResult => CaptureResult::captured('txn_1'));
+
+        $this->assertSame(PaymentStatus::Captured, $result->status);
+    }
+
+    public function testShouldSetTheStatusBeforeThePaymentIsPersisted(): void
+    {
+        $payment = new TrackedPayment();
+        $storage = new StatusSpyStorage();
+
+        // Resolved through the collection, so this exercises the real priorities rather than an order
+        // written by hand here.
+        $middleware = CoreDefaults::statusAndPersistence($storage)->resolve(new \DI\Container());
+
+        (new Pipeline($middleware))->process(
+            CaptureCommand::forToken($this->createMock(TokenInterface::class)),
+            $context = $this->context($payment, $this->createMock(TokenInterface::class)),
+            static function () use ($context): CaptureResult {
+                // PersistState only writes when the handler touched state, as a handler would.
+                $context->state()['checkout_id'] = 'chk_1';
+
+                return CaptureResult::captured('txn_1');
+            },
+        );
+
+        // Recorded further out than PersistState, the row would have been written a command too early.
+        $this->assertSame(PaymentStatus::Captured, $storage->statusWhenUpdated);
+    }
+
+    private function dispatch(Payment $payment, callable $handler): mixed
+    {
+        return (new Pipeline([new RecordPaymentStatusMiddleware()]))->process(
+            CaptureCommand::forPayment($payment),
+            $this->context($payment),
+            $handler,
+        );
+    }
+
+    private function context(Payment $payment, ?TokenInterface $token = null): Context
+    {
+        return new Context(
+            $this->createMock(Gateway::class),
+            CaptureCommand::forPayment($payment),
+            $this->createMock(PaymentGateway::class),
+            $this->createMock(ServerRequestInterface::class),
+            $this->createMock(GenericTokenFactoryInterface::class),
+            $payment,
+            $token,
+        );
+    }
+}
+
+final class CoreDefaults
+{
+    /**
+     * @param StorageInterface<object> $storage
+     */
+    public static function statusAndPersistence(StorageInterface $storage): MiddlewareCollection
+    {
+        $registry = new class($storage) implements StorageRegistryInterface {
+            /**
+             * @param StorageInterface<object> $storage
+             */
+            public function __construct(
+                private readonly StorageInterface $storage
+            ) {
+            }
+
+            public function getStorage(string | object $class): StorageInterface
+            {
+                return $this->storage;
+            }
+
+            public function getStorages(): array
+            {
+                return [];
+            }
+        };
+
+        // Registered status-first on purpose: priority, not registration order, has to decide.
+        return (new MiddlewareCollection())
+            ->with(new RecordPaymentStatusMiddleware())
+            ->with(new PersistStateMiddleware($registry));
+    }
+}
+
+class TrackedPayment extends Payment implements HasPaymentStatus
+{
+    private PaymentStatus $status = PaymentStatus::New;
+
+    public function getStatus(): PaymentStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(PaymentStatus $status): void
+    {
+        $this->status = $status;
+    }
+}
+
+/**
+ * @implements StorageInterface<object>
+ */
+final class StatusSpyStorage implements StorageInterface
+{
+    public ?PaymentStatus $statusWhenUpdated = null;
+
+    public function create(): object
+    {
+        return new TrackedPayment();
+    }
+
+    public function support(object $model): bool
+    {
+        return $model instanceof TrackedPayment;
+    }
+
+    public function update(object $model): object
+    {
+        $this->statusWhenUpdated = $model instanceof HasPaymentStatus ? $model->getStatus() : null;
+
+        return $model;
+    }
+
+    public function delete(object $model): void
+    {
+    }
+
+    public function find($id): ?object
+    {
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $criteria
+     *
+     * @return array<object>
+     */
+    public function findBy(array $criteria): array
+    {
+        return [];
+    }
+
+    public function identify($model): IdentityInterface
+    {
+        throw new LogicException('not needed');
+    }
+}


### PR DESCRIPTION
A handler never touches the payment. It owns the PSP state bag and describes what happened; Payum commits it. This adds the piece that does the committing.

## Declaring a status

`Result::$status` is the payment's state after the operation, and it is **null when the operation concluded nothing about it**:

```php
CaptureResult::captured('txn_1');                        // the payment is captured
RefundResult::failed($failure);                          // the payment is unchanged
CaptureResult::failed($failure, PaymentStatus::Failed);  // this one is terminal
```

A refund that was declined leaves a captured payment captured. A capture that was declined leaves the payment where it was, so the customer can try another card rather than the payment reading as dead on the first bad card. A handler that means the payment really has finished says so with the second argument.

## Keeping it on the payment

```php
use Payum\Core\Model\HasPaymentStatus;
use Payum\Core\Result\PaymentStatus;

class Payment implements PaymentInterface, HasPaymentStatus
{
    #[ORM\Column(enumType: PaymentStatus::class)]
    private PaymentStatus $status = PaymentStatus::New;

    public function getStatus(): PaymentStatus { return $this->status; }
    public function setStatus(PaymentStatus $status): void { $this->status = $status; }
}
```

Payum keeps it current after every command, so the status is readable without going near a gateway and queryable in whatever the payment is stored in — "every pending payment older than an hour" becomes an ordinary query.

Read it through `PaymentStatuses`, which returns null for a payment that tracks nothing. That is not the same as `New`: it means nobody knows.

```php
PaymentStatuses::of($payment);        // ?PaymentStatus
PaymentStatuses::isTracked($payment);
```

A payment that does not implement the interface tracks no status, exactly as before.

## Where it is committed

`RecordPaymentStatusMiddleware`, at priority 50 — inside `PersistStateMiddleware`, so the status reaches the same write as the state. Recorded further out it would be persisted a command late.

It sits next to `PersistStateMiddleware` doing deliberately the opposite thing when a handler throws:

| | On exception |
| :--- | :--- |
| `PersistStateMiddleware` | writes anyway — a PSP token recorded before a failure has to survive, or the retry opens a second checkout |
| `RecordPaymentStatusMiddleware` | writes nothing — an exception means nobody learned the status |

Both are pinned by tests, because it is the sort of pair a later change would make consistent.

## Nesting

A handler dispatching a sub-command means the inner one records first and the outer one last, so the command the caller actually asked for wins.
