### PR TITLE
Answer 1.x requests with handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Add `Payum\Core\Model\StatusAwareInterface`. A subject implementing it has its status kept current by Payum after every command, which makes it readable without a gateway and queryable in storage. Read it through `Payum\Core\Model\PaymentStatuses`
 * `Result::$status` is now null when an operation concluded nothing about the payment, so a declined refund no longer reads as a failed payment. `failed()` takes an optional status for a failure that really is terminal
+* A 1.x request sent to a gateway built from handlers is translated to the command that means the same thing, so an application keeps working when a gateway package ports. `Capture`, `Authorize`, `Refund`, `Cancel`, `Payout` and `Sync` translate; `GetHumanStatus` and `GetBinaryStatus` are answered from the recorded status
+* Fix `Payum::done()` against a gateway built from handlers, which previously reported `GetHumanStatus` as unsupported
 * Add a middleware pipeline around command execution. `Payum\Core\Middleware\MiddlewareInterface` wraps a command, `PayumBuilder::addMiddleware()` registers one for every gateway, and a gateway declares its own through `Payum\Core\Gateway\DeclaresMiddleware`
 * Extensions registered on a gateway now run for commands too, through `Payum\Core\Middleware\LegacyExtensionMiddleware`
 * Add a command/handler model for gateways. A gateway describes itself and ships handlers that answer typed commands and return a result, instead of being assembled by a factory and interrupted by thrown replies. See the Gateways chapter in the docs

--- a/docs/gateways/migrating-from-v1.md
+++ b/docs/gateways/migrating-from-v1.md
@@ -214,9 +214,41 @@ It is built from actions: dispatch the matching Payum\Core\Request instead, or p
 * Anything depending on the order in which Payum's own actions ran.
 * Extensions, on the command path. Cross-cutting concerns move to middleware.
 
-### Applications
+### Applications do not have to change at all
 
-An application usually changes one line. `Payum::capture()`, `Payum::done()` and the token flow are unchanged, and `Payum::capture()` dispatches a command when the gateway has a handler for it and the 1.x `Capture` request when it does not.
+A gateway package releases on its own schedule, so an application should not break because one of its dependencies moved to handlers. It does not: a 1.x request sent to a ported gateway is translated to the command that means the same thing, run through the handler, and answered the way 1.x expects.
+
+```php
+// unchanged, still works after the gateway ports
+$gateway = $payum->getGateway($token->getGatewayName());
+
+try {
+    $gateway->execute(new Capture($token));
+} catch (HttpRedirect $reply) {
+    header('Location: ' . $reply->getUrl());
+}
+```
+
+`Payum::capture()`, `Payum::done()`, the token factory and the token flow are all unchanged.
+
+What translates:
+
+| 1.x request | Answered by |
+| :--- | :--- |
+| `Capture`, `Authorize`, `Refund` | the matching handler |
+| `Cancel`, `Sync` | the matching handler, for a payment or a payout |
+| `Payout` | the payout handler |
+| `GetHumanStatus`, `GetBinaryStatus` | the status recorded on the subject |
+| `Notify` | nothing yet — webhooks are their own piece of work |
+
+Two limits worth knowing:
+
+- A status request is answered from the status Payum records, so it needs the subject to implement `Payum\Core\Model\StatusAwareInterface`. One that tracks nothing is marked unknown rather than guessed at.
+- A handler returning `RenderTemplate`, `Challenge` or `Poll` has no 1.x reply to become, so those throw rather than report the payment finished when it is not. A gateway using them needs a caller that acts on a `Result`.
+
+### Moving your own code across
+
+When you are ready, the call site becomes:
 
 ```php
 -$reply = $gateway->execute(new Capture($token), true);

--- a/src/Payum/Core/Gateway.php
+++ b/src/Payum/Core/Gateway.php
@@ -16,11 +16,18 @@ use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
 use Payum\Core\Handler\Context as HandlerContext;
 use Payum\Core\Handler\HandlerInterface;
 use Payum\Core\Handler\HandlerMap;
+use Payum\Core\Legacy\RequestToCommand;
+use Payum\Core\Legacy\ResultToReply;
+use Payum\Core\Legacy\StatusMarker;
 use Payum\Core\Middleware\MiddlewareCollection;
 use Payum\Core\Middleware\Pipeline;
+use Payum\Core\Model\PaymentStatuses;
 use Payum\Core\Model\SubjectInterface;
 use Payum\Core\Registry\StorageRegistryInterface;
+use Payum\Core\Reply\Base;
 use Payum\Core\Reply\ReplyInterface;
+use Payum\Core\Request\Generic;
+use Payum\Core\Request\GetStatusInterface;
 use Payum\Core\Result\Result;
 use Payum\Core\Security\GenericTokenFactoryInterface;
 use Psr\Container\ContainerExceptionInterface;
@@ -144,6 +151,13 @@ class Gateway implements GatewayInterface
             __METHOD__,
             self::class
         );
+
+        // A gateway built from handlers has no actions to find, so a 1.x request would report itself
+        // unsupported. Translate instead: an application should not break because a gateway package it
+        // depends on moved to handlers.
+        if ($this->handlerMap instanceof HandlerMap && ! $this->findActionSupported($request)) {
+            return $this->executeThroughHandlers($request, $catchReply);
+        }
 
         $context = new Context($this, $request, $this->stack);
 
@@ -400,10 +414,90 @@ class Gateway implements GatewayInterface
     }
 
     /**
-     * @param CommandInterface<Result> $command
-     *
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
+     */
+    /**
+     * Answers a 1.x request with the handler that means the same thing.
+     *
+     * Throws the matching reply when the handler decided the customer has somewhere to be, which is how a
+     * 1.x caller expects to hear about it.
+     */
+    private function executeThroughHandlers(object $request, bool $catchReply): ?Base
+    {
+        if ($request instanceof GetStatusInterface) {
+            $this->answerStatus($request);
+
+            return null;
+        }
+
+        $subject = $this->resolveSubjectOf($request);
+        $command = RequestToCommand::translate($request, $subject);
+
+        if (! $command instanceof CommandInterface || ! $this->supportsCommand($command::class)) {
+            throw RequestNotSupportedException::create($request);
+        }
+
+        $reply = ResultToReply::translate($this->dispatch($command));
+
+        if (! $reply instanceof Base) {
+            return null;
+        }
+
+        if ($catchReply) {
+            return $reply;
+        }
+
+        throw $reply;
+    }
+
+    /**
+     * A gateway built from handlers has no status action. It has something better: the status recorded
+     * after every command, which is what this reads.
+     *
+     * A subject that tracks no status leaves the request marked unknown, since nobody knows.
+     */
+    private function answerStatus(GetStatusInterface $request): void
+    {
+        $subject = $this->resolveSubjectOf($request);
+
+        if ($subject instanceof SubjectInterface) {
+            // 1.x actions do this, and it is what makes getFirstModel() return the payment rather than
+            // the token it arrived on -- which Payum::done() relies on.
+            $request->setModel($subject);
+        }
+
+        StatusMarker::mark($request, $subject instanceof SubjectInterface ? PaymentStatuses::of($subject) : null);
+    }
+
+    /**
+     * The subject a 1.x request is about, from the model it carries or the token it arrived on.
+     */
+    private function resolveSubjectOf(object $request): ?SubjectInterface
+    {
+        if (! $request instanceof Generic) {
+            return null;
+        }
+
+        if (($model = $request->getFirstModel()) instanceof SubjectInterface) {
+            return $model;
+        }
+
+        $identity = $request->getToken()?->getDetails();
+
+        if (null === $identity || ! $this->container->has(StorageRegistryInterface::class)) {
+            return null;
+        }
+
+        $model = $this->container->get(StorageRegistryInterface::class)
+            ->getStorage($identity->getClass())
+            ->find($identity);
+
+        return $model instanceof SubjectInterface ? $model : null;
+    }
+
+    /**
+     * @param CommandInterface<Result> $command
      */
     private function resolveSubject(CommandInterface $command): ?SubjectInterface
     {

--- a/src/Payum/Core/Legacy/RequestToCommand.php
+++ b/src/Payum/Core/Legacy/RequestToCommand.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Legacy;
+
+use Payum\Core\Command\AuthorizeCommand;
+use Payum\Core\Command\CancelCommand;
+use Payum\Core\Command\CaptureCommand;
+use Payum\Core\Command\CommandInterface;
+use Payum\Core\Command\PayoutCommand;
+use Payum\Core\Command\RefundCommand;
+use Payum\Core\Command\SyncCommand;
+use Payum\Core\Model\PaymentInterface;
+use Payum\Core\Model\PayoutInterface;
+use Payum\Core\Model\SubjectInterface;
+use Payum\Core\Request\Authorize;
+use Payum\Core\Request\Cancel;
+use Payum\Core\Request\Capture;
+use Payum\Core\Request\Generic;
+use Payum\Core\Request\Payout;
+use Payum\Core\Request\Refund;
+use Payum\Core\Request\Sync;
+use Payum\Core\Result\Result;
+use Payum\Core\Security\TokenInterface;
+
+/**
+ * Turns a 1.x request into the command that means the same thing.
+ *
+ * What lets an application keep calling execute(new Capture($token)) against a gateway that has been
+ * ported to handlers. Gateway packages release on their own schedule, so an application should not break
+ * because one of its dependencies moved on.
+ *
+ * @deprecated since 2.0, removed in 3.0 along with the requests it translates.
+ */
+final class RequestToCommand
+{
+    /**
+     * Null when nothing means the same thing, or when there is nothing usable to point a command at. The
+     * caller then behaves as it did before, which is to say it reports the request as unsupported.
+     *
+     * @param SubjectInterface|null $subject what the request resolves to, when the caller has already
+     *                                       looked it up from a token
+     *
+     * @return CommandInterface<Result>|null
+     */
+    public static function translate(object $request, ?SubjectInterface $subject = null): ?CommandInterface
+    {
+        if (! $request instanceof Generic) {
+            return null;
+        }
+
+        $token = $request->getToken();
+        $subject ??= $request->getFirstModel() instanceof SubjectInterface ? $request->getFirstModel() : null;
+
+        $payment = $subject instanceof PaymentInterface ? $subject : null;
+        $payout = $subject instanceof PayoutInterface ? $subject : null;
+
+        return match (true) {
+            $request instanceof Capture => match (true) {
+                $token instanceof TokenInterface => CaptureCommand::forToken($token),
+                $payment instanceof PaymentInterface => CaptureCommand::forPayment($payment),
+                default => null,
+            },
+            $request instanceof Authorize => match (true) {
+                $token instanceof TokenInterface => AuthorizeCommand::forToken($token),
+                $payment instanceof PaymentInterface => AuthorizeCommand::forPayment($payment),
+                default => null,
+            },
+            $request instanceof Refund => match (true) {
+                $token instanceof TokenInterface => RefundCommand::forToken($token),
+                $payment instanceof PaymentInterface => RefundCommand::forPayment($payment),
+                default => null,
+            },
+            // Cancel and Sync take either, because cancelling and refreshing mean the same thing
+            // whatever they are pointed at.
+            $request instanceof Cancel => match (true) {
+                $token instanceof TokenInterface => CancelCommand::forToken($token),
+                $payout instanceof PayoutInterface => CancelCommand::forPayout($payout),
+                $payment instanceof PaymentInterface => CancelCommand::forPayment($payment),
+                default => null,
+            },
+            $request instanceof Sync => match (true) {
+                $token instanceof TokenInterface => SyncCommand::forToken($token),
+                $payout instanceof PayoutInterface => SyncCommand::forPayout($payout),
+                $payment instanceof PaymentInterface => SyncCommand::forPayment($payment),
+                default => null,
+            },
+            $request instanceof Payout => match (true) {
+                $token instanceof TokenInterface => PayoutCommand::forToken($token),
+                $payout instanceof PayoutInterface => PayoutCommand::forPayout($payout),
+                default => null,
+            },
+            default => null,
+        };
+    }
+}

--- a/src/Payum/Core/Legacy/ResultToReply.php
+++ b/src/Payum/Core/Legacy/ResultToReply.php
@@ -8,6 +8,7 @@ use Payum\Core\Exception\LogicException;
 use Payum\Core\Reply\Base;
 use Payum\Core\Reply\HttpPostRedirect;
 use Payum\Core\Reply\HttpRedirect;
+use Payum\Core\Result\NextAction;
 use Payum\Core\Result\NextAction\PostRedirect;
 use Payum\Core\Result\NextAction\Redirect;
 use Payum\Core\Result\Result;
@@ -29,7 +30,7 @@ final class ResultToReply
         $next = $result->next;
 
         return match (true) {
-            null === $next => null,
+            ! $next instanceof NextAction => null,
             $next instanceof Redirect => new HttpRedirect($next->url, $next->statusCode, $next->headers),
             $next instanceof PostRedirect => new HttpPostRedirect($next->url, $next->fields),
             // Rendering, 3-D Secure and polling have no reply to become. A 1.x caller has nowhere to put

--- a/src/Payum/Core/Legacy/ResultToReply.php
+++ b/src/Payum/Core/Legacy/ResultToReply.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Legacy;
+
+use Payum\Core\Exception\LogicException;
+use Payum\Core\Reply\Base;
+use Payum\Core\Reply\HttpPostRedirect;
+use Payum\Core\Reply\HttpRedirect;
+use Payum\Core\Result\NextAction\PostRedirect;
+use Payum\Core\Result\NextAction\Redirect;
+use Payum\Core\Result\Result;
+use function sprintf;
+
+/**
+ * Turns what a handler decided into the reply a 1.x caller is waiting to catch.
+ *
+ * @deprecated since 2.0, removed in 3.0 along with the replies it produces.
+ */
+final class ResultToReply
+{
+    /**
+     * Null when the operation is finished and there is nothing for the caller to act on, which is the
+     * same as a 1.x action returning without throwing.
+     */
+    public static function translate(Result $result): ?Base
+    {
+        $next = $result->next;
+
+        return match (true) {
+            null === $next => null,
+            $next instanceof Redirect => new HttpRedirect($next->url, $next->statusCode, $next->headers),
+            $next instanceof PostRedirect => new HttpPostRedirect($next->url, $next->fields),
+            // Rendering, 3-D Secure and polling have no reply to become. A 1.x caller has nowhere to put
+            // them, and inventing something would report the payment as finished when it is not.
+            default => throw new LogicException(sprintf(
+                '%s has no 1.x reply to become. The gateway needs a caller that acts on a %s.',
+                $next::class,
+                Result::class,
+            )),
+        };
+    }
+}

--- a/src/Payum/Core/Legacy/StatusMarker.php
+++ b/src/Payum/Core/Legacy/StatusMarker.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Legacy;
+
+use Payum\Core\Request\GetStatusInterface;
+use Payum\Core\Result\PaymentStatus;
+
+/**
+ * Marks a 1.x status request from a recorded status.
+ *
+ * @deprecated since 2.0, removed in 3.0 along with the requests it marks.
+ */
+final class StatusMarker
+{
+    /**
+     * A null status means the subject does not track one, so nobody knows -- which is what markUnknown
+     * means, and is honest rather than guessing at New.
+     *
+     * PartiallyRefunded has no 1.x equivalent and becomes refunded, which is what 1.x would have said
+     * about the same payment.
+     */
+    public static function mark(GetStatusInterface $request, ?PaymentStatus $status): void
+    {
+        match ($status) {
+            PaymentStatus::New => $request->markNew(),
+            PaymentStatus::Pending => $request->markPending(),
+            PaymentStatus::Authorized => $request->markAuthorized(),
+            PaymentStatus::Captured => $request->markCaptured(),
+            PaymentStatus::Refunded, PaymentStatus::PartiallyRefunded => $request->markRefunded(),
+            PaymentStatus::PaidOut => $request->markPayedout(),
+            PaymentStatus::Canceled => $request->markCanceled(),
+            PaymentStatus::Failed => $request->markFailed(),
+            PaymentStatus::Expired => $request->markExpired(),
+            PaymentStatus::Suspended => $request->markSuspended(),
+            default => $request->markUnknown(),
+        };
+    }
+}

--- a/src/Payum/Core/Tests/LegacyRequestTest.php
+++ b/src/Payum/Core/Tests/LegacyRequestTest.php
@@ -14,6 +14,7 @@ use Payum\Core\Handler\CancelHandlerInterface;
 use Payum\Core\Handler\CaptureHandlerInterface;
 use Payum\Core\Handler\Context;
 use Payum\Core\Metadata\Logo;
+use Payum\Core\Metadata\Logo\Url;
 use Payum\Core\Model\Payment;
 use Payum\Core\Model\StatusAwareInterface;
 use Payum\Core\Payum;
@@ -29,6 +30,7 @@ use Payum\Core\Result\CaptureResult;
 use Payum\Core\Result\NextAction\Redirect;
 use Payum\Core\Result\PaymentStatus;
 use Payum\Core\Security\TokenInterface;
+use Payum\Core\Storage\FilesystemStorage;
 use Payum\Core\Storage\StorageInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -165,7 +167,7 @@ final class LegacyRequestTest extends TestCase
     {
         return (new PayumBuilder())
             ->addDefaultStorages()
-            ->addStorage(LegacyTrackedPayment::class, new \Payum\Core\Storage\FilesystemStorage(
+            ->addStorage(LegacyTrackedPayment::class, new FilesystemStorage(
                 sys_get_temp_dir(),
                 LegacyTrackedPayment::class,
                 'number',
@@ -197,7 +199,7 @@ final class LegacyGateway implements PaymentGateway
 
     public function logo(): Logo
     {
-        return Logo\Url::create('https://acme.test/logo.svg');
+        return Url::create('https://acme.test/logo.svg');
     }
 
     public function name(): string

--- a/src/Payum/Core/Tests/LegacyRequestTest.php
+++ b/src/Payum/Core/Tests/LegacyRequestTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests;
+
+use League\Uri\Uri;
+use Payum\Core\Command\CancelCommand;
+use Payum\Core\Command\CaptureCommand;
+use Payum\Core\Config\GatewayConfig;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
+use Payum\Core\Handler\CancelHandlerInterface;
+use Payum\Core\Handler\CaptureHandlerInterface;
+use Payum\Core\Handler\Context;
+use Payum\Core\Metadata\Logo;
+use Payum\Core\Model\Payment;
+use Payum\Core\Model\StatusAwareInterface;
+use Payum\Core\Payum;
+use Payum\Core\PayumBuilder;
+use Payum\Core\Registry\StorageRegistryInterface;
+use Payum\Core\Reply\HttpRedirect;
+use Payum\Core\Request\Cancel;
+use Payum\Core\Request\Capture;
+use Payum\Core\Request\GetHumanStatus;
+use Payum\Core\Request\Notify;
+use Payum\Core\Result\CancelResult;
+use Payum\Core\Result\CaptureResult;
+use Payum\Core\Result\NextAction\Redirect;
+use Payum\Core\Result\PaymentStatus;
+use Payum\Core\Security\TokenInterface;
+use Payum\Core\Storage\StorageInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A gateway package moves to handlers on its own schedule. An application calling execute(new Capture())
+ * should not break because of it.
+ */
+final class LegacyRequestTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_SERVER = [
+            'HTTP_HOST' => 'payum.dev',
+        ];
+
+        LegacyCaptureHandler::$next = null;
+        LegacyCaptureHandler::$dispatched = false;
+    }
+
+    public function testShouldAnswerAOneXCaptureWithTheHandler(): void
+    {
+        $gateway = $this->buildPayum()->getGateway('acme');
+
+        $gateway->execute(new Capture($this->buildPayment()));
+
+        $this->assertTrue(LegacyCaptureHandler::$dispatched);
+    }
+
+    public function testShouldThrowTheReplyMatchingWhatTheHandlerDecided(): void
+    {
+        LegacyCaptureHandler::$next = new Redirect('https://acme.test/checkout/1');
+
+        $gateway = $this->buildPayum()->getGateway('acme');
+
+        try {
+            $gateway->execute(new Capture($this->buildPayment()));
+
+            $this->fail('Expected a reply to be thrown.');
+        } catch (HttpRedirect $reply) {
+            $this->assertSame('https://acme.test/checkout/1', $reply->getUrl());
+        }
+    }
+
+    public function testShouldReturnTheReplyWhenTheCallerAsksToCatchIt(): void
+    {
+        LegacyCaptureHandler::$next = new Redirect('https://acme.test/checkout/1');
+
+        $gateway = $this->buildPayum()->getGateway('acme');
+
+        $reply = $gateway->execute(new Capture($this->buildPayment()), true);
+
+        $this->assertInstanceOf(HttpRedirect::class, $reply);
+    }
+
+    public function testShouldTranslateEachRequestToItsOwnCommand(): void
+    {
+        $gateway = $this->buildPayum()->getGateway('acme');
+
+        $gateway->execute(new Cancel($this->buildPayment()));
+
+        $this->assertTrue(LegacyCancelHandler::$dispatched);
+    }
+
+    public function testShouldReportARequestWithNoEquivalentAsUnsupported(): void
+    {
+        $gateway = $this->buildPayum()->getGateway('acme');
+
+        // Notify has no command behind it yet, so nothing changes for it.
+        $this->expectException(RequestNotSupportedException::class);
+
+        $gateway->execute(new Notify($this->buildPayment()));
+    }
+
+    public function testShouldAnswerAOneXStatusRequestFromTheRecordedStatus(): void
+    {
+        $payment = new LegacyTrackedPayment();
+        $payment->setStatus(PaymentStatus::Captured);
+
+        $gateway = $this->buildPayum()->getGateway('acme');
+
+        $gateway->execute($status = new GetHumanStatus($payment));
+
+        $this->assertTrue($status->isCaptured());
+    }
+
+    public function testShouldSayUnknownForASubjectThatTracksNoStatus(): void
+    {
+        $gateway = $this->buildPayum()->getGateway('acme');
+
+        $gateway->execute($status = new GetHumanStatus($this->buildPayment()));
+
+        // Nobody knows, which is not the same as new.
+        $this->assertTrue($status->isUnknown());
+    }
+
+    public function testDoneShouldWorkAgainstAGatewayBuiltFromHandlers(): void
+    {
+        $payum = $this->buildPayum();
+
+        /** @var LegacyTrackedPayment $payment */
+        $payment = $payum->getStorage(LegacyTrackedPayment::class)->create();
+        $payment->setNumber(uniqid());
+        $payment->setStatus(PaymentStatus::Captured);
+        $payum->getStorage(LegacyTrackedPayment::class)->update($payment);
+
+        $token = $payum->getTokenFactory()->createCaptureToken('acme', $payment, 'done.php');
+
+        // The plain-php verifier checks the current url against the token's target, from globals.
+        $_SERVER['REQUEST_URI'] = $token->getTargetUrl();
+
+        $done = $payum->done([
+            'payum_token' => $token->getHash(),
+        ]);
+
+        // Broken before this: done() dispatches GetHumanStatus, which a handler gateway had no action for.
+        $this->assertInstanceOf(LegacyTrackedPayment::class, $done);
+        $this->assertSame($payment->getNumber(), $done->getNumber());
+    }
+
+    private function buildPayment(): Payment
+    {
+        $payment = new Payment();
+        $payment->setNumber(uniqid());
+        $payment->setTotalAmount(123);
+        $payment->setCurrencyCode('EUR');
+
+        return $payment;
+    }
+
+    /**
+     * @return Payum<StorageRegistryInterface<StorageInterface<TokenInterface>>>
+     */
+    private function buildPayum(): Payum
+    {
+        return (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addStorage(LegacyTrackedPayment::class, new \Payum\Core\Storage\FilesystemStorage(
+                sys_get_temp_dir(),
+                LegacyTrackedPayment::class,
+                'number',
+            ))
+            ->registerGateway('acme', new LegacyConfig())
+            ->getPayum();
+    }
+}
+
+final class LegacyConfig implements GatewayConfig
+{
+    public function getGatewayClass(): string
+    {
+        return LegacyGateway::class;
+    }
+}
+
+final class LegacyGateway implements PaymentGateway
+{
+    public function configClass(): string
+    {
+        return LegacyConfig::class;
+    }
+
+    public function handlers(): array
+    {
+        return [LegacyCaptureHandler::class, LegacyCancelHandler::class];
+    }
+
+    public function logo(): Logo
+    {
+        return Logo\Url::create('https://acme.test/logo.svg');
+    }
+
+    public function name(): string
+    {
+        return 'Acme';
+    }
+
+    public function websiteUrl(): Uri
+    {
+        return Uri::new('https://acme.test');
+    }
+}
+
+final class LegacyCaptureHandler implements CaptureHandlerInterface
+{
+    public static ?Redirect $next = null;
+
+    public static bool $dispatched = false;
+
+    public function handle(CaptureCommand $command, Context $context): CaptureResult
+    {
+        self::$dispatched = true;
+
+        return self::$next instanceof Redirect
+            ? CaptureResult::pending(self::$next)
+            : CaptureResult::captured('txn_1');
+    }
+}
+
+final class LegacyCancelHandler implements CancelHandlerInterface
+{
+    public static bool $dispatched = false;
+
+    public function handle(CancelCommand $command, Context $context): CancelResult
+    {
+        self::$dispatched = true;
+
+        return CancelResult::canceled();
+    }
+}
+
+class LegacyTrackedPayment extends Payment implements StatusAwareInterface
+{
+    private PaymentStatus $status = PaymentStatus::New;
+
+    public function getStatus(): PaymentStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(PaymentStatus $status): void
+    {
+        $this->status = $status;
+    }
+}

--- a/src/Payum/Core/Tests/SyncTest.php
+++ b/src/Payum/Core/Tests/SyncTest.php
@@ -14,10 +14,10 @@ use Payum\Core\Handler\Context;
 use Payum\Core\Handler\SyncHandlerInterface;
 use Payum\Core\Metadata\Logo;
 use Payum\Core\Metadata\Logo\Url;
-use Payum\Core\Model\HasPaymentStatus;
 use Payum\Core\Model\Payment;
 use Payum\Core\Model\PaymentInterface;
 use Payum\Core\Model\Payout;
+use Payum\Core\Model\StatusAwareInterface;
 use Payum\Core\Payum;
 use Payum\Core\PayumBuilder;
 use Payum\Core\Registry\StorageRegistryInterface;
@@ -163,7 +163,7 @@ final class AcmeSyncHandler implements SyncHandlerInterface
     }
 }
 
-class TrackedSyncPayment extends Payment implements HasPaymentStatus
+class TrackedSyncPayment extends Payment implements StatusAwareInterface
 {
     private PaymentStatus $status = PaymentStatus::New;
 


### PR DESCRIPTION
A gateway package releases on its own schedule. When one ports to handlers it has no actions left, so an application still calling `execute(new Capture($token))` was told the request was unsupported — having changed nothing itself.

It now works.

```php
// unchanged, still works after the gateway ports to handlers
$gateway = $payum->getGateway($token->getGatewayName());

try {
    $gateway->execute(new Capture($token));
} catch (HttpRedirect $reply) {
    header('Location: ' . $reply->getUrl());
}
```

The request is translated to the command that means the same thing, run through the handler, and answered the way 1.x expects — the matching reply thrown, or returned when the caller passed `$catchReply`.

## What translates

| 1.x request | Answered by |
| :--- | :--- |
| `Capture`, `Authorize`, `Refund` | the matching handler |
| `Cancel`, `Sync` | the matching handler, for a payment or a payout |
| `Payout` | the payout handler |
| `GetHumanStatus`, `GetBinaryStatus` | the status recorded on the subject |
| `Notify` | nothing yet — webhooks are their own piece of work |

Only when no action supports the request, so a gateway that still has actions is untouched.

## Status requests

A handler gateway has no status action. It has something better: the status recorded after every command.

```php
$gateway->execute($status = new GetHumanStatus($token));

$status->isCaptured();
```

Answered from `StatusAwareInterface`, so a subject that tracks no status is marked **unknown** rather than guessed at as new.

## Fixes `Payum::done()`

`done()` dispatches `GetHumanStatus`, so it had been failing against handler gateways since they were introduced. It needed no change of its own — setting the model back on the request is what makes `getFirstModel()` return the payment rather than the token it arrived on, which is what the 1.x actions did.

## Two limits

`Notify` has no command behind it yet.

A handler returning `RenderTemplate`, `Challenge` or `Poll` has no 1.x reply to become, so those throw rather than reporting the payment finished when it is not. A gateway using them needs a caller that acts on a `Result`.

## Also

Fixes `SyncTest`, left referencing `HasPaymentStatus` by the order the rename and the sync command landed in — `2.x` currently fatals on it.
