### PR TITLE
Cancel, payout and sync commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Add a command/handler model for gateways. A gateway describes itself and ships handlers that answer typed commands and return a result, instead of being assembled by a factory and interrupted by thrown replies. See the Gateways chapter in the docs
 * Add `Payum\Core\Gateway\GatewayInterface`, which a gateway implements to declare its name, logo, website, config class and handlers. It replaces the gateway factory
 * Add `Payum\Core\Config\GatewayConfig` for typed, self-validating gateway credentials, and `PayumBuilder::registerGateway()` to register one
-* Add `Payum\Core\Command\{CaptureCommand, AuthorizeCommand, RefundCommand}` and a handler interface per command
+* Add `Payum\Core\Command\{CaptureCommand, AuthorizeCommand, RefundCommand, CancelCommand}` and a handler interface per command
 * Add `Payum\Core\Result\Result` with `PaymentStatus`, a `NextAction` describing what the customer must do, and a `Failure` carrying a portable reason plus the PSP's own code. Declines are results; infrastructure faults remain exceptions
 * Add `Payum\Core\Handler\Context`, giving a handler the payment, the token, the inbound PSR-7 request and the PSP state
 * Add `Payum\Core\Gateway\Capability`. Operation capabilities are derived from the handlers a gateway ships; `DeclaresCapabilities` covers the rest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 * Add a command/handler model for gateways. A gateway describes itself and ships handlers that answer typed commands and return a result, instead of being assembled by a factory and interrupted by thrown replies. See the Gateways chapter in the docs
 * Add `Payum\Core\Gateway\GatewayInterface`, which a gateway implements to declare its name, logo, website, config class and handlers. It replaces the gateway factory
 * Add `Payum\Core\Config\GatewayConfig` for typed, self-validating gateway credentials, and `PayumBuilder::registerGateway()` to register one
-* Add `Payum\Core\Command\{CaptureCommand, AuthorizeCommand, RefundCommand, CancelCommand}` and a handler interface per command
+* Add `Payum\Core\Command\{CaptureCommand, AuthorizeCommand, RefundCommand, CancelCommand, PayoutCommand}` and a handler interface per command
+* Add `Payum\Core\Model\SubjectInterface`, what a command operates on. `PaymentInterface` and `PayoutInterface` both extend it, so core works against a payout as readily as a payment
 * Add `Payum\Core\Result\Result` with `PaymentStatus`, a `NextAction` describing what the customer must do, and a `Failure` carrying a portable reason plus the PSP's own code. Declines are results; infrastructure faults remain exceptions
 * Add `Payum\Core\Handler\Context`, giving a handler the payment, the token, the inbound PSR-7 request and the PSP state
 * Add `Payum\Core\Gateway\Capability`. Operation capabilities are derived from the handlers a gateway ships; `DeclaresCapabilities` covers the rest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Add a command/handler model for gateways. A gateway describes itself and ships handlers that answer typed commands and return a result, instead of being assembled by a factory and interrupted by thrown replies. See the Gateways chapter in the docs
 * Add `Payum\Core\Gateway\GatewayInterface`, which a gateway implements to declare its name, logo, website, config class and handlers. It replaces the gateway factory
 * Add `Payum\Core\Config\GatewayConfig` for typed, self-validating gateway credentials, and `PayumBuilder::registerGateway()` to register one
-* Add `Payum\Core\Command\{CaptureCommand, AuthorizeCommand, RefundCommand, CancelCommand, PayoutCommand}` and a handler interface per command
+* Add `Payum\Core\Command\{CaptureCommand, AuthorizeCommand, RefundCommand, CancelCommand, PayoutCommand, SyncCommand}` and a handler interface per command
 * Add `Payum\Core\Model\SubjectInterface`, what a command operates on. `PaymentInterface` and `PayoutInterface` both extend it, so core works against a payout as readily as a payment
 * Add `Payum\Core\Result\Result` with `PaymentStatus`, a `NextAction` describing what the customer must do, and a `Failure` carrying a portable reason plus the PSP's own code. Declines are results; infrastructure faults remain exceptions
 * Add `Payum\Core\Handler\Context`, giving a handler the payment, the token, the inbound PSR-7 request and the PSP state

--- a/docs/gateways/commands.md
+++ b/docs/gateways/commands.md
@@ -9,6 +9,7 @@ A command is what the caller wants done. It is immutable, carries no services, a
 | `Payum\Core\Command\CaptureCommand` | `Capture` | `CaptureResult` | `amount`, `idempotencyKey` |
 | `Payum\Core\Command\AuthorizeCommand` | `Authorize` | `AuthorizeResult` | `amount`, `idempotencyKey` |
 | `Payum\Core\Command\RefundCommand` | `Refund` | `RefundResult` | `amount`, `reason`, `idempotencyKey` |
+| `Payum\Core\Command\CancelCommand` | `Cancel` | `CancelResult` | `reason`, `idempotencyKey` |
 
 ### Building one
 
@@ -33,7 +34,12 @@ CaptureCommand::forToken($token, idempotencyKey: $order->getUuid());
 
 // Partial refund with a reason the PSP will record.
 RefundCommand::forPayment($payment, amount: 500, reason: 'damaged_on_arrival');
+
+// Void an authorization the merchant has decided not to settle.
+CancelCommand::forPayment($payment, reason: 'out_of_stock');
 ```
+
+Cancel calls a payment off before the money moves — voiding an authorization, or abandoning a payment the customer never completed. It is not a refund, which gives back money already taken, and it carries no amount because it is all or nothing.
 
 Give it neither a token nor a payment and the constructor throws — it has to know what it is operating on.
 

--- a/docs/gateways/commands.md
+++ b/docs/gateways/commands.md
@@ -11,6 +11,7 @@ A command is what the caller wants done. It is immutable, carries no services, a
 | `Payum\Core\Command\RefundCommand` | `Refund` | `RefundResult` | `amount`, `reason`, `idempotencyKey` |
 | `Payum\Core\Command\CancelCommand` | `Cancel` | `CancelResult` | `reason`, `idempotencyKey` |
 | `Payum\Core\Command\PayoutCommand` | `Payout` | `PayoutResult` | `idempotencyKey` |
+| `Payum\Core\Command\SyncCommand` | `Sync` | `SyncResult` | — |
 
 ### Building one
 
@@ -41,6 +42,20 @@ CancelCommand::forPayment($payment, reason: 'out_of_stock');
 ```
 
 Cancel calls it off before the money moves — voiding an authorization, abandoning a payment the customer never completed, or stopping a payout that has not gone out. It is not a refund, which gives back money already taken, and it carries no amount because it is all or nothing.
+
+### Refreshing from the PSP
+
+`SyncCommand` asks the PSP what it currently thinks and records the answer, which is how a stored status catches up after a webhook that never arrived:
+
+```php
+$result = $gateway->execute(SyncCommand::forPayment($payment));
+
+$result->status;   // whatever the PSP says
+```
+
+It is for callers — an admin screen with a refresh button, a reconciliation job. A handler that needs fresh data mid-flow calls its api directly instead; dispatching a command to fetch something it uses two lines later is indirection for its own sake.
+
+It reads rather than mutates, so it takes no idempotency key. Not every PSP offers a way to re-read, which is why `Capability::Sync` is a capability like any other rather than something assumed.
 
 ### What a command operates on
 

--- a/docs/gateways/commands.md
+++ b/docs/gateways/commands.md
@@ -10,6 +10,7 @@ A command is what the caller wants done. It is immutable, carries no services, a
 | `Payum\Core\Command\AuthorizeCommand` | `Authorize` | `AuthorizeResult` | `amount`, `idempotencyKey` |
 | `Payum\Core\Command\RefundCommand` | `Refund` | `RefundResult` | `amount`, `reason`, `idempotencyKey` |
 | `Payum\Core\Command\CancelCommand` | `Cancel` | `CancelResult` | `reason`, `idempotencyKey` |
+| `Payum\Core\Command\PayoutCommand` | `Payout` | `PayoutResult` | `idempotencyKey` |
 
 ### Building one
 
@@ -39,7 +40,28 @@ RefundCommand::forPayment($payment, amount: 500, reason: 'damaged_on_arrival');
 CancelCommand::forPayment($payment, reason: 'out_of_stock');
 ```
 
-Cancel calls a payment off before the money moves — voiding an authorization, or abandoning a payment the customer never completed. It is not a refund, which gives back money already taken, and it carries no amount because it is all or nothing.
+Cancel calls it off before the money moves — voiding an authorization, abandoning a payment the customer never completed, or stopping a payout that has not gone out. It is not a refund, which gives back money already taken, and it carries no amount because it is all or nothing.
+
+### What a command operates on
+
+Every command acts on a **subject**: a payment for most of them, a payout for `PayoutCommand`. Both implement `Payum\Core\Model\SubjectInterface`, which is all core needs — details it can read and write, and a class to look a storage up by.
+
+```php
+// a payout is not a payment
+PayoutCommand::forPayout($payout);
+
+// cancelling does not care which it is
+CancelCommand::forPayment($payment);
+CancelCommand::forPayout($payout);
+```
+
+The subject on the command is **what the caller supplied**, which is null whenever the command carries only a token — the usual case for anything arriving over HTTP. Core resolves the real one from the token's identity, so a handler reads it from the context instead:
+
+```php
+$context->subject();   // whatever it is
+$context->payment();   // null when it is not a payment
+$context->payout();    // null when it is not a payout
+```
 
 Give it neither a token nor a payment and the constructor throws — it has to know what it is operating on.
 

--- a/docs/gateways/defining-a-gateway.md
+++ b/docs/gateways/defining-a-gateway.md
@@ -108,7 +108,7 @@ The full set:
 
 | Derived from `handlers()` | Declared |
 | :--- | :--- |
-| `Authorize`, `Cancel`, `Capture`, `Payout`, `Refund` | `MultiCurrency`, `PartialCapture`, `PartialRefund`, `Recurring`, `StoredPaymentMethods`, `ThreeDSecure`, `Webhooks` |
+| `Authorize`, `Cancel`, `Capture`, `Payout`, `Refund`, `Sync` | `MultiCurrency`, `PartialCapture`, `PartialRefund`, `Recurring`, `StoredPaymentMethods`, `ThreeDSecure`, `Webhooks` |
 
 The enum is string-backed, so a capability list can be persisted, sent as JSON, or rendered in an admin screen.
 

--- a/docs/gateways/handlers.md
+++ b/docs/gateways/handlers.md
@@ -9,6 +9,7 @@ A handler answers exactly one command. There is one interface per command, so bo
 | `RefundCommand` | `Payum\Core\Handler\RefundHandlerInterface` |
 | `CancelCommand` | `Payum\Core\Handler\CancelHandlerInterface` |
 | `PayoutCommand` | `Payum\Core\Handler\PayoutHandlerInterface` |
+| `SyncCommand` | `Payum\Core\Handler\SyncHandlerInterface` |
 
 ```php
 <?php

--- a/docs/gateways/handlers.md
+++ b/docs/gateways/handlers.md
@@ -7,6 +7,7 @@ A handler answers exactly one command. There is one interface per command, so bo
 | `CaptureCommand` | `Payum\Core\Handler\CaptureHandlerInterface` |
 | `AuthorizeCommand` | `Payum\Core\Handler\AuthorizeHandlerInterface` |
 | `RefundCommand` | `Payum\Core\Handler\RefundHandlerInterface` |
+| `CancelCommand` | `Payum\Core\Handler\CancelHandlerInterface` |
 
 ```php
 <?php

--- a/docs/gateways/handlers.md
+++ b/docs/gateways/handlers.md
@@ -8,6 +8,7 @@ A handler answers exactly one command. There is one interface per command, so bo
 | `AuthorizeCommand` | `Payum\Core\Handler\AuthorizeHandlerInterface` |
 | `RefundCommand` | `Payum\Core\Handler\RefundHandlerInterface` |
 | `CancelCommand` | `Payum\Core\Handler\CancelHandlerInterface` |
+| `PayoutCommand` | `Payum\Core\Handler\PayoutHandlerInterface` |
 
 ```php
 <?php
@@ -67,7 +68,9 @@ Do not take the payment, the token or the HTTP request. Those belong to a single
 | Method | What it gives you |
 | :--- | :--- |
 | `state()` | The PSP state carried across requests, as an `ArrayObject` |
-| `payment()` | The payment, resolved from the command or loaded from its token |
+| `subject()` | What the command operates on, resolved from the command or loaded from its token |
+| `payment()` | The subject when it is a payment, else null |
+| `payout()` | The subject when it is a payout, else null |
 | `token()` | The token this execution arrived on, if any |
 | `httpRequest()` | The inbound request as PSR-7 |
 | `tokens()` | The token factory, for minting a notify or second-hop URL |

--- a/docs/gateways/results.md
+++ b/docs/gateways/results.md
@@ -19,6 +19,7 @@ $result->requiresInteraction();  // $next !== null
 | `CaptureResult` | `capturedAmount` |
 | `AuthorizeResult` | `authorizedAmount`, `expiresAt` |
 | `RefundResult` | `refundedAmount` |
+| `CancelResult` | — |
 
 ### Building one
 

--- a/docs/gateways/results.md
+++ b/docs/gateways/results.md
@@ -20,6 +20,7 @@ $result->requiresInteraction();  // $next !== null
 | `AuthorizeResult` | `authorizedAmount`, `expiresAt` |
 | `RefundResult` | `refundedAmount` |
 | `CancelResult` | — |
+| `PayoutResult` | `paidOutAmount` |
 
 ### Building one
 

--- a/docs/gateways/results.md
+++ b/docs/gateways/results.md
@@ -21,6 +21,7 @@ $result->requiresInteraction();  // $next !== null
 | `RefundResult` | `refundedAmount` |
 | `CancelResult` | — |
 | `PayoutResult` | `paidOutAmount` |
+| `SyncResult` | — |
 
 ### Building one
 

--- a/src/Payum/Core/Command/AuthorizeCommand.php
+++ b/src/Payum/Core/Command/AuthorizeCommand.php
@@ -7,6 +7,7 @@ namespace Payum\Core\Command;
 use Payum\Core\Exception\LogicException;
 use Payum\Core\Gateway\Capability;
 use Payum\Core\Model\PaymentInterface;
+use Payum\Core\Model\SubjectInterface;
 use Payum\Core\Result\AuthorizeResult;
 use Payum\Core\Security\TokenInterface;
 
@@ -53,6 +54,11 @@ final class AuthorizeCommand implements CommandInterface
     }
 
     public function payment(): ?PaymentInterface
+    {
+        return $this->payment;
+    }
+
+    public function subject(): ?SubjectInterface
     {
         return $this->payment;
     }

--- a/src/Payum/Core/Command/CancelCommand.php
+++ b/src/Payum/Core/Command/CancelCommand.php
@@ -7,16 +7,22 @@ namespace Payum\Core\Command;
 use Payum\Core\Exception\LogicException;
 use Payum\Core\Gateway\Capability;
 use Payum\Core\Model\PaymentInterface;
+use Payum\Core\Model\PayoutInterface;
+use Payum\Core\Model\SubjectInterface;
 use Payum\Core\Result\CancelResult;
 use Payum\Core\Security\TokenInterface;
 
 /**
- * Call the payment off before the money moves.
+ * Call it off before the money moves.
  *
- * Voids an authorization the merchant has decided not to settle, or abandons a payment the customer never
- * completed. Distinct from a refund, which gives back money that has already been taken.
+ * Voids an authorization the merchant has decided not to settle, abandons a payment the customer never
+ * completed, or stops a payout that has not gone out. Distinct from a refund, which gives back money that
+ * has already been taken.
  *
- * Merchant-initiated rather than customer-facing, so it is usually built from the payment. There is no
+ * Deliberately not tied to payments: cancelling is the same operation whatever it is cancelling, which is
+ * why this takes a subject rather than a payment.
+ *
+ * Merchant-initiated rather than customer-facing, so it is usually built from the model. There is no
  * cancel token path, and a gateway needing the customer to confirm can still return a NextAction.
  *
  * @implements CommandInterface<CancelResult>
@@ -28,13 +34,13 @@ final class CancelCommand implements CommandInterface
      */
     public function __construct(
         private readonly ?TokenInterface $token = null,
-        private readonly ?PaymentInterface $payment = null,
+        private readonly ?SubjectInterface $subject = null,
         public readonly ?string $reason = null,
         public readonly ?string $idempotencyKey = null,
     ) {
-        if (! $this->token instanceof TokenInterface && ! $this->payment instanceof PaymentInterface) {
+        if (! $this->token instanceof TokenInterface && ! $this->subject instanceof SubjectInterface) {
             throw new LogicException(sprintf(
-                'A %s needs either a token or a payment: it has to know what it is canceling.',
+                'A %s needs either a token or something to cancel.',
                 self::class,
             ));
         }
@@ -47,7 +53,12 @@ final class CancelCommand implements CommandInterface
 
     public static function forPayment(PaymentInterface $payment, ?string $reason = null): self
     {
-        return new self(payment: $payment, reason: $reason);
+        return new self(subject: $payment, reason: $reason);
+    }
+
+    public static function forPayout(PayoutInterface $payout, ?string $reason = null): self
+    {
+        return new self(subject: $payout, reason: $reason);
     }
 
     public static function forToken(TokenInterface $token, ?string $reason = null): self
@@ -57,7 +68,17 @@ final class CancelCommand implements CommandInterface
 
     public function payment(): ?PaymentInterface
     {
-        return $this->payment;
+        return $this->subject instanceof PaymentInterface ? $this->subject : null;
+    }
+
+    public function payout(): ?PayoutInterface
+    {
+        return $this->subject instanceof PayoutInterface ? $this->subject : null;
+    }
+
+    public function subject(): ?SubjectInterface
+    {
+        return $this->subject;
     }
 
     public function token(): ?TokenInterface

--- a/src/Payum/Core/Command/CancelCommand.php
+++ b/src/Payum/Core/Command/CancelCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Command;
+
+use Payum\Core\Exception\LogicException;
+use Payum\Core\Gateway\Capability;
+use Payum\Core\Model\PaymentInterface;
+use Payum\Core\Result\CancelResult;
+use Payum\Core\Security\TokenInterface;
+
+/**
+ * Call the payment off before the money moves.
+ *
+ * Voids an authorization the merchant has decided not to settle, or abandons a payment the customer never
+ * completed. Distinct from a refund, which gives back money that has already been taken.
+ *
+ * Merchant-initiated rather than customer-facing, so it is usually built from the payment. There is no
+ * cancel token path, and a gateway needing the customer to confirm can still return a NextAction.
+ *
+ * @implements CommandInterface<CancelResult>
+ */
+final class CancelCommand implements CommandInterface
+{
+    /**
+     * @param string|null $reason some PSPs record a reason code and surface it in their dashboard
+     */
+    public function __construct(
+        private readonly ?TokenInterface $token = null,
+        private readonly ?PaymentInterface $payment = null,
+        public readonly ?string $reason = null,
+        public readonly ?string $idempotencyKey = null,
+    ) {
+        if (! $this->token instanceof TokenInterface && ! $this->payment instanceof PaymentInterface) {
+            throw new LogicException(sprintf(
+                'A %s needs either a token or a payment: it has to know what it is canceling.',
+                self::class,
+            ));
+        }
+    }
+
+    public static function capability(): Capability
+    {
+        return Capability::Cancel;
+    }
+
+    public static function forPayment(PaymentInterface $payment, ?string $reason = null): self
+    {
+        return new self(payment: $payment, reason: $reason);
+    }
+
+    public static function forToken(TokenInterface $token, ?string $reason = null): self
+    {
+        return new self(token: $token, reason: $reason);
+    }
+
+    public function payment(): ?PaymentInterface
+    {
+        return $this->payment;
+    }
+
+    public function token(): ?TokenInterface
+    {
+        return $this->token;
+    }
+}

--- a/src/Payum/Core/Command/CaptureCommand.php
+++ b/src/Payum/Core/Command/CaptureCommand.php
@@ -7,6 +7,7 @@ namespace Payum\Core\Command;
 use Payum\Core\Exception\LogicException;
 use Payum\Core\Gateway\Capability;
 use Payum\Core\Model\PaymentInterface;
+use Payum\Core\Model\SubjectInterface;
 use Payum\Core\Result\CaptureResult;
 use Payum\Core\Security\TokenInterface;
 
@@ -68,6 +69,11 @@ final class CaptureCommand implements CommandInterface
     }
 
     public function payment(): ?PaymentInterface
+    {
+        return $this->payment;
+    }
+
+    public function subject(): ?SubjectInterface
     {
         return $this->payment;
     }

--- a/src/Payum/Core/Command/CommandInterface.php
+++ b/src/Payum/Core/Command/CommandInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Payum\Core\Command;
 
 use Payum\Core\Gateway\Capability;
-use Payum\Core\Model\PaymentInterface;
+use Payum\Core\Model\SubjectInterface;
 use Payum\Core\Result\Result;
 use Payum\Core\Security\TokenInterface;
 
@@ -31,12 +31,13 @@ interface CommandInterface
     public static function capability(): Capability;
 
     /**
-     * The payment being operated on, when the caller had one to hand.
+     * What is being operated on -- a payment, a payout -- when the caller had it to hand.
      *
-     * Null when the command carries only a token; core then resolves the payment from the token's
-     * identity.
+     * Null when the command carries only a token, which is the usual case for anything arriving over
+     * HTTP: core then resolves the subject from the token's identity. Handlers should read the resolved
+     * one from the context rather than this.
      */
-    public function payment(): ?PaymentInterface;
+    public function subject(): ?SubjectInterface;
 
     /**
      * The token this command arrived on, when it came in over HTTP.

--- a/src/Payum/Core/Command/PayoutCommand.php
+++ b/src/Payum/Core/Command/PayoutCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Command;
+
+use Payum\Core\Exception\LogicException;
+use Payum\Core\Gateway\Capability;
+use Payum\Core\Model\PayoutInterface;
+use Payum\Core\Model\SubjectInterface;
+use Payum\Core\Result\PayoutResult;
+use Payum\Core\Security\TokenInterface;
+
+/**
+ * Send money out to a recipient.
+ *
+ * The one operation that is not about a payment: it acts on a {@see PayoutInterface}, which carries a
+ * recipient rather than a customer.
+ *
+ * Re-entrant on the same terms as a capture. A PSP that makes a payout in one call has a handler that
+ * checks whether it has already gone out and returns; one that needs approval before it executes has a
+ * handler that reads which pass it is on, exactly as a redirect capture does. Neither needs its own
+ * command.
+ *
+ * @implements CommandInterface<PayoutResult>
+ */
+final class PayoutCommand implements CommandInterface
+{
+    public function __construct(
+        private readonly ?TokenInterface $token = null,
+        private readonly ?PayoutInterface $payout = null,
+        public readonly ?string $idempotencyKey = null,
+    ) {
+        if (! $this->token instanceof TokenInterface && ! $this->payout instanceof PayoutInterface) {
+            throw new LogicException(sprintf(
+                'A %s needs either a token or a payout: it has to know what it is paying out.',
+                self::class,
+            ));
+        }
+    }
+
+    public static function capability(): Capability
+    {
+        return Capability::Payout;
+    }
+
+    public static function forPayout(PayoutInterface $payout, ?string $idempotencyKey = null): self
+    {
+        return new self(payout: $payout, idempotencyKey: $idempotencyKey);
+    }
+
+    public static function forToken(TokenInterface $token, ?string $idempotencyKey = null): self
+    {
+        return new self(token: $token, idempotencyKey: $idempotencyKey);
+    }
+
+    public function payout(): ?PayoutInterface
+    {
+        return $this->payout;
+    }
+
+    public function subject(): ?SubjectInterface
+    {
+        return $this->payout;
+    }
+
+    public function token(): ?TokenInterface
+    {
+        return $this->token;
+    }
+}

--- a/src/Payum/Core/Command/RefundCommand.php
+++ b/src/Payum/Core/Command/RefundCommand.php
@@ -7,6 +7,7 @@ namespace Payum\Core\Command;
 use Payum\Core\Exception\LogicException;
 use Payum\Core\Gateway\Capability;
 use Payum\Core\Model\PaymentInterface;
+use Payum\Core\Model\SubjectInterface;
 use Payum\Core\Result\RefundResult;
 use Payum\Core\Security\TokenInterface;
 
@@ -57,6 +58,11 @@ final class RefundCommand implements CommandInterface
     }
 
     public function payment(): ?PaymentInterface
+    {
+        return $this->payment;
+    }
+
+    public function subject(): ?SubjectInterface
     {
         return $this->payment;
     }

--- a/src/Payum/Core/Command/SyncCommand.php
+++ b/src/Payum/Core/Command/SyncCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Command;
+
+use Payum\Core\Exception\LogicException;
+use Payum\Core\Gateway\Capability;
+use Payum\Core\Model\PaymentInterface;
+use Payum\Core\Model\PayoutInterface;
+use Payum\Core\Model\SubjectInterface;
+use Payum\Core\Result\SyncResult;
+use Payum\Core\Security\TokenInterface;
+
+/**
+ * Ask the PSP what it thinks the current state is, and record the answer.
+ *
+ * Only for callers: an admin screen with a refresh button, a reconciliation job, recovery after a webhook
+ * that never arrived. A handler that needs fresh data mid-flow calls its api directly -- dispatching a
+ * command to fetch something it uses two lines later is the indirection this model exists to remove.
+ *
+ * Reads rather than mutates, so it carries no idempotency key: running it twice costs a request and
+ * changes nothing.
+ *
+ * Not every PSP offers a way to re-read, which is why Capability::Sync is a capability like any other
+ * rather than something core assumes.
+ *
+ * @implements CommandInterface<SyncResult>
+ */
+final class SyncCommand implements CommandInterface
+{
+    public function __construct(
+        private readonly ?TokenInterface $token = null,
+        private readonly ?SubjectInterface $subject = null,
+    ) {
+        if (! $this->token instanceof TokenInterface && ! $this->subject instanceof SubjectInterface) {
+            throw new LogicException(sprintf(
+                'A %s needs either a token or something to synchronise.',
+                self::class,
+            ));
+        }
+    }
+
+    public static function capability(): Capability
+    {
+        return Capability::Sync;
+    }
+
+    public static function forPayment(PaymentInterface $payment): self
+    {
+        return new self(subject: $payment);
+    }
+
+    public static function forPayout(PayoutInterface $payout): self
+    {
+        return new self(subject: $payout);
+    }
+
+    public static function forToken(TokenInterface $token): self
+    {
+        return new self(token: $token);
+    }
+
+    public function payment(): ?PaymentInterface
+    {
+        return $this->subject instanceof PaymentInterface ? $this->subject : null;
+    }
+
+    public function payout(): ?PayoutInterface
+    {
+        return $this->subject instanceof PayoutInterface ? $this->subject : null;
+    }
+
+    public function subject(): ?SubjectInterface
+    {
+        return $this->subject;
+    }
+
+    public function token(): ?TokenInterface
+    {
+        return $this->token;
+    }
+}

--- a/src/Payum/Core/Gateway.php
+++ b/src/Payum/Core/Gateway.php
@@ -18,7 +18,7 @@ use Payum\Core\Handler\HandlerInterface;
 use Payum\Core\Handler\HandlerMap;
 use Payum\Core\Middleware\MiddlewareCollection;
 use Payum\Core\Middleware\Pipeline;
-use Payum\Core\Model\PaymentInterface;
+use Payum\Core\Model\SubjectInterface;
 use Payum\Core\Registry\StorageRegistryInterface;
 use Payum\Core\Reply\ReplyInterface;
 use Payum\Core\Result\Result;
@@ -393,7 +393,7 @@ class Gateway implements GatewayInterface
             $this->container->get(PaymentGateway::class),
             $this->container->get(ServerRequestInterface::class),
             $this->container->get(GenericTokenFactoryInterface::class),
-            $this->resolvePayment($command),
+            $this->resolveSubject($command),
             $command->token(),
             $this->commandStack,
         );
@@ -405,10 +405,10 @@ class Gateway implements GatewayInterface
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      */
-    private function resolvePayment(CommandInterface $command): ?PaymentInterface
+    private function resolveSubject(CommandInterface $command): ?SubjectInterface
     {
-        if (($payment = $command->payment()) instanceof PaymentInterface) {
-            return $payment;
+        if (($subject = $command->subject()) instanceof SubjectInterface) {
+            return $subject;
         }
 
         $identity = $command->token()?->getDetails();
@@ -421,6 +421,6 @@ class Gateway implements GatewayInterface
             ->getStorage($identity->getClass())
             ->find($identity);
 
-        return $model instanceof PaymentInterface ? $model : null;
+        return $model instanceof SubjectInterface ? $model : null;
     }
 }

--- a/src/Payum/Core/Gateway/Capability.php
+++ b/src/Payum/Core/Gateway/Capability.php
@@ -27,6 +27,8 @@ enum Capability: string
 
     case Refund = 'refund';
 
+    case Sync = 'sync';
+
     // Nuance -- declared, because no handler list implies them.
     case MultiCurrency = 'multi_currency';
 

--- a/src/Payum/Core/Handler/CancelHandlerInterface.php
+++ b/src/Payum/Core/Handler/CancelHandlerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Handler;
+
+use Payum\Core\Command\CancelCommand;
+use Payum\Core\Result\CancelResult;
+
+/**
+ * Calls the payment off before the money moves.
+ */
+interface CancelHandlerInterface extends HandlerInterface
+{
+    public function handle(CancelCommand $command, Context $context): CancelResult;
+}

--- a/src/Payum/Core/Handler/Context.php
+++ b/src/Payum/Core/Handler/Context.php
@@ -10,6 +10,8 @@ use Payum\Core\Exception\LogicException;
 use Payum\Core\Gateway as Executor;
 use Payum\Core\Gateway\GatewayInterface;
 use Payum\Core\Model\PaymentInterface;
+use Payum\Core\Model\PayoutInterface;
+use Payum\Core\Model\SubjectInterface;
 use Payum\Core\Result\Result;
 use Payum\Core\Security\GenericTokenFactoryInterface;
 use Payum\Core\Security\TokenInterface;
@@ -46,7 +48,7 @@ final class Context
         private readonly GatewayInterface $gateway,
         private readonly ServerRequestInterface $httpRequest,
         private readonly GenericTokenFactoryInterface $tokenFactory,
-        private readonly ?PaymentInterface $payment = null,
+        private readonly ?SubjectInterface $subject = null,
         private readonly ?TokenInterface $token = null,
         private readonly array $previous = [],
     ) {
@@ -111,9 +113,29 @@ final class Context
         return $this->state;
     }
 
+    /**
+     * What this command is operating on, whatever it is. Handlers normally want one of the narrower
+     * accessors below.
+     */
+    public function subject(): ?SubjectInterface
+    {
+        return $this->subject;
+    }
+
+    /**
+     * Null when the subject is not a payment, which is the case for a payout.
+     */
     public function payment(): ?PaymentInterface
     {
-        return $this->payment;
+        return $this->subject instanceof PaymentInterface ? $this->subject : null;
+    }
+
+    /**
+     * Null when the subject is not a payout.
+     */
+    public function payout(): ?PayoutInterface
+    {
+        return $this->subject instanceof PayoutInterface ? $this->subject : null;
     }
 
     /**
@@ -154,13 +176,13 @@ final class Context
      */
     public function state(): ArrayObject
     {
-        if (! $this->payment instanceof PaymentInterface) {
-            throw new LogicException('There is no payment in this context, so there is no state to read.');
+        if (! $this->subject instanceof SubjectInterface) {
+            throw new LogicException('There is nothing in this context to read state from.');
         }
 
         // Cached, so every call within one execution mutates the same instance. Core writes it back onto
         // the payment after the handler returns -- inline for now, PersistStateMiddleware later.
-        return $this->state ??= ArrayObject::ensureArrayObject($this->payment->getDetails());
+        return $this->state ??= ArrayObject::ensureArrayObject($this->subject->getDetails());
     }
 
     /**

--- a/src/Payum/Core/Handler/PayoutHandlerInterface.php
+++ b/src/Payum/Core/Handler/PayoutHandlerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Handler;
+
+use Payum\Core\Command\PayoutCommand;
+use Payum\Core\Result\PayoutResult;
+
+/**
+ * Sends money out to a recipient.
+ */
+interface PayoutHandlerInterface extends HandlerInterface
+{
+    public function handle(PayoutCommand $command, Context $context): PayoutResult;
+}

--- a/src/Payum/Core/Handler/SyncHandlerInterface.php
+++ b/src/Payum/Core/Handler/SyncHandlerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Handler;
+
+use Payum\Core\Command\SyncCommand;
+use Payum\Core\Result\SyncResult;
+
+/**
+ * Re-reads the current state from the PSP.
+ */
+interface SyncHandlerInterface extends HandlerInterface
+{
+    public function handle(SyncCommand $command, Context $context): SyncResult;
+}

--- a/src/Payum/Core/Middleware/PersistStateMiddleware.php
+++ b/src/Payum/Core/Middleware/PersistStateMiddleware.php
@@ -7,7 +7,7 @@ namespace Payum\Core\Middleware;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Command\CommandInterface;
 use Payum\Core\Handler\Context;
-use Payum\Core\Model\PaymentInterface;
+use Payum\Core\Model\SubjectInterface;
 use Payum\Core\Registry\StorageRegistryInterface;
 use Payum\Core\Result\Result;
 use Payum\Core\Security\TokenInterface;
@@ -50,21 +50,21 @@ final class PersistStateMiddleware implements MiddlewareInterface, HasPriority
      */
     private function persist(CommandInterface $command, Context $context): void
     {
-        $payment = $context->payment();
+        $subject = $context->subject();
         $state = $context->pendingState();
 
-        if (! $payment instanceof PaymentInterface || ! $state instanceof ArrayObject) {
+        if (! $subject instanceof SubjectInterface || ! $state instanceof ArrayObject) {
             return;
         }
 
-        $payment->setDetails($state);
+        $subject->setDetails($state);
 
-        // Core writes back only what it loaded. A payment handed to the command directly belongs to the
+        // Core writes back only what it loaded. A model handed to the command directly belongs to the
         // caller, who persists it on their own terms.
         if (! $command->token() instanceof TokenInterface || ! $this->storages instanceof StorageRegistryInterface) {
             return;
         }
 
-        $this->storages->getStorage($payment::class)->update($payment);
+        $this->storages->getStorage($subject::class)->update($subject);
     }
 }

--- a/src/Payum/Core/Middleware/RecordPaymentStatusMiddleware.php
+++ b/src/Payum/Core/Middleware/RecordPaymentStatusMiddleware.php
@@ -6,8 +6,8 @@ namespace Payum\Core\Middleware;
 
 use Payum\Core\Command\CommandInterface;
 use Payum\Core\Handler\Context;
-use Payum\Core\Model\PaymentInterface;
 use Payum\Core\Model\PaymentStatuses;
+use Payum\Core\Model\SubjectInterface;
 use Payum\Core\Result\PaymentStatus;
 use Payum\Core\Result\Result;
 
@@ -35,12 +35,12 @@ final class RecordPaymentStatusMiddleware implements MiddlewareInterface, HasPri
         // not learn what the payment's status is, and guessing would be worse than leaving it.
         $result = $next($command, $context);
 
-        $payment = $context->payment();
+        $subject = $context->subject();
 
         // A null status means the operation concluded nothing about the payment — a declined refund
         // leaves a captured payment captured.
-        if ($payment instanceof PaymentInterface && $result->status instanceof PaymentStatus) {
-            PaymentStatuses::set($payment, $result->status);
+        if ($subject instanceof SubjectInterface && $result->status instanceof PaymentStatus) {
+            PaymentStatuses::set($subject, $result->status);
         }
 
         return $result;

--- a/src/Payum/Core/Model/PaymentInterface.php
+++ b/src/Payum/Core/Model/PaymentInterface.php
@@ -5,7 +5,7 @@ namespace Payum\Core\Model;
 /**
  * @method array getDetails()
  */
-interface PaymentInterface extends CreditCardPaymentInterface, DetailsAggregateInterface, DetailsAwareInterface
+interface PaymentInterface extends CreditCardPaymentInterface, SubjectInterface
 {
     /**
      * @return string

--- a/src/Payum/Core/Model/PayoutInterface.php
+++ b/src/Payum/Core/Model/PayoutInterface.php
@@ -5,7 +5,7 @@ namespace Payum\Core\Model;
 /**
  * @method array getDetails()
  */
-interface PayoutInterface extends DetailsAggregateInterface, DetailsAwareInterface
+interface PayoutInterface extends SubjectInterface
 {
     /**
      * @return string

--- a/src/Payum/Core/Model/SubjectInterface.php
+++ b/src/Payum/Core/Model/SubjectInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Model;
+
+/**
+ * The thing a command operates on: a payment, a payout, or whatever a gateway adds.
+ *
+ * Core needs two things from it and nothing more — details it can read and write, and a class it can look
+ * a storage up by. Everything specific, an amount or a recipient, is the handler's business.
+ *
+ * Named for the role rather than the capability. If a middleware ever needs the amount or the currency
+ * without knowing what it is holding, this is where they would move: PaymentInterface and PayoutInterface
+ * both declare them already, so adding them here would break nothing.
+ */
+interface SubjectInterface extends DetailsAggregateInterface, DetailsAwareInterface
+{
+}

--- a/src/Payum/Core/Result/CancelResult.php
+++ b/src/Payum/Core/Result/CancelResult.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Result;
+
+/**
+ * The outcome of a {@see \Payum\Core\Command\CancelCommand}.
+ */
+final class CancelResult extends Result
+{
+    /**
+     * @param array<string, mixed> $raw
+     */
+    public function __construct(
+        ?PaymentStatus $status,
+        ?NextAction $next = null,
+        ?string $transactionId = null,
+        ?Failure $failure = null,
+        array $raw = [],
+    ) {
+        parent::__construct($status, $next, $transactionId, $failure, $raw);
+    }
+
+    /**
+     * @param array<string, mixed> $raw
+     */
+    public static function canceled(?string $transactionId = null, array $raw = []): self
+    {
+        return new self(PaymentStatus::Canceled, transactionId: $transactionId, raw: $raw);
+    }
+
+    /**
+     * The operation did not succeed. By default this says nothing about the payment's status: a cancel the
+     * PSP refused leaves the payment exactly as it was, which is usually still authorized.
+     *
+     * Pass $status when the failure is terminal and the payment really has moved.
+     *
+     * @param array<string, mixed> $raw
+     */
+    public static function failed(Failure $failure, ?PaymentStatus $status = null, array $raw = []): self
+    {
+        return new self($status, failure: $failure, raw: $raw);
+    }
+
+    /**
+     * Not finished. Some PSPs confirm a cancellation asynchronously, and a gateway needing the customer to
+     * confirm passes a NextAction.
+     *
+     * @param array<string, mixed> $raw
+     */
+    public static function pending(?NextAction $next = null, array $raw = []): self
+    {
+        return new self(PaymentStatus::Pending, $next, raw: $raw);
+    }
+}

--- a/src/Payum/Core/Result/PayoutResult.php
+++ b/src/Payum/Core/Result/PayoutResult.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Result;
+
+/**
+ * The outcome of a {@see \Payum\Core\Command\PayoutCommand}.
+ */
+final class PayoutResult extends Result
+{
+    /**
+     * @param array<string, mixed> $raw
+     * @param int|null $paidOutAmount in minor units. Lower than asked for when a PSP fulfils a batch in
+     *                                part
+     */
+    public function __construct(
+        ?PaymentStatus $status,
+        ?NextAction $next = null,
+        ?string $transactionId = null,
+        ?Failure $failure = null,
+        array $raw = [],
+        public readonly ?int $paidOutAmount = null,
+    ) {
+        parent::__construct($status, $next, $transactionId, $failure, $raw);
+    }
+
+    /**
+     * The operation did not succeed. By default this says nothing about the payout's status: a rejected
+     * payout leaves it where it was, ready to be tried again.
+     *
+     * Pass $status when the failure is terminal.
+     *
+     * @param array<string, mixed> $raw
+     */
+    public static function failed(Failure $failure, ?PaymentStatus $status = null, array $raw = []): self
+    {
+        return new self($status, failure: $failure, raw: $raw);
+    }
+
+    /**
+     * @param array<string, mixed> $raw
+     */
+    public static function paidOut(?string $transactionId = null, ?int $paidOutAmount = null, array $raw = []): self
+    {
+        return new self(PaymentStatus::PaidOut, transactionId: $transactionId, raw: $raw, paidOutAmount: $paidOutAmount);
+    }
+
+    /**
+     * Payouts are commonly submitted and settled later, so this is the usual first answer.
+     *
+     * @param array<string, mixed> $raw
+     */
+    public static function pending(?NextAction $next = null, array $raw = []): self
+    {
+        return new self(PaymentStatus::Pending, $next, raw: $raw);
+    }
+}

--- a/src/Payum/Core/Result/SyncResult.php
+++ b/src/Payum/Core/Result/SyncResult.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Result;
+
+/**
+ * The outcome of a {@see \Payum\Core\Command\SyncCommand}.
+ *
+ * The only result whose status is an argument rather than fixed by the constructor that built it: a sync
+ * reports whatever the PSP says, which could be any state at all. Recording it is what makes a sync worth
+ * running -- the stored status catches up with the PSP.
+ */
+final class SyncResult extends Result
+{
+    /**
+     * @param array<string, mixed> $raw
+     */
+    public function __construct(
+        ?PaymentStatus $status,
+        ?NextAction $next = null,
+        ?string $transactionId = null,
+        ?Failure $failure = null,
+        array $raw = [],
+    ) {
+        parent::__construct($status, $next, $transactionId, $failure, $raw);
+    }
+
+    /**
+     * The PSP could not be asked, or answered with something unusable. The stored status is left alone,
+     * since a failed read is not evidence that anything changed.
+     *
+     * @param array<string, mixed> $raw
+     */
+    public static function failed(Failure $failure, ?PaymentStatus $status = null, array $raw = []): self
+    {
+        return new self($status, failure: $failure, raw: $raw);
+    }
+
+    /**
+     * @param array<string, mixed> $raw the PSP's answer, which is usually the point of asking
+     */
+    public static function synced(PaymentStatus $status, ?string $transactionId = null, array $raw = []): self
+    {
+        return new self($status, transactionId: $transactionId, raw: $raw);
+    }
+}

--- a/src/Payum/Core/Tests/Command/CancelCommandTest.php
+++ b/src/Payum/Core/Tests/Command/CancelCommandTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests\Command;
+
+use Payum\Core\Command\CancelCommand;
+use Payum\Core\Exception\LogicException;
+use Payum\Core\Gateway\Capability;
+use Payum\Core\Model\Payment;
+use Payum\Core\Model\PaymentInterface;
+use Payum\Core\Result\CancelResult;
+use Payum\Core\Result\Failure;
+use Payum\Core\Result\FailureReason;
+use Payum\Core\Result\NextAction;
+use Payum\Core\Result\PaymentStatus;
+use Payum\Core\Security\TokenInterface;
+use PHPUnit\Framework\TestCase;
+
+final class CancelCommandTest extends TestCase
+{
+    public function testShouldExerciseTheCancelCapability(): void
+    {
+        $this->assertSame(Capability::Cancel, CancelCommand::capability());
+    }
+
+    public function testShouldBeBuiltFromAPayment(): void
+    {
+        $payment = new Payment();
+
+        $command = CancelCommand::forPayment($payment, 'merchant_abandoned');
+
+        $this->assertSame($payment, $command->payment());
+        $this->assertNotInstanceOf(TokenInterface::class, $command->token());
+        $this->assertSame('merchant_abandoned', $command->reason);
+    }
+
+    public function testShouldBeBuiltFromAToken(): void
+    {
+        $token = $this->createMock(TokenInterface::class);
+
+        $command = CancelCommand::forToken($token);
+
+        $this->assertSame($token, $command->token());
+        $this->assertNotInstanceOf(PaymentInterface::class, $command->payment());
+    }
+
+    public function testShouldRefuseToBeBuiltWithNothingToCancel(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('needs either a token or a payment');
+
+        new CancelCommand();
+    }
+
+    public function testShouldReportCanceled(): void
+    {
+        $result = CancelResult::canceled('txn_1');
+
+        $this->assertSame(PaymentStatus::Canceled, $result->status);
+        $this->assertSame('txn_1', $result->transactionId);
+        $this->assertNotInstanceOf(NextAction::class, $result->next);
+    }
+
+    public function testShouldSayNothingAboutTheStatusWhenTheCancelIsRefused(): void
+    {
+        // A cancel the PSP refused leaves the payment as it was, usually still authorized.
+        $result = CancelResult::failed(new Failure(FailureReason::Declined, 'already_captured'));
+
+        $this->assertNotInstanceOf(PaymentStatus::class, $result->status);
+        $this->assertTrue($result->isFailed());
+    }
+
+    public function testShouldReportATerminalFailureWhenTheHandlerSaysSo(): void
+    {
+        $result = CancelResult::failed(
+            new Failure(FailureReason::Configuration, 'bad_key'),
+            PaymentStatus::Failed,
+        );
+
+        $this->assertSame(PaymentStatus::Failed, $result->status);
+    }
+}

--- a/src/Payum/Core/Tests/Command/CancelCommandTest.php
+++ b/src/Payum/Core/Tests/Command/CancelCommandTest.php
@@ -48,7 +48,7 @@ final class CancelCommandTest extends TestCase
     public function testShouldRefuseToBeBuiltWithNothingToCancel(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('needs either a token or a payment');
+        $this->expectExceptionMessage('needs either a token or something to cancel');
 
         new CancelCommand();
     }

--- a/src/Payum/Core/Tests/CommandDispatchTest.php
+++ b/src/Payum/Core/Tests/CommandDispatchTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Payum\Core\Tests;
 
 use League\Uri\Uri;
+use Payum\Core\Command\CancelCommand;
 use Payum\Core\Command\CaptureCommand;
 use Payum\Core\Command\RefundCommand;
 use Payum\Core\Config\GatewayConfig;
 use Payum\Core\Exception\CommandNotSupportedException;
 use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
+use Payum\Core\Handler\CancelHandlerInterface;
 use Payum\Core\Handler\CaptureHandlerInterface;
 use Payum\Core\Handler\Context;
 use Payum\Core\Metadata\Logo;
@@ -18,6 +20,7 @@ use Payum\Core\Model\Payment;
 use Payum\Core\Payum;
 use Payum\Core\PayumBuilder;
 use Payum\Core\Registry\StorageRegistryInterface;
+use Payum\Core\Result\CancelResult;
 use Payum\Core\Result\CaptureResult;
 use Payum\Core\Result\NextAction;
 use Payum\Core\Result\NextAction\Redirect;
@@ -118,7 +121,7 @@ final class CommandDispatchTest extends TestCase
 
             $this->assertSame('acme', $e->getGatewayName());
             $this->assertSame(AcmeGateway::class, $e->getGatewayClass());
-            $this->assertSame([CaptureCommand::class], $e->getSupportedCommands());
+            $this->assertSame([CaptureCommand::class, CancelCommand::class], $e->getSupportedCommands());
             $this->assertInstanceOf(RefundCommand::class, $e->getCommand());
         }
     }
@@ -143,6 +146,17 @@ final class CommandDispatchTest extends TestCase
             $this->assertNull($e->getGatewayClass());
             $this->assertSame([], $e->getSupportedCommands());
         }
+    }
+
+    public function testShouldDispatchACancel(): void
+    {
+        $gateway = $this->buildPayum()->getGateway('acme');
+
+        $result = $gateway->execute(CancelCommand::forPayment($this->buildPayment(), 'merchant_abandoned'));
+
+        $this->assertInstanceOf(CancelResult::class, $result);
+        $this->assertSame(PaymentStatus::Canceled, $result->status);
+        $this->assertSame('merchant_abandoned', AcmeCancelHandler::$seenReason);
     }
 
     public function testShouldReportWhichCommandsItSupports(): void
@@ -236,7 +250,7 @@ final class AcmeGateway implements PaymentGateway
 
     public function handlers(): array
     {
-        return [AcmeCaptureHandler::class];
+        return [AcmeCaptureHandler::class, AcmeCancelHandler::class];
     }
 
     public function logo(): Logo
@@ -252,6 +266,18 @@ final class AcmeGateway implements PaymentGateway
     public function websiteUrl(): Uri
     {
         return Uri::new('https://acme.test');
+    }
+}
+
+final class AcmeCancelHandler implements CancelHandlerInterface
+{
+    public static ?string $seenReason = null;
+
+    public function handle(CancelCommand $command, Context $context): CancelResult
+    {
+        self::$seenReason = $command->reason;
+
+        return CancelResult::canceled('void_1');
     }
 }
 

--- a/src/Payum/Core/Tests/Handler/HandlerMapTest.php
+++ b/src/Payum/Core/Tests/Handler/HandlerMapTest.php
@@ -4,15 +4,18 @@ declare(strict_types=1);
 
 namespace Payum\Core\Tests\Handler;
 
+use Payum\Core\Command\CancelCommand;
 use Payum\Core\Command\CaptureCommand;
 use Payum\Core\Command\RefundCommand;
 use Payum\Core\Exception\LogicException;
 use Payum\Core\Gateway\Capability;
+use Payum\Core\Handler\CancelHandlerInterface;
 use Payum\Core\Handler\CaptureHandlerInterface;
 use Payum\Core\Handler\Context;
 use Payum\Core\Handler\HandlerInterface;
 use Payum\Core\Handler\HandlerMap;
 use Payum\Core\Handler\RefundHandlerInterface;
+use Payum\Core\Result\CancelResult;
 use Payum\Core\Result\CaptureResult;
 use Payum\Core\Result\RefundResult;
 use PHPUnit\Framework\TestCase;
@@ -45,9 +48,24 @@ final class HandlerMapTest extends TestCase
 
     public function testShouldDeriveCapabilitiesFromTheCommandsItHandles(): void
     {
-        $map = HandlerMap::fromHandlers([CaptureHandlerStub::class, RefundHandlerStub::class]);
+        $map = HandlerMap::fromHandlers([
+            CaptureHandlerStub::class,
+            RefundHandlerStub::class,
+            CancelHandlerStub::class,
+        ]);
 
-        $this->assertSame([Capability::Capture, Capability::Refund], $map->capabilities());
+        $this->assertSame(
+            [Capability::Capture, Capability::Refund, Capability::Cancel],
+            $map->capabilities(),
+        );
+    }
+
+    public function testShouldMapCancel(): void
+    {
+        $map = HandlerMap::fromHandlers([CancelHandlerStub::class]);
+
+        $this->assertSame(CancelHandlerInterface::class, $map->serviceIdFor(CancelCommand::class));
+        $this->assertSame([CancelCommand::class], $map->commands());
     }
 
     public function testShouldBeEmptyWhenThereAreNoHandlers(): void
@@ -97,6 +115,14 @@ final class RefundHandlerStub implements RefundHandlerInterface
     public function handle(RefundCommand $command, Context $context): RefundResult
     {
         return RefundResult::refunded();
+    }
+}
+
+final class CancelHandlerStub implements CancelHandlerInterface
+{
+    public function handle(CancelCommand $command, Context $context): CancelResult
+    {
+        return CancelResult::canceled();
     }
 }
 

--- a/src/Payum/Core/Tests/PayoutTest.php
+++ b/src/Payum/Core/Tests/PayoutTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests;
+
+use League\Uri\Uri;
+use Payum\Core\Command\CancelCommand;
+use Payum\Core\Command\PayoutCommand;
+use Payum\Core\Config\GatewayConfig;
+use Payum\Core\Exception\LogicException;
+use Payum\Core\Gateway\Capability;
+use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
+use Payum\Core\Handler\Context;
+use Payum\Core\Handler\PayoutHandlerInterface;
+use Payum\Core\Metadata\Logo;
+use Payum\Core\Metadata\Logo\Url;
+use Payum\Core\Model\Payment;
+use Payum\Core\Model\PaymentInterface;
+use Payum\Core\Model\Payout;
+use Payum\Core\Model\SubjectInterface;
+use Payum\Core\Payum;
+use Payum\Core\PayumBuilder;
+use Payum\Core\Registry\StorageRegistryInterface;
+use Payum\Core\Result\PaymentStatus;
+use Payum\Core\Result\PayoutResult;
+use Payum\Core\Security\TokenInterface;
+use Payum\Core\Storage\StorageInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Payout is the one operation that does not act on a payment, so it is what proves core works against any
+ * subject rather than only against payments.
+ */
+final class PayoutTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_SERVER = [
+            'HTTP_HOST' => 'payum.dev',
+        ];
+    }
+
+    public function testShouldExerciseThePayoutCapability(): void
+    {
+        $this->assertSame(Capability::Payout, PayoutCommand::capability());
+    }
+
+    public function testShouldCarryThePayoutAsItsSubject(): void
+    {
+        $payout = new Payout();
+
+        $command = PayoutCommand::forPayout($payout);
+
+        $this->assertSame($payout, $command->payout());
+        $this->assertSame($payout, $command->subject());
+    }
+
+    public function testShouldRefuseToBeBuiltWithNothingToPayOut(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('needs either a token or a payout');
+
+        new PayoutCommand();
+    }
+
+    public function testAPayoutIsASubject(): void
+    {
+        $this->assertInstanceOf(SubjectInterface::class, new Payout());
+        $this->assertInstanceOf(SubjectInterface::class, new Payment());
+    }
+
+    public function testShouldDispatchAPayoutToItsHandler(): void
+    {
+        $payout = $this->buildPayout();
+
+        $result = $this->buildPayum()->getGateway('acme')->execute(PayoutCommand::forPayout($payout));
+
+        $this->assertInstanceOf(PayoutResult::class, $result);
+        $this->assertSame(PaymentStatus::PaidOut, $result->status);
+        $this->assertSame(1500, $result->paidOutAmount);
+    }
+
+    public function testShouldGiveTheHandlerThePayoutThroughTheContext(): void
+    {
+        $payout = $this->buildPayout();
+
+        $this->buildPayum()->getGateway('acme')->execute(PayoutCommand::forPayout($payout));
+
+        $this->assertSame('payee@example.com', AcmePayoutHandler::$seenRecipient);
+        // A payout is not a payment, so the narrower accessor says so rather than guessing.
+        $this->assertNull(AcmePayoutHandler::$seenPayment);
+    }
+
+    public function testShouldWriteStateOntoThePayout(): void
+    {
+        $payout = $this->buildPayout();
+
+        $this->buildPayum()->getGateway('acme')->execute(PayoutCommand::forPayout($payout));
+
+        // The same persistence path a payment takes, against a model that is not one.
+        $this->assertSame([
+            'batch_id' => 'batch_1',
+        ], $payout->getDetails());
+    }
+
+    public function testShouldCancelAPayout(): void
+    {
+        $payout = new Payout();
+
+        $command = CancelCommand::forPayout($payout);
+
+        // Cancelling is the same operation whatever it cancels, so it takes either.
+        $this->assertSame($payout, $command->payout());
+        $this->assertSame($payout, $command->subject());
+        $this->assertNotInstanceOf(PaymentInterface::class, $command->payment());
+    }
+
+    private function buildPayout(): Payout
+    {
+        $payout = new Payout();
+        $payout->setRecipientEmail('payee@example.com');
+        $payout->setTotalAmount(1500);
+        $payout->setCurrencyCode('EUR');
+
+        return $payout;
+    }
+
+    /**
+     * @return Payum<StorageRegistryInterface<StorageInterface<TokenInterface>>>
+     */
+    private function buildPayum(): Payum
+    {
+        AcmePayoutHandler::$seenRecipient = null;
+        AcmePayoutHandler::$seenPayment = null;
+
+        return (new PayumBuilder())
+            ->addDefaultStorages()
+            ->registerGateway('acme', new AcmePayoutConfig())
+            ->getPayum();
+    }
+}
+
+final class AcmePayoutConfig implements GatewayConfig
+{
+    public function getGatewayClass(): string
+    {
+        return AcmePayoutGateway::class;
+    }
+}
+
+final class AcmePayoutGateway implements PaymentGateway
+{
+    public function configClass(): string
+    {
+        return AcmePayoutConfig::class;
+    }
+
+    public function handlers(): array
+    {
+        return [AcmePayoutHandler::class];
+    }
+
+    public function logo(): Logo
+    {
+        return Url::create('https://acme.test/logo.svg');
+    }
+
+    public function name(): string
+    {
+        return 'Acme Payouts';
+    }
+
+    public function websiteUrl(): Uri
+    {
+        return Uri::new('https://acme.test');
+    }
+}
+
+final class AcmePayoutHandler implements PayoutHandlerInterface
+{
+    public static ?string $seenRecipient = null;
+
+    public static mixed $seenPayment = null;
+
+    public function handle(PayoutCommand $command, Context $context): PayoutResult
+    {
+        self::$seenRecipient = $context->payout()?->getRecipientEmail();
+        self::$seenPayment = $context->payment();
+
+        $state = $context->state();
+
+        // The re-entrancy guard a real payout uses: do not send it twice.
+        if ($state['batch_id']) {
+            return PayoutResult::paidOut($state['batch_id'], $context->payout()?->getTotalAmount());
+        }
+
+        $state['batch_id'] = 'batch_1';
+
+        return PayoutResult::paidOut('batch_1', $context->payout()?->getTotalAmount());
+    }
+}

--- a/src/Payum/Core/Tests/SyncTest.php
+++ b/src/Payum/Core/Tests/SyncTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests;
+
+use League\Uri\Uri;
+use Payum\Core\Command\SyncCommand;
+use Payum\Core\Config\GatewayConfig;
+use Payum\Core\Exception\LogicException;
+use Payum\Core\Gateway\Capability;
+use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
+use Payum\Core\Handler\Context;
+use Payum\Core\Handler\SyncHandlerInterface;
+use Payum\Core\Metadata\Logo;
+use Payum\Core\Metadata\Logo\Url;
+use Payum\Core\Model\HasPaymentStatus;
+use Payum\Core\Model\Payment;
+use Payum\Core\Model\PaymentInterface;
+use Payum\Core\Model\Payout;
+use Payum\Core\Payum;
+use Payum\Core\PayumBuilder;
+use Payum\Core\Registry\StorageRegistryInterface;
+use Payum\Core\Result\Failure;
+use Payum\Core\Result\FailureReason;
+use Payum\Core\Result\PaymentStatus;
+use Payum\Core\Result\SyncResult;
+use Payum\Core\Security\TokenInterface;
+use Payum\Core\Storage\StorageInterface;
+use PHPUnit\Framework\TestCase;
+
+final class SyncTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_SERVER = [
+            'HTTP_HOST' => 'payum.dev',
+        ];
+
+        AcmeSyncHandler::$answer = PaymentStatus::Captured;
+    }
+
+    public function testShouldExerciseTheSyncCapability(): void
+    {
+        $this->assertSame(Capability::Sync, SyncCommand::capability());
+    }
+
+    public function testShouldSynchroniseEitherAPaymentOrAPayout(): void
+    {
+        $payment = new Payment();
+        $payout = new Payout();
+
+        $this->assertSame($payment, SyncCommand::forPayment($payment)->subject());
+        $this->assertSame($payout, SyncCommand::forPayout($payout)->subject());
+        $this->assertNotInstanceOf(PaymentInterface::class, SyncCommand::forPayout($payout)->payment());
+    }
+
+    public function testShouldRefuseToBeBuiltWithNothingToSynchronise(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('needs either a token or something to synchronise');
+
+        new SyncCommand();
+    }
+
+    public function testShouldReportWhateverThePspSays(): void
+    {
+        AcmeSyncHandler::$answer = PaymentStatus::Refunded;
+
+        $result = $this->buildPayum()->getGateway('acme')->execute(SyncCommand::forPayment(new Payment()));
+
+        $this->assertInstanceOf(SyncResult::class, $result);
+        $this->assertSame(PaymentStatus::Refunded, $result->status);
+    }
+
+    public function testShouldBringTheStoredStatusUpToDate(): void
+    {
+        $payment = new TrackedSyncPayment();
+        $payment->setStatus(PaymentStatus::Pending);
+
+        AcmeSyncHandler::$answer = PaymentStatus::Captured;
+
+        $this->buildPayum()->getGateway('acme')->execute(SyncCommand::forPayment($payment));
+
+        // Catching a status up with the PSP after a webhook that never arrived is the point of a sync.
+        $this->assertSame(PaymentStatus::Captured, $payment->getStatus());
+    }
+
+    public function testShouldLeaveTheStoredStatusAloneWhenThePspCouldNotBeAsked(): void
+    {
+        $payment = new TrackedSyncPayment();
+        $payment->setStatus(PaymentStatus::Captured);
+
+        AcmeSyncHandler::$answer = null;
+
+        $this->buildPayum()->getGateway('acme')->execute(SyncCommand::forPayment($payment));
+
+        // A read that failed is not evidence that anything changed.
+        $this->assertSame(PaymentStatus::Captured, $payment->getStatus());
+    }
+
+    /**
+     * @return Payum<StorageRegistryInterface<StorageInterface<TokenInterface>>>
+     */
+    private function buildPayum(): Payum
+    {
+        return (new PayumBuilder())
+            ->addDefaultStorages()
+            ->registerGateway('acme', new AcmeSyncConfig())
+            ->getPayum();
+    }
+}
+
+final class AcmeSyncConfig implements GatewayConfig
+{
+    public function getGatewayClass(): string
+    {
+        return AcmeSyncGateway::class;
+    }
+}
+
+final class AcmeSyncGateway implements PaymentGateway
+{
+    public function configClass(): string
+    {
+        return AcmeSyncConfig::class;
+    }
+
+    public function handlers(): array
+    {
+        return [AcmeSyncHandler::class];
+    }
+
+    public function logo(): Logo
+    {
+        return Url::create('https://acme.test/logo.svg');
+    }
+
+    public function name(): string
+    {
+        return 'Acme';
+    }
+
+    public function websiteUrl(): Uri
+    {
+        return Uri::new('https://acme.test');
+    }
+}
+
+final class AcmeSyncHandler implements SyncHandlerInterface
+{
+    public static ?PaymentStatus $answer = PaymentStatus::Captured;
+
+    public function handle(SyncCommand $command, Context $context): SyncResult
+    {
+        if (! self::$answer instanceof PaymentStatus) {
+            return SyncResult::failed(new Failure(FailureReason::Network, 'timeout'));
+        }
+
+        return SyncResult::synced(self::$answer, 'txn_1', [
+            'status' => self::$answer->value,
+        ]);
+    }
+}
+
+class TrackedSyncPayment extends Payment implements HasPaymentStatus
+{
+    private PaymentStatus $status = PaymentStatus::New;
+
+    public function getStatus(): PaymentStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(PaymentStatus $status): void
+    {
+        $this->status = $status;
+    }
+}


### PR DESCRIPTION
Adds the three commands that were missing, which completes the set — every `Capability` operation now has a command behind it.

```php
CancelCommand::forPayment($payment, reason: 'out_of_stock');
PayoutCommand::forPayout($payout);
SyncCommand::forPayment($payment);
```

## Cancel

Calls it off before the money moves: voiding an authorization, abandoning a payment the customer never completed, or stopping a payout that has not gone out. Not a refund, which gives back money already taken, and it carries no amount because it is all or nothing.

```php
$result = $gateway->execute(CancelCommand::forPayment($payment));

$result->status;   // PaymentStatus::Canceled
```

A cancel the PSP refuses reports no status at all, leaving the payment where it was — usually still authorized.

## Payout

Sends money out to a recipient, so it is the one operation that does not act on a payment.

```php
final class PayoutHandler implements PayoutHandlerInterface
{
    public function handle(PayoutCommand $command, Context $context): PayoutResult
    {
        $payout = $context->payout();

        $batch = $this->api->submitBatch([
            'recipient' => $payout->getRecipientEmail(),
            'amount' => $payout->getTotalAmount(),
        ]);

        return PayoutResult::paidOut($batch['id'], $payout->getTotalAmount());
    }
}
```

Approval flows do not need their own commands. A payout that has to be approved before it executes is a handler reading `$context->state()` to see which pass it is on, exactly as a redirect capture does.

## Sync

Asks the PSP what it currently thinks and records the answer, which is how a stored status catches up after a webhook that never arrived.

```php
$result = $gateway->execute(SyncCommand::forPayment($payment));

$result->status;   // whatever the PSP says
```

For callers — an admin refresh button, a reconciliation job. A handler needing fresh data mid-flow calls its api directly instead. It reads rather than mutates, so it takes no idempotency key, and a sync that failed leaves the stored status alone.

It is the only result whose status is an argument: every other one is fixed by the constructor that built it, while a sync exists to discover the state.

## What a command operates on

Payout forced this: a payout is not a payment. Both now implement `Payum\Core\Model\SubjectInterface`, which is all core ever needs — details it can read and write, and a class to look a storage up by.

```php
$context->subject();   // whatever it is
$context->payment();   // null when it is not a payment
$context->payout();    // null when it is not a payout
```

Commands that are inherently about one model keep the narrow accessor. `CancelCommand` and `SyncCommand` take either, because cancelling and refreshing are the same operation whatever they are pointed at.

The subject on a command is what the *caller* supplied, which is null whenever the command carries only a token — the usual case over HTTP. Core resolves the real one from the token, so handlers read it from the context.

## Capabilities

`Capability::Sync` is new. Not every PSP offers a way to re-read, so a gateway that cannot simply ships no handler and the capability is not derived.
