### PR TITLE
Fix empty afterUrl when chaining authorize/payout tokens

### DIFF
--- a/src/Payum/Core/Payum.php
+++ b/src/Payum/Core/Payum.php
@@ -173,7 +173,7 @@ class Payum implements RegistryInterface
             return new Response($reply->getContent(), $reply->getStatusCode(), $reply->getHeaders());
         }
 
-        return new RedirectResponse($token->getAfterUrl());
+        return $this->redirectToAfterUrl($token);
     }
 
     /**
@@ -225,7 +225,7 @@ class Payum implements RegistryInterface
         $next = $result->next;
 
         if (! $next instanceof NextAction) {
-            return new RedirectResponse($token->getAfterUrl());
+            return $this->redirectToAfterUrl($token);
         }
 
         if ($next instanceof Redirect) {
@@ -247,5 +247,28 @@ class Payum implements RegistryInterface
             Redirect::class,
             PostRedirect::class,
         ));
+    }
+
+    /**
+     * A token with no afterUrl usually means it was created as an intermediate step
+     * (e.g. GenericTokenFactory::createAuthorizeToken()'s $afterPath token) without telling
+     * the factory where that step should lead once it finishes on its own. Fail with a
+     * message pointing at the cause instead of Symfony's generic "empty URL" exception.
+     */
+    private function redirectToAfterUrl(TokenInterface $token): RedirectResponse
+    {
+        $afterUrl = $token->getAfterUrl();
+
+        if (! $afterUrl) {
+            throw new LogicException(sprintf(
+                'The token "%s" has no afterUrl to redirect to. If it was created as an intermediate '
+                . 'step (for example via GenericTokenFactory::createAuthorizeToken() or '
+                . 'createPayoutToken()), pass a $finalPath so that token also knows where to redirect '
+                . 'once it completes on its own.',
+                $token->getHash()
+            ));
+        }
+
+        return new RedirectResponse($afterUrl);
     }
 }

--- a/src/Payum/Core/Security/GenericTokenFactory.php
+++ b/src/Payum/Core/Security/GenericTokenFactory.php
@@ -65,14 +65,21 @@ class GenericTokenFactory implements GenericTokenFactoryInterface
      * @param object|array<string, scalar> $model
      * @param string|null $afterPath
      * @param array<string, scalar> $afterParameters
+     * @param string|null $finalPath Path the $afterPath token itself should redirect to once it
+     *                               completes without producing its own reply. Needed when $afterPath
+     *                               is itself another Payum action (e.g. chaining authorize into a
+     *                               subsequent capture step) to avoid leaving that token without an
+     *                               afterUrl of its own, which otherwise fails later with
+     *                               "Cannot redirect to an empty URL."
+     * @param array<string, scalar> $finalParameters
      *
      * @return TokenInterface
      */
-    public function createAuthorizeToken($gatewayName, $model, $afterPath, array $afterParameters = [])
+    public function createAuthorizeToken($gatewayName, $model, $afterPath, array $afterParameters = [], $finalPath = null, array $finalParameters = [])
     {
         $authorizePath = $this->getPath('authorize');
 
-        $afterToken = $this->createToken($gatewayName, $model, $afterPath, $afterParameters);
+        $afterToken = $this->createToken($gatewayName, $model, $afterPath, $afterParameters, $finalPath, $finalParameters);
 
         return $this->createToken($gatewayName, $model, $authorizePath, [], $afterToken->getTargetUrl());
     }
@@ -122,14 +129,17 @@ class GenericTokenFactory implements GenericTokenFactoryInterface
      * @param object|array<string, scalar> $model
      * @param string|null $afterPath
      * @param array<string, scalar> $afterParameters
+     * @param string|null $finalPath Path the $afterPath token itself should redirect to once it
+     *                               completes without producing its own reply. See createAuthorizeToken().
+     * @param array<string, scalar> $finalParameters
      *
      * @return TokenInterface
      */
-    public function createPayoutToken($gatewayName, $model, $afterPath, array $afterParameters = [])
+    public function createPayoutToken($gatewayName, $model, $afterPath, array $afterParameters = [], $finalPath = null, array $finalParameters = [])
     {
         $capturePath = $this->getPath('payout');
 
-        $afterToken = $this->createToken($gatewayName, $model, $afterPath, $afterParameters);
+        $afterToken = $this->createToken($gatewayName, $model, $afterPath, $afterParameters, $finalPath, $finalParameters);
 
         return $this->createToken(
             $gatewayName,

--- a/src/Payum/Core/Security/GenericTokenFactoryInterface.php
+++ b/src/Payum/Core/Security/GenericTokenFactoryInterface.php
@@ -11,10 +11,16 @@ interface GenericTokenFactoryInterface extends TokenFactoryInterface
      * @param string $gatewayName
      * @param object $model
      * @param string $afterPath
+     * @param string|null $finalPath Path the $afterPath token itself should redirect to once it
+     *                               completes without producing its own reply. Needed when $afterPath
+     *                               is itself another Payum action (e.g. chaining authorize into a
+     *                               subsequent capture step) to avoid leaving that token without an
+     *                               afterUrl of its own.
+     * @param array<string, scalar> $finalParameters
      *
      * @return TokenInterface
      */
-    public function createAuthorizeToken($gatewayName, $model, $afterPath, array $afterParameters = []);
+    public function createAuthorizeToken($gatewayName, $model, $afterPath, array $afterParameters = [], $finalPath = null, array $finalParameters = []);
 
     /**
      * @param string $gatewayName
@@ -38,10 +44,13 @@ interface GenericTokenFactoryInterface extends TokenFactoryInterface
      * @param string $gatewayName
      * @param object $model
      * @param string $afterPath
+     * @param string|null $finalPath Path the $afterPath token itself should redirect to once it
+     *                               completes without producing its own reply. See createAuthorizeToken().
+     * @param array<string, scalar> $finalParameters
      *
      * @return TokenInterface
      */
-    public function createPayoutToken($gatewayName, $model, $afterPath, array $afterParameters = []);
+    public function createPayoutToken($gatewayName, $model, $afterPath, array $afterParameters = [], $finalPath = null, array $finalParameters = []);
 
     /**
      * @param string      $gatewayName

--- a/src/Payum/Core/Tests/PayumTest.php
+++ b/src/Payum/Core/Tests/PayumTest.php
@@ -302,6 +302,56 @@ final class PayumTest extends TestCase
         $this->assertSame('https://example.com/done', $response->getTargetUrl());
     }
 
+    public function testCaptureMethodThrowsAClearExceptionWhenTheTokenHasNoAfterUrl(): void
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $gateway = $this->createMock(Gateway::class);
+
+        $this->httpRequestVerifierMock
+            ->expects($this->once())
+            ->method('verify')
+            ->willReturn($token);
+
+        $token
+            ->expects($this->once())
+            ->method('getGatewayName')
+            ->willReturn('aGateway');
+
+        $token
+            ->expects($this->once())
+            ->method('getAfterUrl')
+            ->willReturn(null);
+
+        $token
+            ->expects($this->once())
+            ->method('getHash')
+            ->willReturn('theTokenHash');
+
+        $gateway
+            ->expects($this->once())
+            ->method('supportsCommand')
+            ->willReturn(true);
+
+        $gateway
+            ->expects($this->once())
+            ->method('execute')
+            ->willReturn(CaptureResult::captured('txn_1'));
+
+        $payum = new Payum(
+            new SimpleRegistry([
+                'aGateway' => $gateway,
+            ]),
+            $this->httpRequestVerifierMock,
+            $this->tokenFactoryMock,
+            $this->storageMock
+        );
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('theTokenHash');
+
+        $payum->capture(Request::create('/capture'));
+    }
+
     public function testCaptureMethodRepliesHttpRedirect(): void
     {
         $token = $this->createMock(TokenInterface::class);

--- a/src/Payum/Core/Tests/Security/GenericTokenFactoryTest.php
+++ b/src/Payum/Core/Tests/Security/GenericTokenFactoryTest.php
@@ -278,6 +278,67 @@ final class GenericTokenFactoryTest extends TestCase
         $this->assertSame($authorizeToken, $actualToken);
     }
 
+    public function testShouldPassFinalPathToTheAfterTokenWhenCreatingAuthorizeToken(): void
+    {
+        $gatewayName = 'theGatewayName';
+        $model = new stdClass();
+        $authorizePath = 'theAuthorizePath';
+        $afterPath = 'theAfterPath';
+        $afterUrl = 'theAfterUrl';
+        $afterParameters = [
+            'after' => 'val',
+        ];
+        $finalPath = 'theFinalPath';
+        $finalParameters = [
+            'final' => 'val',
+        ];
+
+        $afterToken = new Token();
+        $afterToken->setTargetUrl($afterUrl);
+
+        $authorizeToken = new Token();
+
+        $tokenFactoryMock = $this->createTokenFactoryMock();
+        $tokenFactoryMock
+            ->expects($this->atLeast(2))
+            ->method('createToken')
+            ->withConsecutive(
+                [
+                    $gatewayName,
+                    $this->identicalTo($model),
+                    $afterPath,
+                    $afterParameters,
+                    $finalPath,
+                    $finalParameters,
+                ],
+                [
+                    $gatewayName,
+                    $this->identicalTo($model),
+                    $authorizePath,
+                    [],
+                    $afterUrl,
+                    [],
+                ]
+            )
+            ->willReturnOnConsecutiveCalls($afterToken, $authorizeToken)
+        ;
+
+        $factory = new GenericTokenFactory($tokenFactoryMock, [
+            'authorize' => $authorizePath,
+        ]);
+
+        $actualToken = $factory->createAuthorizeToken(
+            $gatewayName,
+            $model,
+            $afterPath,
+            $afterParameters,
+            $finalPath,
+            $finalParameters
+        );
+
+        $this->assertSame($authorizeToken, $actualToken);
+    }
+
     public function testThrowIfRefundPathNotConfigured(): void
     {
         $this->expectException(LogicException::class);
@@ -683,6 +744,67 @@ final class GenericTokenFactoryTest extends TestCase
             $model,
             $afterPath,
             $afterParameters
+        );
+
+        $this->assertSame($payoutToken, $actualToken);
+    }
+
+    public function testShouldPassFinalPathToTheAfterTokenWhenCreatingPayoutToken(): void
+    {
+        $gatewayName = 'theGatewayName';
+        $model = new stdClass();
+        $payoutPath = 'thePayoutPath';
+        $afterPath = 'theAfterPath';
+        $afterUrl = 'theAfterUrl';
+        $afterParameters = [
+            'after' => 'val',
+        ];
+        $finalPath = 'theFinalPath';
+        $finalParameters = [
+            'final' => 'val',
+        ];
+
+        $afterToken = new Token();
+        $afterToken->setTargetUrl($afterUrl);
+
+        $payoutToken = new Token();
+
+        $tokenFactoryMock = $this->createTokenFactoryMock();
+        $tokenFactoryMock
+            ->expects($this->atLeast(2))
+            ->method('createToken')
+            ->withConsecutive(
+                [
+                    $gatewayName,
+                    $this->identicalTo($model),
+                    $afterPath,
+                    $afterParameters,
+                    $finalPath,
+                    $finalParameters,
+                ],
+                [
+                    $gatewayName,
+                    $this->identicalTo($model),
+                    $payoutPath,
+                    [],
+                    $afterUrl,
+                    [],
+                ]
+            )
+            ->willReturnOnConsecutiveCalls($afterToken, $payoutToken)
+        ;
+
+        $factory = new GenericTokenFactory($tokenFactoryMock, [
+            'payout' => $payoutPath,
+        ]);
+
+        $actualToken = $factory->createPayoutToken(
+            $gatewayName,
+            $model,
+            $afterPath,
+            $afterParameters,
+            $finalPath,
+            $finalParameters
         );
 
         $this->assertSame($payoutToken, $actualToken);


### PR DESCRIPTION
## Summary

Fixes #694.

`GenericTokenFactory::createAuthorizeToken()` and `createPayoutToken()` build an intermediate, persisted token for `$afterPath` but never give it an `afterUrl` of its own. When that intermediate token points at another Payum action (e.g. chaining an authorize step into a follow-up capture step, as in #694) and that action finishes without producing an explicit reply, `Payum::capture()` tries to redirect to the token's empty `afterUrl` and crashes with Symfony's generic `Cannot redirect to an empty URL.` exception.

- `GenericTokenFactory`/`GenericTokenFactoryInterface`: `createAuthorizeToken()` and `createPayoutToken()` gain an optional `$finalPath`/`$finalParameters` pair (default `null`/`[]`, fully backward compatible) so callers can give that intermediate token its own destination.
- `Payum::capture()`/`respondTo()`: when a token still has no `afterUrl`, raise a clear `LogicException` naming the token hash and pointing at `$finalPath`, instead of the confusing low-level Symfony exception.

## Test plan

- [x] `./bin/phpunit src/Payum/Core/Tests` — 1201 tests, 0 failures
- [x] `bin/phpstan` on changed files — no errors
- [x] `bin/ecs check` on changed files — no errors