### PR TITLE
Support ListableContainerInterface for autowiring services

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -21,6 +21,17 @@
   * The `Payum\Core\Bridge\Httplug\HttplugClient` is deprecated and will be removed in 3.0. Use PSR-18 HTTP Client instead
   * The `payum.http_client` config option will return an instance of `Psr\Http\Client\ClientInterface` in a future version.
     * Change all type-hints from `Payum\Core\HttpClientInterface` or `Payum\Core\Bridge\Httplug\HttplugClient` to `Psr\Http\Client\ClientInterface`
+* Gateways are now built with a dependency injection container (php-di). See [docs/di](docs/di/README.md).
+  * A gateway factory should implement `Payum\Core\DI\ContainerConfiguration` and define its services in
+    `configureContainer()`, its actions in `getActions()` and its extensions in `getExtensions()`.
+  * `Payum\Core\GatewayFactoryInterface::create()` and `createConfig()`, `Payum\Core\GatewayFactory::populateConfig()`
+    and the `payum.action.*` / `payum.extension.*` config options are deprecated. A gateway factory which does not
+    implement `Payum\Core\DI\ContainerConfiguration` still works, but triggers a deprecation.
+  * `Payum\Core\Bridge\Spl\ArrayObject` as a service is deprecated. Type-hint `Psr\Container\ContainerInterface` instead.
+  * An application can hand its own PSR-11 container to `Payum\Core\PayumBuilder::setGlobalContainer()`, or register
+    single services with `Payum\Core\PayumBuilder::addGlobalService()`. Implement
+    `Payum\Core\DI\ListableContainerInterface` on your container to have its services autowired into gateway actions.
+* The whole `Payum\Core\Bridge\Symfony` namespace is deprecated. Use the same classes from `payum/payum-bundle` instead.
 
 ## 1.5.0
 

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
         "nyholm/psr7": "^1.8"
     },
     "replace": {
-        "payum/core": "^1",
+        "payum/core": "^1 || ^2",
         "payum/paypal-express-checkout-nvp": "self.version",
         "payum/paypal-pro-checkout-nvp": "self.version",
         "payum/paypal-rest": "self.version",

--- a/docs/di/customization.md
+++ b/docs/di/customization.md
@@ -206,7 +206,9 @@ Pass a PHP-DI container and everything in it — including `'my.custom.service'`
 gateway's actions.
 
 Most framework containers cannot list what they hold, so Payum has no way to know which ids to make
-injectable. Register those with `addGlobalService()`, which works alongside your container:
+injectable. There are two ways around that.
+
+Register the ones you need with `addGlobalService()`, which works alongside your container:
 
 ```php
 <?php
@@ -220,6 +222,37 @@ $payum = (new PayumBuilder())
     // ... add gateways
     ->getPayum();
 ```
+
+Or, when your container is able to report its entries, let it say so by implementing
+`Payum\Core\DI\ListableContainerInterface`. Payum then makes every one of them injectable, without
+you having to list them one by one:
+
+```php
+<?php
+
+use Payum\Core\DI\ListableContainerInterface;
+
+class MyContainer implements ListableContainerInterface
+{
+    public function get(string $id): mixed { /* ... */ }
+
+    public function has(string $id): bool { /* ... */ }
+
+    public function getKnownEntryNames(): array
+    {
+        return ['logger', 'my.custom.service'];
+    }
+}
+
+$payum = (new PayumBuilder())
+    ->setGlobalContainer(new MyContainer())
+
+    // ... add gateways
+    ->getPayum();
+```
+
+A container which implements neither stays fully usable - its services are still resolved through the
+gateway containers - they just cannot be autowired.
 
 ## Accessing Services
 

--- a/docs/di/framework-integration.md
+++ b/docs/di/framework-integration.md
@@ -142,6 +142,43 @@ $payum = (new PayumBuilder())
     ->getPayum();
 ```
 
+Services reached this way are resolvable from a gateway, but they cannot be autowired into the
+constructor of an action: Payum only turns the entries of a container into gateway container
+definitions when the container can report them. Implement
+`Payum\Core\DI\ListableContainerInterface` on the adapter to get that. A Symfony `ServiceLocator`
+is a good fit, since it both narrows what Payum can see and lists what it holds:
+
+```php
+<?php
+
+namespace App\DependencyInjection;
+
+use Payum\Core\DI\ListableContainerInterface;
+use Symfony\Contracts\Service\ServiceProviderInterface;
+
+class PayumContainerAdapter implements ListableContainerInterface
+{
+    public function __construct(
+        private ServiceProviderInterface $locator
+    ) {}
+
+    public function get(string $id): mixed
+    {
+        return $this->locator->get($id);
+    }
+
+    public function has(string $id): bool
+    {
+        return $this->locator->has($id);
+    }
+
+    public function getKnownEntryNames(): array
+    {
+        return array_keys($this->locator->getProvidedServices());
+    }
+}
+```
+
 For most applications the `addGlobalService()` approach shown above is simpler and does not require you to
 re-declare Payum's own services.
 

--- a/src/Payum/Core/Bridge/Spl/ArrayObject.php
+++ b/src/Payum/Core/Bridge/Spl/ArrayObject.php
@@ -193,10 +193,13 @@ class ArrayObject extends \ArrayObject
     }
 
     /**
-     * @param array<string, mixed>|ArrayObject<string, mixed>|\ArrayObject<string, mixed>|null $input
+     * Accepts everything the constructor does, so that a model which is an ArrayAccess of its own - a
+     * Payum\Core\Model\ArrayObject for instance - can be wrapped as well.
+     *
+     * @param array<string, mixed>|ArrayObject<string, mixed>|\ArrayObject<string, mixed>|ArrayAccess<string, mixed>|Traversable<string, mixed>|null $input
      * @return ArrayObject<string, mixed>
      */
-    public static function ensureArrayObject(array | self | \ArrayObject | null $input): self
+    public static function ensureArrayObject(array | self | \ArrayObject | ArrayAccess | Traversable | null $input): self
     {
         return $input instanceof static ? $input : new self($input);
     }

--- a/src/Payum/Core/DI/FallbackContainer.php
+++ b/src/Payum/Core/DI/FallbackContainer.php
@@ -56,7 +56,7 @@ final class FallbackContainer implements ListableContainerInterface
     private static function knownEntryNamesOf(ContainerInterface $container): array
     {
         if ($container instanceof ListableContainerInterface) {
-            return array_values($container->getKnownEntryNames());
+            return $container->getKnownEntryNames();
         }
 
         if ($container instanceof Container) {

--- a/src/Payum/Core/DI/FallbackContainer.php
+++ b/src/Payum/Core/DI/FallbackContainer.php
@@ -15,7 +15,7 @@ use function array_values;
  * This lets an application hand its own container to Payum without having to re-declare every service
  * Payum needs: whatever the application defines wins, the rest comes from Payum's own defaults.
  */
-final class FallbackContainer implements ContainerInterface
+final class FallbackContainer implements ListableContainerInterface
 {
     public function __construct(
         private ContainerInterface $primary,
@@ -36,8 +36,9 @@ final class FallbackContainer implements ContainerInterface
     }
 
     /**
-     * The ids of both containers, as far as they are able to report them. A container which cannot
-     * enumerate its entries contributes nothing.
+     * The ids of both containers, as far as they are able to report them. Only a container which is
+     * able to enumerate its entries - a PHP-DI container or a ListableContainerInterface - contributes
+     * anything here, any other one contributes nothing.
      *
      * @return list<string>
      */
@@ -54,8 +55,8 @@ final class FallbackContainer implements ContainerInterface
      */
     private static function knownEntryNamesOf(ContainerInterface $container): array
     {
-        if ($container instanceof self) {
-            return $container->getKnownEntryNames();
+        if ($container instanceof ListableContainerInterface) {
+            return array_values($container->getKnownEntryNames());
         }
 
         if ($container instanceof Container) {

--- a/src/Payum/Core/DI/ListableContainerInterface.php
+++ b/src/Payum/Core/DI/ListableContainerInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Payum\Core\DI;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * A container which is able to tell which entries it holds.
+ *
+ * PSR-11 has no way of listing the entries of a container, so Payum can only turn the services of a
+ * container it is given into definitions of the gateway containers when that container is able to
+ * report them. Implement this interface to have the services of your own container - a framework
+ * container for instance - injected into the actions of a gateway.
+ *
+ * @see FallbackContainer
+ */
+interface ListableContainerInterface extends ContainerInterface
+{
+    /**
+     * The ids of every entry this container can resolve.
+     *
+     * @return list<string>
+     */
+    public function getKnownEntryNames(): array;
+}

--- a/src/Payum/Core/PayumBuilder.php
+++ b/src/Payum/Core/PayumBuilder.php
@@ -21,6 +21,7 @@ use Payum\Core\Config\GatewayConfig;
 use Payum\Core\DI\ContainerConfiguration;
 use Payum\Core\DI\CreatesGateway;
 use Payum\Core\DI\FallbackContainer;
+use Payum\Core\DI\ListableContainerInterface;
 use Payum\Core\Exception\InvalidArgumentException;
 use Payum\Core\Extension\GenericTokenFactoryExtension;
 use Payum\Core\Extension\StorageExtension;
@@ -680,7 +681,7 @@ class PayumBuilder
     {
         $names = [];
 
-        if ($container instanceof FallbackContainer || $container instanceof Container) {
+        if ($container instanceof ListableContainerInterface || $container instanceof Container) {
             $names = $container->getKnownEntryNames();
         }
 

--- a/src/Payum/Core/Tests/Bridge/Spl/ArrayObjectTest.php
+++ b/src/Payum/Core/Tests/Bridge/Spl/ArrayObjectTest.php
@@ -24,6 +24,36 @@ final class ArrayObjectTest extends TestCase
         $this->assertTrue($rc->isSubclassOf(\ArrayObject::class));
     }
 
+    public function testEnsureArrayObjectShouldReturnTheGivenArrayObjectAsIs(): void
+    {
+        $array = new ArrayObject([
+            'foo' => 'fooVal',
+        ]);
+
+        $this->assertSame($array, ArrayObject::ensureArrayObject($array));
+    }
+
+    public function testEnsureArrayObjectShouldWrapAnArray(): void
+    {
+        $array = ArrayObject::ensureArrayObject([
+            'foo' => 'fooVal',
+        ]);
+
+        $this->assertInstanceOf(ArrayObject::class, $array);
+        $this->assertSame('fooVal', $array['foo']);
+    }
+
+    public function testEnsureArrayObjectShouldWrapAModelWhichIsAnArrayAccessOfItsOwn(): void
+    {
+        $model = new \Payum\Core\Model\ArrayObject();
+        $model['foo'] = 'fooVal';
+
+        $array = ArrayObject::ensureArrayObject($model);
+
+        $this->assertInstanceOf(ArrayObject::class, $array);
+        $this->assertSame('fooVal', $array['foo']);
+    }
+
     public function testShouldAllowGetPreviouslySetValueByIndex(): void
     {
         $array = new ArrayObject();

--- a/src/Payum/Core/Tests/DI/FallbackContainerTest.php
+++ b/src/Payum/Core/Tests/DI/FallbackContainerTest.php
@@ -7,6 +7,7 @@ namespace Payum\Core\Tests\DI;
 use DI\Container;
 use DI\ContainerBuilder;
 use Payum\Core\DI\FallbackContainer;
+use Payum\Core\DI\ListableContainerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -20,6 +21,13 @@ final class FallbackContainerTest extends TestCase
         $rc = new ReflectionClass(FallbackContainer::class);
 
         $this->assertTrue($rc->implementsInterface(ContainerInterface::class));
+    }
+
+    public function testShouldImplementListableContainerInterface(): void
+    {
+        $rc = new ReflectionClass(FallbackContainer::class);
+
+        $this->assertTrue($rc->implementsInterface(ListableContainerInterface::class));
     }
 
     public function testShouldBeFinal(): void
@@ -201,6 +209,38 @@ final class FallbackContainerTest extends TestCase
         $this->assertSame($expected, $container->get('foo'));
     }
 
+    public function testShouldReportTheKnownEntryNamesOfAListableContainer(): void
+    {
+        $container = new FallbackContainer(
+            new ListableContainerStub([
+                'foo' => 'fooVal',
+            ]),
+            $this->buildContainer([
+                'bar' => 'barVal',
+            ])
+        );
+
+        $names = $container->getKnownEntryNames();
+
+        $this->assertContains('foo', $names);
+        $this->assertContains('bar', $names);
+    }
+
+    public function testShouldResolveAServiceOfAListableContainer(): void
+    {
+        $expected = new stdClass();
+
+        $container = new FallbackContainer(
+            new ListableContainerStub([
+                'foo' => $expected,
+            ]),
+            $this->buildContainer()
+        );
+
+        $this->assertTrue($container->has('foo'));
+        $this->assertSame($expected, $container->get('foo'));
+    }
+
     /**
      * @param array<string, mixed> $definitions
      */
@@ -210,5 +250,34 @@ final class FallbackContainerTest extends TestCase
         $builder->addDefinitions($definitions);
 
         return $builder->build();
+    }
+}
+
+/**
+ * A container which is not a PHP-DI one but is able to report its entries.
+ */
+final class ListableContainerStub implements ListableContainerInterface
+{
+    /**
+     * @param array<string, mixed> $services
+     */
+    public function __construct(
+        private array $services = []
+    ) {
+    }
+
+    public function get(string $id): mixed
+    {
+        return $this->services[$id];
+    }
+
+    public function has(string $id): bool
+    {
+        return isset($this->services[$id]);
+    }
+
+    public function getKnownEntryNames(): array
+    {
+        return array_keys($this->services);
     }
 }

--- a/src/Payum/Core/Tests/DI/ListableContainerInterfaceTest.php
+++ b/src/Payum/Core/Tests/DI/ListableContainerInterfaceTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests\DI;
+
+use Payum\Core\DI\FallbackContainer;
+use Payum\Core\DI\ListableContainerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use ReflectionClass;
+use ReflectionNamedType;
+
+final class ListableContainerInterfaceTest extends TestCase
+{
+    public function testShouldBeInterface(): void
+    {
+        $rc = new ReflectionClass(ListableContainerInterface::class);
+
+        $this->assertTrue($rc->isInterface());
+    }
+
+    public function testShouldExtendContainerInterface(): void
+    {
+        $rc = new ReflectionClass(ListableContainerInterface::class);
+
+        $this->assertTrue($rc->implementsInterface(ContainerInterface::class));
+    }
+
+    public function testShouldDefineGetKnownEntryNamesMethodReturningArray(): void
+    {
+        $rc = new ReflectionClass(ListableContainerInterface::class);
+
+        $this->assertTrue($rc->hasMethod('getKnownEntryNames'));
+
+        $method = $rc->getMethod('getKnownEntryNames');
+
+        $this->assertTrue($method->isPublic());
+        $this->assertSame(0, $method->getNumberOfParameters());
+
+        $returnType = $method->getReturnType();
+
+        $this->assertInstanceOf(ReflectionNamedType::class, $returnType);
+        $this->assertSame('array', $returnType->getName());
+    }
+
+    public function testShouldBeImplementedByFallbackContainer(): void
+    {
+        $rc = new ReflectionClass(FallbackContainer::class);
+
+        $this->assertTrue($rc->implementsInterface(ListableContainerInterface::class));
+    }
+
+    public function testShouldAllowCustomImplementation(): void
+    {
+        $container = new class() implements ListableContainerInterface {
+            public function get(string $id): mixed
+            {
+                return 'fooVal';
+            }
+
+            public function has(string $id): bool
+            {
+                return 'foo' === $id;
+            }
+
+            public function getKnownEntryNames(): array
+            {
+                return ['foo'];
+            }
+        };
+
+        $this->assertInstanceOf(ContainerInterface::class, $container);
+        $this->assertSame(['foo'], $container->getKnownEntryNames());
+    }
+}

--- a/src/Payum/Core/Tests/PayumBuilderGlobalContainerTest.php
+++ b/src/Payum/Core/Tests/PayumBuilderGlobalContainerTest.php
@@ -13,6 +13,7 @@ use Payum\Core\Bridge\PlainPhp\Security\HttpRequestVerifier;
 use Payum\Core\CoreGatewayFactory;
 use Payum\Core\DI\ContainerConfiguration;
 use Payum\Core\DI\CreatesGateway;
+use Payum\Core\DI\ListableContainerInterface;
 use Payum\Core\Extension\StorageExtension;
 use Payum\Core\Gateway;
 use Payum\Core\GatewayFactoryInterface;
@@ -897,6 +898,75 @@ final class PayumBuilderGlobalContainerTest extends TestCase
         $this->assertInstanceOf(HttpRequestVerifier::class, $payum->getHttpRequestVerifier());
     }
 
+    /**
+     * A container which is not a PHP-DI one but is able to report its entries has those entries turned
+     * into definitions of the gateway containers, so that they can be autowired.
+     */
+    public function testShouldInjectAServiceOfAListablePresetContainerIntoAnAction(): void
+    {
+        $logger = new NullLogger();
+
+        $payum = (new PayumBuilder())
+            ->setGlobalContainer(new ListableContainer([
+                LoggerInterface::class => $logger,
+            ]))
+            ->addGatewayFactory('documented', new DocumentedGatewayFactory())
+            ->addGateway('documented', [
+                'factory' => 'documented',
+            ])
+            ->getPayum()
+        ;
+
+        $documentedAction = null;
+        foreach ($this->readAttribute($payum->getGateway('documented'), 'actions') as $action) {
+            if ($action instanceof DocumentedCaptureAction) {
+                $documentedAction = $action;
+            }
+        }
+
+        $this->assertInstanceOf(DocumentedCaptureAction::class, $documentedAction);
+        $this->assertSame($logger, $documentedAction->logger);
+    }
+
+    public function testShouldShareTheEntriesOfAListablePresetContainerWithTheGatewayContainer(): void
+    {
+        $service = new stdClass();
+
+        $factory = new ContainerConfigurationGatewayFactoryStub();
+
+        (new PayumBuilder())
+            ->setGlobalContainer(new ListableContainer([
+                'acme.service' => $service,
+            ]))
+            ->addGatewayFactory('acme_factory', $factory)
+            ->addGateway('acme', [
+                'factory' => 'acme_factory',
+            ])
+            ->getPayum()
+        ;
+
+        $this->assertTrue($factory->container->has('acme.service'));
+        $this->assertSame($service, $factory->container->get('acme.service'));
+    }
+
+    public function testShouldStillResolvePayumsOwnServicesWithAListablePresetContainer(): void
+    {
+        $factory = new ContainerConfigurationGatewayFactoryStub();
+
+        (new PayumBuilder())
+            ->setGlobalContainer(new ListableContainer())
+            ->addGatewayFactory('acme_factory', $factory)
+            ->addGateway('acme', [
+                'factory' => 'acme_factory',
+            ])
+            ->getPayum()
+        ;
+
+        $this->assertInstanceOf(StorageInterface::class, $factory->container->get('payum.security.token_storage'));
+        $this->assertInstanceOf(GenericTokenFactoryInterface::class, $factory->container->get(GenericTokenFactoryInterface::class));
+        $this->assertInstanceOf(ClientInterface::class, $factory->container->get(ClientInterface::class));
+    }
+
     public function testShouldStillSupportTheDeprecatedCreateApiOnADocumentedGatewayFactory(): void
     {
         $gateway = (new DocumentedGatewayFactory())->create([
@@ -1131,6 +1201,26 @@ class OpaqueContainer implements ContainerInterface
     public function has(string $id): bool
     {
         return isset($this->services[$id]);
+    }
+}
+
+/**
+ * A PSR-11 container which is not a PHP-DI one but is able to report the entries it holds.
+ */
+class ListableContainer extends OpaqueContainer implements ListableContainerInterface
+{
+    /**
+     * @param array<string, mixed> $services
+     */
+    public function __construct(
+        private array $services = []
+    ) {
+        parent::__construct($services);
+    }
+
+    public function getKnownEntryNames(): array
+    {
+        return array_keys($this->services);
     }
 }
 

--- a/src/Payum/Core/Tests/SyncTest.php
+++ b/src/Payum/Core/Tests/SyncTest.php
@@ -14,10 +14,10 @@ use Payum\Core\Handler\Context;
 use Payum\Core\Handler\SyncHandlerInterface;
 use Payum\Core\Metadata\Logo;
 use Payum\Core\Metadata\Logo\Url;
-use Payum\Core\Model\HasPaymentStatus;
 use Payum\Core\Model\Payment;
 use Payum\Core\Model\PaymentInterface;
 use Payum\Core\Model\Payout;
+use Payum\Core\Model\StatusAwareInterface;
 use Payum\Core\Payum;
 use Payum\Core\PayumBuilder;
 use Payum\Core\Registry\StorageRegistryInterface;
@@ -163,7 +163,7 @@ final class AcmeSyncHandler implements SyncHandlerInterface
     }
 }
 
-class TrackedSyncPayment extends Payment implements HasPaymentStatus
+class TrackedSyncPayment extends Payment implements StatusAwareInterface
 {
     private PaymentStatus $status = PaymentStatus::New;
 


### PR DESCRIPTION
## Summary
This PR introduces `ListableContainerInterface` to enable autowiring of services from custom PSR-11 containers that can report their entries. Previously, only PHP-DI containers could have their services automatically injected into gateway actions. Now, any container implementing this interface can participate in dependency injection.

## Key Changes

- **New Interface**: Added `Payum\Core\DI\ListableContainerInterface` extending `ContainerInterface` with a `getKnownEntryNames(): array` method to allow containers to report their available entries.

- **FallbackContainer Enhancement**: Updated `FallbackContainer` to implement `ListableContainerInterface` and aggregate known entry names from both the primary container (if it implements the interface) and the fallback PHP-DI container.

- **PayumBuilder Integration**: Modified `PayumBuilder` to recognize `ListableContainerInterface` implementations and register their services as definitions in gateway containers, enabling autowiring into action constructors.

- **ArrayObject Improvements**: Enhanced `ArrayObject::ensureArrayObject()` to accept any `ArrayAccess` or `Traversable` implementation, allowing it to wrap Payum's own `Model\ArrayObject`.

- **Documentation**: Added comprehensive examples in `docs/di/` showing how to implement `ListableContainerInterface` with framework containers (e.g., Symfony's `ServiceLocator`).

- **Tests**: Added extensive test coverage including:
  - `ListableContainerInterfaceTest` validating the interface contract
  - Tests in `PayumBuilderGlobalContainerTest` demonstrating autowiring with listable containers
  - Tests in `FallbackContainerTest` verifying service resolution and entry name aggregation
  - Tests in `ArrayObjectTest` for the enhanced `ensureArrayObject()` method

## Implementation Details

The solution maintains backward compatibility: containers that don't implement `ListableContainerInterface` continue to work through `FallbackContainer`, but their services cannot be autowired. Only containers that explicitly implement the interface have their entries turned into gateway container definitions.

The `getKnownEntryNames()` method is called during gateway factory initialization to populate the gateway's DI container with definitions for all known services, enabling constructor injection in actions.

https://claude.ai/code/session_01ARB2EkkjTiRA2WvJjgwteU