### PR TITLE
Force the split push so a diverged branch cannot wedge the workflow

### DIFF
--- a/bin/subtree-split
+++ b/bin/subtree-split
@@ -17,11 +17,15 @@ BRANCH="${1:-$(git rev-parse --abbrev-ref HEAD)}"
 SPLITSH_LITE="${SPLITSH_LITE:-./bin/splitsh-lite}"
 SUBSPLITS="$(dirname "$0")/subsplits"
 
+# The split repositories are generated from this one, so the split is the only
+# correct history they can have and anything else on the branch is stale. That
+# happens whenever this repository's history is rewritten or a branch is
+# renamed, which is why the push is forced rather than left to be rejected.
 function split()
 {
     # split_new_repo $1 $2
     SHA1=`$SPLITSH_LITE --prefix=$1 --origin=origin/$BRANCH`
-    git push $2 "$SHA1:refs/heads/$BRANCH"
+    git push $2 "$SHA1:refs/heads/$BRANCH" -f
 }
 
 function split_new_repo()


### PR DESCRIPTION
Fixes the Subtree Split failure on `2.x` ([run 31527139412](https://github.com/Payum/Payum/actions/runs/31527139412/job/93898127509)):

```
! [rejected]  334aff44 -> 2.x (fetch first)
error: failed to push some refs to 'github.com:Payum/Core.git'
```

## What happened

The workflow created `2.x` on the split repos from the split, and it was replaced by `master` two minutes later:

```
15:06:34  CreateEvent  ref=2.x     ← workflow pushed the split (334aff44)
15:08:08  DeleteEvent  ref=2.x
15:08:27  CreateEvent  ref=2.x     ← recreated from master
15:08:29  DeleteEvent  ref=master
```

So all 16 repos now have `2.x` at the old `master` tip from 2023-11-17, which is not an ancestor of the split. Every push since has been rejected, which is why nothing has been mirrored.

## Why the histories diverge

They agree up to `60e48ebd` "Remove deprecated Guzzle Bridge" and differ by exactly one commit. `Payum/Core` is representative — `cdbb5b7e...334aff44` is 89 ahead, 1 behind, and the one commit behind is the branch tip itself:

| | commit | subject |
|---|---|---|
| old `master` tip | `cdbb5b7e` | Remove all weak type checks |
| in the split | `a9608554` | Remove all weak type checks |

Same change, same author date, different SHA — the monorepo commit it is generated from was rewritten at some point, so its split no longer matches. **Nothing is lost by replacing the old tip**: the change is present in the split, followed by 88 further commits.

## The fix

`bin/subtree-split` force-pushes. A split repository is generated from this one, so the split is the only correct history it can have; anything else on the branch is stale by definition, and a rejected push cannot be resolved except by overwriting. This repairs all 16 repos on the next run and stops the next branch rename or history rewrite from wedging the workflow. It is what Laravel's `bin/split.sh` does for the same reason.

Tag pushes in `bin/release` are deliberately **not** forced — a tag that already exists is skipped instead.

## Verification

A sandbox test reproduces the exact breakage: a split repo whose branch holds an unrelated, diverged history, as renaming `master` → `2.x` left it. Before the change the push is rejected; after it, the run succeeds, the branch is replaced with the generated split, the stale commit is gone, the package content sits at the repo root, and a second run is a no-op.

## After merging

The next push to `2.x` repairs all 16 repos automatically. `1.7.x` is stale as well — `Payum/Core`'s is at 2025-10-27 while `1.7.x` here has newer changes to that package — so it is worth dispatching the workflow against `1.7.x` once this is in.