### PR TITLE
docs: fix custom API usage factory syntax (Symfony)

### DIFF
--- a/docs/symfony/custom-api-usage.md
+++ b/docs/symfony/custom-api-usage.md
@@ -61,8 +61,7 @@ services:
     acme.payment.payum.paypal_express_checkout_api:
         class: Payum\Paypal\ExpressCheckout\Nvp\Api
         public: true
-        factory_service: acme.payment.payum.api.factory
-        factory_method: createPaypalExpressCheckoutApi
+        factory: ['@acme.payment.payum.api.factory', createPaypalExpressCheckoutApi]
 ```
 
 When we are done we can tell payum to use this service instead of default one:


### PR DESCRIPTION
## Summary
`docs/symfony/custom-api-usage.md` used a removed Symfony DI syntax
(`factory_service` / `factory_method` keys), deprecated since Symfony 3.3
and removed in 4.0. Following the doc as written breaks with a "Too few
arguments" error. Fixed the service definition to use the current
`factory: ['@service', method]` array syntax.

Fixes #1014
Related: #748

## Changes
- `config/services.yml` example: replaced `factory_service`/`factory_method`
  keys with `factory: ['@acme.payment.payum.api.factory', createPaypalExpressCheckoutApi]`

## Test plan
- Docs-only change, no code affected
- Verified syntax against https://symfony.com/doc/current/service_container/factories.html