### PR TITLE
Let a gateway move one operation at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `Payum\Core\Model\StatusAwareInterface`. A subject implementing it has its status kept current by Payum after every command, which makes it readable without a gateway and queryable in storage. Read it through `Payum\Core\Model\PaymentStatuses`
 * `Result::$status` is now null when an operation concluded nothing about the payment, so a declined refund no longer reads as a failed payment. `failed()` takes an optional status for a failure that really is terminal
+* Add `Payum\Core\Gateway\DeclaresActions`, so a gateway can keep the 1.x actions it has not ported beside the handlers it has and move one operation at a time. Handlers answer first; anything without one falls through to the actions
 * A 1.x request sent to a gateway built from handlers is translated to the command that means the same thing, so an application keeps working when a gateway package ports. `Capture`, `Authorize`, `Refund`, `Cancel`, `Payout` and `Sync` translate; `GetHumanStatus` and `GetBinaryStatus` are answered from the recorded status
 * Fix `Payum::done()` against a gateway built from handlers, which previously reported `GetHumanStatus` as unsupported
 * Add a middleware pipeline around command execution. `Payum\Core\Middleware\MiddlewareInterface` wraps a command, `PayumBuilder::addMiddleware()` registers one for every gateway, and a gateway declares its own through `Payum\Core\Gateway\DeclaresMiddleware`

--- a/docs/gateways/migrating-from-v1.md
+++ b/docs/gateways/migrating-from-v1.md
@@ -246,6 +246,37 @@ Two limits worth knowing:
 - A status request is answered from the status Payum records, so it needs the subject to implement `Payum\Core\Model\StatusAwareInterface`. One that tracks nothing is marked unknown rather than guessed at.
 - A handler returning `RenderTemplate`, `Challenge` or `Poll` has no 1.x reply to become, so those throw rather than report the payment finished when it is not. A gateway using them needs a caller that acts on a `Result`.
 
+### Moving one operation at a time
+
+A gateway does not have to port everything at once. List the actions you have not moved yet and they keep working beside the handlers you have:
+
+```php
+use Payum\Core\Gateway\DeclaresActions;
+use Payum\Core\Gateway\GatewayInterface;
+
+final class AcmeGateway implements GatewayInterface, DeclaresActions
+{
+    public function handlers(): array
+    {
+        return [CaptureHandler::class];      // ported
+    }
+
+    public function actions(): array
+    {
+        return [RefundAction::class];        // not yet
+    }
+}
+```
+
+`Capture` goes to the handler. `Refund` falls through to the action. When the last action becomes a handler, drop the interface.
+
+Declaring any action brings core's own actions and extensions along, since an action dispatching `GetHttpRequest` or `RenderTemplate` still expects an answer. A gateway that declares none gets a clean gateway with no 1.x machinery on it at all.
+
+Two ordering rules worth knowing:
+
+- **Handlers are asked before actions.** They have to be: a token is a `DetailsAggregateInterface`, so core's `ExecuteSameRequestWithModelDetailsAction` claims `Capture($token)`. Asking actions first would swallow almost every request before a handler saw it.
+- **Except for status requests**, where an action wins. A gateway still holding a status action reads the details of whatever has not moved, which is more than the recorded status knows.
+
 ### Moving your own code across
 
 When you are ready, the call site becomes:

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,6 @@ use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\PHPUnit\CodeQuality\Rector\Expression\AssertArrayCastedObjectToAssertSameRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\NarrowIdenticalWithConsecutiveRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\SingleWithConsecutiveToWithRector;
-use Rector\PHPUnit\PHPUnit100\Rector\StmtsAwareInterface\WithConsecutiveRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
@@ -35,12 +34,9 @@ return RectorConfig::configure()
         SetList::INSTANCEOF,
 
         // PHPUnit
-        PHPUnitSetList::PHPUNIT_40,
-        PHPUnitSetList::PHPUNIT_50,
-        PHPUnitSetList::PHPUNIT_60,
-        PHPUnitSetList::PHPUNIT_70,
-        PHPUnitSetList::PHPUNIT_80,
-        PHPUnitSetList::PHPUNIT_90,
+        PHPUnitSetList::COMPOSER_BASED,
+        PHPUnitSetList::PHPUNIT_MOCK_TO_STUB,
+        PHPUnitSetList::PHPUNIT_NARROW_ASSERTS,
         PHPUnitSetList::PHPUNIT_CODE_QUALITY,
     ])
     ->withRules([
@@ -68,7 +64,6 @@ return RectorConfig::configure()
         //  - narrowing withConsecutive(['x'], ['x']) to with(['x']) treats the
         //    argument list as a single expected argument;
         //  - the PHPUnit 10 matcher idiom compares constraints with assertSame().
-        WithConsecutiveRector::class,
         NarrowIdenticalWithConsecutiveRector::class,
         SingleWithConsecutiveToWithRector::class,
 

--- a/src/Payum/Core/CoreGatewayFactory.php
+++ b/src/Payum/Core/CoreGatewayFactory.php
@@ -40,6 +40,7 @@ use Payum\Core\DI\ContainerConfiguration;
 use Payum\Core\DI\CreatesGateway;
 use Payum\Core\Extension\EndlessCycleDetectorExtension;
 use Payum\Core\Extension\PrependExtensionInterface;
+use Payum\Core\Gateway\DeclaresActions;
 use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
 use Payum\Core\Handler\HandlerMap;
 use Payum\Core\Middleware\EndlessCycleDetectorMiddleware;
@@ -355,10 +356,21 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
 
         $gateway->setContainer($container);
 
+        $declaredActions = [];
+
         if ($container->has(PaymentGateway::class)) {
-            return $gateway->setHandlerMap(
-                HandlerMap::fromHandlers($container->get(PaymentGateway::class)->handlers())
-            );
+            $paymentGateway = $container->get(PaymentGateway::class);
+
+            $gateway->setHandlerMap(HandlerMap::fromHandlers($paymentGateway->handlers()));
+
+            // A gateway that has finished moving gets nothing else: no actions, no extensions, no Twig
+            // environment it will never render with. One still holding actions says so, and then needs
+            // core's own alongside them, since an action dispatching GetHttpRequest expects an answer.
+            if (! $paymentGateway instanceof DeclaresActions) {
+                return $gateway;
+            }
+
+            $declaredActions = $paymentGateway->actions();
         }
 
         if ($container->has('twig.env')) {
@@ -373,7 +385,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
             );
         }
 
-        foreach ($this->getActions() as $action) {
+        foreach ([...$this->getActions(), ...$declaredActions] as $action) {
             // Skip GetTokenAction if token storage is not configured
             if (GetTokenAction::class === $action && ! $container->has('payum.security.token_storage')) {
                 continue;

--- a/src/Payum/Core/Gateway.php
+++ b/src/Payum/Core/Gateway.php
@@ -152,11 +152,30 @@ class Gateway implements GatewayInterface
             self::class
         );
 
-        // A gateway built from handlers has no actions to find, so a 1.x request would report itself
-        // unsupported. Translate instead: an application should not break because a gateway package it
-        // depends on moved to handlers.
-        if ($this->handlerMap instanceof HandlerMap && ! $this->findActionSupported($request)) {
-            return $this->executeThroughHandlers($request, $catchReply);
+        // A 1.x request is answered by the handler that means the same thing, when the gateway has one.
+        //
+        // Handlers are asked first on purpose. Core's own actions claim requests broadly -- a token is a
+        // DetailsAggregateInterface, so ExecuteSameRequestWithModelDetailsAction supports Capture($token)
+        // -- and asking actions first would swallow every request before a handler ever saw it. Asking
+        // handlers first is also what a gateway part-way through moving needs: what it has ported goes to
+        // a handler, and the rest falls through to the actions it still has.
+        if ($this->handlerMap instanceof HandlerMap) {
+            if ($request instanceof GetStatusInterface) {
+                // A gateway still holding a status action reads the details of whatever has not moved,
+                // which is more than the recorded status knows. Only answer from the record when nothing
+                // else claims it.
+                if (! $this->findActionSupported($request)) {
+                    $this->answerStatus($request);
+
+                    return null;
+                }
+            } elseif (RequestToCommand::supports($request)) {
+                $command = RequestToCommand::translate($request, $this->resolveSubjectOf($request));
+
+                if ($command instanceof CommandInterface && $this->supportsCommand($command::class)) {
+                    return $this->replyFor($this->dispatch($command), $catchReply);
+                }
+            }
         }
 
         $context = new Context($this, $request, $this->stack);
@@ -414,31 +433,15 @@ class Gateway implements GatewayInterface
     }
 
     /**
-     * @throws ContainerExceptionInterface
-     * @throws NotFoundExceptionInterface
-     */
-    /**
-     * Answers a 1.x request with the handler that means the same thing.
+     * Tells a 1.x caller what a handler decided, the way it expects to hear it.
      *
-     * Throws the matching reply when the handler decided the customer has somewhere to be, which is how a
-     * 1.x caller expects to hear about it.
+     * Throws the matching reply when the customer has somewhere to be, or returns it when the caller
+     * asked to catch it. A result with nothing left to do answers with null, the same as a 1.x action
+     * returning without throwing.
      */
-    private function executeThroughHandlers(object $request, bool $catchReply): ?Base
+    private function replyFor(Result $result, bool $catchReply): ?Base
     {
-        if ($request instanceof GetStatusInterface) {
-            $this->answerStatus($request);
-
-            return null;
-        }
-
-        $subject = $this->resolveSubjectOf($request);
-        $command = RequestToCommand::translate($request, $subject);
-
-        if (! $command instanceof CommandInterface || ! $this->supportsCommand($command::class)) {
-            throw RequestNotSupportedException::create($request);
-        }
-
-        $reply = ResultToReply::translate($this->dispatch($command));
+        $reply = ResultToReply::translate($result);
 
         if (! $reply instanceof Base) {
             return null;

--- a/src/Payum/Core/Gateway/DeclaresActions.php
+++ b/src/Payum/Core/Gateway/DeclaresActions.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Gateway;
+
+use Payum\Core\Action\ActionInterface;
+
+/**
+ * Optional. Implement while a gateway is part-way through moving to handlers.
+ *
+ * A gateway with 1.x actions it has not ported yet lists them here, and they keep working alongside the
+ * handlers it has. Requests that have a handler go to the handler; everything else falls through to these,
+ * which is what lets a gateway move one operation at a time rather than all at once.
+ *
+ * Declaring any of these brings core's own actions and extensions along, since an action dispatching
+ * GetHttpRequest or RenderTemplate still expects an answer. A gateway that declares none gets a clean
+ * gateway with no 1.x machinery on it at all.
+ *
+ * Temporary by design: when the last action becomes a handler, drop the interface.
+ *
+ * @deprecated since 2.0, removed in 3.0 along with actions.
+ */
+interface DeclaresActions
+{
+    /**
+     * Container ids, resolved from the gateway's own container.
+     *
+     * @return list<class-string<ActionInterface>>
+     */
+    public function actions(): array;
+}

--- a/src/Payum/Core/Legacy/RequestToCommand.php
+++ b/src/Payum/Core/Legacy/RequestToCommand.php
@@ -36,6 +36,22 @@ use Payum\Core\Security\TokenInterface;
 final class RequestToCommand
 {
     /**
+     * Whether a request has a command that means the same thing, without looking anything up.
+     *
+     * Worth asking before {@see self::translate()}, which resolves the subject a request points at and so
+     * may go to storage to do it.
+     */
+    public static function supports(object $request): bool
+    {
+        return $request instanceof Capture
+            || $request instanceof Authorize
+            || $request instanceof Refund
+            || $request instanceof Cancel
+            || $request instanceof Sync
+            || $request instanceof Payout;
+    }
+
+    /**
      * Null when nothing means the same thing, or when there is nothing usable to point a command at. The
      * caller then behaves as it did before, which is to say it reports the request as unsupported.
      *
@@ -46,10 +62,11 @@ final class RequestToCommand
      */
     public static function translate(object $request, ?SubjectInterface $subject = null): ?CommandInterface
     {
-        if (! $request instanceof Generic) {
+        if (! self::supports($request)) {
             return null;
         }
 
+        /** @var Generic $request */
         $token = $request->getToken();
         $subject ??= $request->getFirstModel() instanceof SubjectInterface ? $request->getFirstModel() : null;
 

--- a/src/Payum/Core/Tests/HalfMigratedGatewayTest.php
+++ b/src/Payum/Core/Tests/HalfMigratedGatewayTest.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests;
+
+use League\Uri\Uri;
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Command\CaptureCommand;
+use Payum\Core\Config\GatewayConfig;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Gateway\DeclaresActions;
+use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
+use Payum\Core\Handler\CaptureHandlerInterface;
+use Payum\Core\Handler\Context;
+use Payum\Core\Metadata\Logo;
+use Payum\Core\Model\Payment;
+use Payum\Core\Model\StatusAwareInterface;
+use Payum\Core\Payum;
+use Payum\Core\PayumBuilder;
+use Payum\Core\Registry\StorageRegistryInterface;
+use Payum\Core\Request\Capture;
+use Payum\Core\Request\GetHumanStatus;
+use Payum\Core\Request\GetStatusInterface;
+use Payum\Core\Request\Refund;
+use Payum\Core\Result\CaptureResult;
+use Payum\Core\Result\PaymentStatus;
+use Payum\Core\Security\TokenInterface;
+use Payum\Core\Storage\StorageInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A gateway does not have to move all at once. What it has ported goes to a handler; what it has not goes
+ * to the actions it still has.
+ */
+final class HalfMigratedGatewayTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_SERVER = [
+            'HTTP_HOST' => 'payum.dev',
+        ];
+
+        HalfCaptureHandler::$ran = false;
+        HalfCaptureAction::$ran = false;
+        HalfRefundAction::$ran = false;
+        HalfStatusAction::$ran = false;
+    }
+
+    public function testShouldSendAPortedRequestToItsHandlerRatherThanTheActionItReplaced(): void
+    {
+        $gateway = $this->buildPayum()->getGateway('acme');
+
+        $gateway->execute(new Capture($this->buildPayment()));
+
+        // The gateway still carries the capture action it has not deleted yet. The handler is what
+        // answers, or porting an operation would change nothing.
+        $this->assertTrue(HalfCaptureHandler::$ran);
+        $this->assertFalse(HalfCaptureAction::$ran);
+    }
+
+    public function testShouldLeaveAnUnportedRequestToTheActionThatStillHandlesIt(): void
+    {
+        $gateway = $this->buildPayum()->getGateway('acme');
+
+        $gateway->execute(new Refund($this->buildPayment()));
+
+        $this->assertTrue(HalfRefundAction::$ran);
+        $this->assertFalse(HalfCaptureHandler::$ran);
+    }
+
+    public function testShouldStillTakeCommandsDirectly(): void
+    {
+        $gateway = $this->buildPayum()->getGateway('acme');
+
+        $result = $gateway->execute(CaptureCommand::forPayment($this->buildPayment()));
+
+        $this->assertInstanceOf(CaptureResult::class, $result);
+        $this->assertTrue(HalfCaptureHandler::$ran);
+    }
+
+    public function testShouldPreferAStatusActionOverTheRecordedStatus(): void
+    {
+        $payment = new HalfTrackedPayment();
+        // What Payum recorded says pending; the gateway's own action knows better, because it reads the
+        // details of the part that has not moved.
+        $payment->setStatus(PaymentStatus::Pending);
+
+        $gateway = $this->buildPayum()->getGateway('acme');
+
+        $gateway->execute($status = new GetHumanStatus($payment));
+
+        $this->assertTrue(HalfStatusAction::$ran);
+        $this->assertTrue($status->isCaptured());
+    }
+
+    public function testShouldGiveAGatewayThatDeclaresNoActionsACleanGateway(): void
+    {
+        $payum = (new PayumBuilder())
+            ->addDefaultStorages()
+            ->registerGateway('pure', new PureConfig())
+            ->getPayum();
+
+        // Nothing legacy on it at all, so a request with no handler behind it is simply unsupported.
+        $this->expectException(RequestNotSupportedException::class);
+
+        $payum->getGateway('pure')->execute(new Refund($this->buildPayment()));
+    }
+
+    private function buildPayment(): Payment
+    {
+        $payment = new Payment();
+        $payment->setNumber(uniqid());
+        $payment->setTotalAmount(123);
+        $payment->setCurrencyCode('EUR');
+
+        return $payment;
+    }
+
+    /**
+     * @return Payum<StorageRegistryInterface<StorageInterface<TokenInterface>>>
+     */
+    private function buildPayum(): Payum
+    {
+        return (new PayumBuilder())
+            ->addDefaultStorages()
+            ->registerGateway('acme', new HalfConfig())
+            ->getPayum();
+    }
+}
+
+final class HalfConfig implements GatewayConfig
+{
+    public function getGatewayClass(): string
+    {
+        return HalfGateway::class;
+    }
+}
+
+final class HalfGateway implements PaymentGateway, DeclaresActions
+{
+    public function configClass(): string
+    {
+        return HalfConfig::class;
+    }
+
+    public function handlers(): array
+    {
+        return [HalfCaptureHandler::class];
+    }
+
+    public function actions(): array
+    {
+        return [HalfCaptureAction::class, HalfRefundAction::class, HalfStatusAction::class];
+    }
+
+    public function logo(): Logo
+    {
+        return Logo\Url::create('https://acme.test/logo.svg');
+    }
+
+    public function name(): string
+    {
+        return 'Acme';
+    }
+
+    public function websiteUrl(): Uri
+    {
+        return Uri::new('https://acme.test');
+    }
+}
+
+final class PureConfig implements GatewayConfig
+{
+    public function getGatewayClass(): string
+    {
+        return PureGateway::class;
+    }
+}
+
+final class PureGateway implements PaymentGateway
+{
+    public function configClass(): string
+    {
+        return PureConfig::class;
+    }
+
+    public function handlers(): array
+    {
+        return [HalfCaptureHandler::class];
+    }
+
+    public function logo(): Logo
+    {
+        return Logo\Url::create('https://acme.test/logo.svg');
+    }
+
+    public function name(): string
+    {
+        return 'Acme';
+    }
+
+    public function websiteUrl(): Uri
+    {
+        return Uri::new('https://acme.test');
+    }
+}
+
+final class HalfCaptureHandler implements CaptureHandlerInterface
+{
+    public static bool $ran = false;
+
+    public function handle(CaptureCommand $command, Context $context): CaptureResult
+    {
+        self::$ran = true;
+
+        return CaptureResult::captured('txn_1');
+    }
+}
+
+final class HalfCaptureAction implements ActionInterface
+{
+    public static bool $ran = false;
+
+    public function execute($request): void
+    {
+        self::$ran = true;
+    }
+
+    public function supports($request): bool
+    {
+        return $request instanceof Capture;
+    }
+}
+
+final class HalfRefundAction implements ActionInterface
+{
+    public static bool $ran = false;
+
+    public function execute($request): void
+    {
+        self::$ran = true;
+    }
+
+    public function supports($request): bool
+    {
+        return $request instanceof Refund;
+    }
+}
+
+final class HalfStatusAction implements ActionInterface
+{
+    public static bool $ran = false;
+
+    public function execute($request): void
+    {
+        self::$ran = true;
+
+        /** @var GetStatusInterface $request */
+        $request->markCaptured();
+    }
+
+    public function supports($request): bool
+    {
+        return $request instanceof GetStatusInterface;
+    }
+}
+
+class HalfTrackedPayment extends Payment implements StatusAwareInterface
+{
+    private PaymentStatus $status = PaymentStatus::New;
+
+    public function getStatus(): PaymentStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(PaymentStatus $status): void
+    {
+        $this->status = $status;
+    }
+}

--- a/src/Payum/Core/Tests/HalfMigratedGatewayTest.php
+++ b/src/Payum/Core/Tests/HalfMigratedGatewayTest.php
@@ -14,6 +14,7 @@ use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
 use Payum\Core\Handler\CaptureHandlerInterface;
 use Payum\Core\Handler\Context;
 use Payum\Core\Metadata\Logo;
+use Payum\Core\Metadata\Logo\Url;
 use Payum\Core\Model\Payment;
 use Payum\Core\Model\StatusAwareInterface;
 use Payum\Core\Payum;
@@ -156,7 +157,7 @@ final class HalfGateway implements PaymentGateway, DeclaresActions
 
     public function logo(): Logo
     {
-        return Logo\Url::create('https://acme.test/logo.svg');
+        return Url::create('https://acme.test/logo.svg');
     }
 
     public function name(): string
@@ -192,7 +193,7 @@ final class PureGateway implements PaymentGateway
 
     public function logo(): Logo
     {
-        return Logo\Url::create('https://acme.test/logo.svg');
+        return Url::create('https://acme.test/logo.svg');
     }
 
     public function name(): string


### PR DESCRIPTION
A gateway had to port everything at once — `createGateway()` gave it handlers **or** actions, never both, so the first handler meant deleting every action. Klarna Invoice has nineteen of them.

Now it can move one operation at a time.

```php
use Payum\Core\Gateway\DeclaresActions;
use Payum\Core\Gateway\GatewayInterface;

final class AcmeGateway implements GatewayInterface, DeclaresActions
{
    public function handlers(): array
    {
        return [CaptureHandler::class];      // ported
    }

    public function actions(): array
    {
        return [RefundAction::class];        // not yet
    }
}
```

`Capture` goes to the handler. `Refund` falls through to the action. Commands still work directly. When the last action becomes a handler, drop the interface.

Declaring any action brings core's own actions and extensions along, since an action dispatching `GetHttpRequest` or `RenderTemplate` still expects an answer. A gateway that declares none gets a clean gateway with no 1.x machinery on it at all — no actions, no extensions, no Twig environment it will never render with.

## Handlers are asked before actions

This is what makes it work, and it is not arbitrary. Core's actions claim requests broadly: a token is a `DetailsAggregateInterface`, so `ExecuteSameRequestWithModelDetailsAction::supports()` returns true for `Capture($token)`. Asking actions first would swallow almost every request before a handler ever saw it.

**Status requests are the exception** and still prefer an action. A gateway part-way through migrating has a status action that reads the details of whatever has not moved, which is more than the recorded status knows. Only when nothing claims it does the recorded status answer.

## On the tests

The first version of the capture test passed against *both* orderings, so it was not pinning anything. With actions first, `ExecuteSameRequestWithModelDetailsAction` claims the request, swaps the model for its details, re-executes, and the handler ends up running anyway by a longer route — same observable outcome.

The test now gives the gateway a capture action it has not deleted yet and asserts it never runs while the handler does, which is the thing that actually differs. Both mutations fail it now: asking actions first, and dropping the declared actions from the factory.
