### PR TITLE
Add NotifyCommand and webhook handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 2.0.0 (TBD)
 
+* Add `Payum\Core\Command\NotifyCommand` and `Payum\Core\Handler\NotifyHandlerInterface`, so a gateway built from handlers can receive what a PSP sends when a payment changes. Checking that a message is genuine and acting on it are separate methods: `verify()` returns a `Payum\Core\Handler\WebhookEvent` or throws, and `handle()` is given the event it produced, so a gateway cannot quietly skip the check
+* A gateway whose PSP signs nothing says so with `WebhookEvent::unverified()` and re-reads the state with a `SyncCommand`, which makes the absence of a signature visible rather than looking like an omission
+* `Payum\Core\Result\NotifyResult` carries a `Payum\Core\Result\Acknowledgement`, which is the answer the PSP gets. It defaults to 204 and exists for the PSPs that insist on a particular body. A message that fails verification is answered 400 with nothing in it
+* Add `Payum\Core\Handler\Context::notifyUrl()`, `notifyToken()` and `gatewayName()`, so a gateway that takes a notification address per payment builds one in a line instead of reaching for the token factory
+* The PSR-7 request Payum builds from globals now reads its body from `php://input`, so a gateway can check a signature over the raw payload. An application that registers its own `Psr\Http\Message\ServerRequestInterface` is unaffected
+* `Payum\Core\Request\Notify` is translated to `NotifyCommand`, and a notify handler's acknowledgement is translated back to the `HttpResponse` reply a 1.x notify script catches
 * Add template rendering for gateways built from handlers. A handler returns `Payum\Core\Result\NextAction\RenderTemplate` naming a Twig template and `Payum::capture()` renders it, so a gateway ships a card form or a wallet button without writing rendering code. The result carries the template name and its context, never markup, which is what leaves the application's layout in charge
 * Add `Payum\Core\Gateway\DeclaresTemplates`, so a gateway declares the Twig namespaces for the templates it ships. Templates under a namespace can include and import each other, and an application overrides one by registering its own directory under the same namespace
 * Add `Payum\Core\Template\RendererInterface` and `Payum\Core\Bridge\Twig\TwigRenderer`. One renderer serves every gateway and is reached through `Payum::renderer()`; a gateway declaring its own is a build-time error, since replacing it would break every other gateway's templates

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -32,6 +32,20 @@
     single services with `Payum\Core\PayumBuilder::addGlobalService()`. Implement
     `Payum\Core\DI\ListableContainerInterface` on your container to have its services autowired into gateway actions.
 * The whole `Payum\Core\Bridge\Symfony` namespace is deprecated. Use the same classes from `payum/payum-bundle` instead.
+* Webhooks are handled by a command. `Payum::notify()` dispatches `Payum\Core\Command\NotifyCommand`
+  against a gateway built from handlers, and falls back to `Payum\Core\Request\Notify` for one that
+  still ships actions, so nothing needs changing to keep working.
+  * A gateway porting its `NotifyAction` implements `Payum\Core\Handler\NotifyHandlerInterface`. The
+    signature check goes in `verify()`; the rest goes in `handle()`, which is given the
+    `Payum\Core\Handler\WebhookEvent` that `verify()` returned.
+  * A `Payum\Core\Reply\HttpResponse` the action used to throw becomes a
+    `Payum\Core\Result\Acknowledgement` on the returned `Payum\Core\Result\NotifyResult`. Returning none
+    answers 204.
+  * `Payum\Core\Gateway\Capability::Webhooks` is now derived from shipping a notify handler. A gateway
+    declaring it through `DeclaresCapabilities` still works.
+* The `Psr\Http\Message\ServerRequestInterface` Payum builds from PHP's superglobals now has its body
+  populated from `php://input`, which is what lets a gateway verify a signature over the raw payload.
+  Applications registering their own request through `PayumBuilder::addGlobalService()` are unaffected.
 
 ## 1.5.0
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -13,6 +13,7 @@
   * [Results](gateways/results.md)
   * [Services](gateways/services.md)
   * [Middleware](gateways/middleware.md)
+  * [Webhooks](gateways/webhooks.md)
   * [Migrating a gateway from 1.x](gateways/migrating-from-v1.md)
 * [Dependency Injection](di/README.md)
   * [Getting started](di/getting-started.md)

--- a/docs/examples/notify-script.md
+++ b/docs/examples/notify-script.md
@@ -6,6 +6,31 @@ You can use this script if a gateway allows setting notification url per payment
 <?php
 //notify.php
 
+use Payum\Core\Payum;
+
+include __DIR__.'/config.php';
+
+/** @var Payum $payum */
+
+$response = $payum->notify();
+
+foreach ($response->headers->all() as $name => $values) {
+    foreach ($values as $value) {
+        header($name.': '.$value, false);
+    }
+}
+
+http_response_code($response->getStatusCode());
+echo $response->getContent();
+```
+
+`notify()` verifies the token, finds the gateway and answers the PSP. For a gateway that has not moved
+to handlers, the manual form still works:
+
+```php
+<?php
+//notify.php
+
 use Payum\Core\Request\Notify;
 use Payum\Core\Payum;
 use Payum\Core\Reply\HttpResponse;

--- a/docs/gateways/commands.md
+++ b/docs/gateways/commands.md
@@ -12,6 +12,7 @@ A command is what the caller wants done. It is immutable, carries no services, a
 | `Payum\Core\Command\CancelCommand` | `Cancel` | `CancelResult` | `reason`, `idempotencyKey` |
 | `Payum\Core\Command\PayoutCommand` | `Payout` | `PayoutResult` | `idempotencyKey` |
 | `Payum\Core\Command\SyncCommand` | `Sync` | `SyncResult` | — |
+| `Payum\Core\Command\NotifyCommand` | `Webhooks` | `NotifyResult` | — |
 
 ### Building one
 
@@ -56,6 +57,21 @@ $result->status;   // whatever the PSP says
 It is for callers — an admin screen with a refresh button, a reconciliation job. A handler that needs fresh data mid-flow calls its api directly instead; dispatching a command to fetch something it uses two lines later is indirection for its own sake.
 
 It reads rather than mutates, so it takes no idempotency key. Not every PSP offers a way to re-read, which is why `Capability::Sync` is a capability like any other rather than something assumed.
+
+### Receiving what a PSP sends
+
+`NotifyCommand` carries a message a PSP sent. It is the one command that may point at nothing:
+
+```php
+NotifyCommand::forToken($token);      // arrived on a notify token, which is the usual case
+NotifyCommand::forPayment($payment);  // you already know which payment it is about
+NotifyCommand::forGateway();          // your application routed the endpoint itself
+```
+
+Which payment an event belongs to is something verification works out, so there is nothing to point at
+until the message has been read. It takes no idempotency key either — it sends nothing to the PSP.
+
+See [Webhooks](webhooks.md) for the handler.
 
 ### What a command operates on
 

--- a/docs/gateways/handlers.md
+++ b/docs/gateways/handlers.md
@@ -10,6 +10,7 @@ A handler answers exactly one command. There is one interface per command, so bo
 | `CancelCommand` | `Payum\Core\Handler\CancelHandlerInterface` |
 | `PayoutCommand` | `Payum\Core\Handler\PayoutHandlerInterface` |
 | `SyncCommand` | `Payum\Core\Handler\SyncHandlerInterface` |
+| `NotifyCommand` | `Payum\Core\Handler\NotifyHandlerInterface` |
 
 ```php
 <?php
@@ -79,6 +80,13 @@ Do not take the payment, the token or the HTTP request. Those belong to a single
 | `execute()` | Dispatch a sub-command |
 | `previous()` | The enclosing executions, when a handler dispatched into another |
 | `command()` | The command being handled |
+| `gatewayName()` | The name this gateway is registered under |
+| `notifyUrl()` | A URL the PSP can post notifications about this payment to |
+| `notifyToken()` | The token behind that URL |
+
+`NotifyHandlerInterface` is the one handler whose `handle()` takes three parameters — the verified event
+arrives between the command and the context, and it has a `verify()` alongside. See
+[Webhooks](webhooks.md).
 
 ### Capture runs more than once
 

--- a/docs/gateways/migrating-from-v1.md
+++ b/docs/gateways/migrating-from-v1.md
@@ -19,6 +19,7 @@ Gateways written for 1.x keep working on 2.0 and are still supported. `Gateway::
 | `ApiAwareInterface` / `addApi()` | The api on the constructor |
 | `GatewayFactory::populateConfig()` | A gateway class and a config object |
 | `payum.action.*` container keys | `handlers()` on the gateway |
+| `NotifyAction` | `NotifyHandlerInterface` — the signature check moves into `verify()`, and the `HttpResponse` the action threw becomes an `Acknowledgement` on the result |
 
 Mirror the directory layout so the map stays obvious:
 
@@ -239,7 +240,7 @@ What translates:
 | `Cancel`, `Sync` | the matching handler, for a payment or a payout |
 | `Payout` | the payout handler |
 | `GetHumanStatus`, `GetBinaryStatus` | the status recorded on the subject |
-| `Notify` | nothing yet — webhooks are their own piece of work |
+| `Notify` | the notify handler — see [Webhooks](webhooks.md) |
 
 Two limits worth knowing:
 

--- a/docs/gateways/results.md
+++ b/docs/gateways/results.md
@@ -39,6 +39,22 @@ RefundResult::refunded($transactionId, $amount);
 RefundResult::partiallyRefunded($transactionId, $amount);
 ```
 
+### `NotifyResult`
+
+What a PSP's message amounted to.
+
+```php
+NotifyResult::handled(PaymentStatus::Captured, transactionId: 'txn_1');
+NotifyResult::ignored();                                          // an event type you do not care about
+NotifyResult::handled(PaymentStatus::Captured, Acknowledgement::ok('[accepted]'));
+```
+
+`ignored()` leaves the payment alone and still answers the PSP successfully. A null status means the
+event concluded nothing about the payment.
+
+It carries one thing no other result does: an `Acknowledgement`, which is the HTTP answer the PSP gets.
+Leave it null and the answer is 204, which nearly every PSP accepts.
+
 ### Next actions
 
 `next` says what the customer must do before the operation can finish. It describes intent, never an HTTP response, so a bridge turns it into one — and a JSON API can serialise it straight to a mobile client.

--- a/docs/gateways/results.md
+++ b/docs/gateways/results.md
@@ -22,6 +22,7 @@ $result->requiresInteraction();  // $next !== null
 | `CancelResult` | — |
 | `PayoutResult` | `paidOutAmount` |
 | `SyncResult` | — |
+| `NotifyResult` | `acknowledgement` |
 
 ### Building one
 

--- a/docs/gateways/webhooks.md
+++ b/docs/gateways/webhooks.md
@@ -1,0 +1,181 @@
+# Webhooks
+
+A PSP sends a message when something happens to a payment — it settled, it was disputed, a customer's
+bank finally answered. A gateway receives those by shipping a notify handler.
+
+### The handler
+
+Two methods. Checking that a message is genuine and acting on what it says are separate jobs, and Payum
+keeps them apart: verification is cheap, security-critical and has to answer immediately, while handling
+is the slow part.
+
+```php
+<?php
+namespace Acme\Payum\Handler;
+
+use Acme\Payum\Api\AcmeApi;
+use Payum\Core\Command\NotifyCommand;
+use Payum\Core\Exception\WebhookNotVerifiedException;
+use Payum\Core\Handler\Context;
+use Payum\Core\Handler\NotifyHandlerInterface;
+use Payum\Core\Handler\WebhookEvent;
+use Payum\Core\Result\NotifyResult;
+use Payum\Core\Result\PaymentStatus;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class NotifyHandler implements NotifyHandlerInterface
+{
+    public function __construct(private readonly AcmeApi $api)
+    {
+    }
+
+    public function verify(ServerRequestInterface $request): WebhookEvent
+    {
+        $payload = (string) $request->getBody();
+
+        if (! hash_equals($this->api->sign($payload), $request->getHeaderLine('Acme-Signature'))) {
+            throw new WebhookNotVerifiedException('The signature does not match.');
+        }
+
+        $event = json_decode($payload, true, 512, JSON_THROW_ON_ERROR);
+
+        return WebhookEvent::verified($event, $event['id'], $event['type']);
+    }
+
+    public function handle(NotifyCommand $command, WebhookEvent $event, Context $context): NotifyResult
+    {
+        if ('payment.captured' !== $event->type) {
+            return NotifyResult::ignored();
+        }
+
+        return NotifyResult::handled(PaymentStatus::Captured, transactionId: $event->payload['transaction']);
+    }
+}
+```
+
+List it in `handlers()` like any other handler. That is what gives the gateway `Capability::Webhooks`.
+
+### Verifying
+
+Use `hash_equals()` rather than `===` to compare a signature, and read the signed bytes with
+`(string) $request->getBody()` — most PSPs sign the raw body, and a JSON payload never reaches
+`getParsedBody()`.
+
+Do not reach for the payment in `verify()`. Verification that depends on stored state is handling in
+disguise, and this is the method that has to stay fast.
+
+Throw `WebhookNotVerifiedException` when the message is not genuine. Payum answers the caller 400 with
+an empty body and leaves the payment untouched. The exception's message is for your log — telling
+whoever sent the message which check failed only helps them get it right next time.
+
+### When the PSP signs nothing
+
+Some do not. Say so, rather than leaving the check out:
+
+```php
+public function verify(ServerRequestInterface $request): WebhookEvent
+{
+    return WebhookEvent::unverified($request->getParsedBody());
+}
+```
+
+Then do not act on what the message says — treat it as a nudge and re-read the real state from the PSP:
+
+```php
+public function handle(NotifyCommand $command, WebhookEvent $event, Context $context): NotifyResult
+{
+    $payment = $context->payment();
+
+    if (! $payment instanceof PaymentInterface) {
+        return NotifyResult::ignored();
+    }
+
+    $synced = $context->execute(SyncCommand::forPayment($payment));
+
+    return NotifyResult::handled($synced->status);
+}
+```
+
+It costs a request per message, and it is safe. `$event->isVerified()` tells the two apart if one
+handler covers both.
+
+### Answering the PSP
+
+A PSP retries anything it does not consider a success, so what you answer matters.
+
+| You return | The PSP gets |
+| :--- | :--- |
+| `NotifyResult::handled(...)` | 204 No Content |
+| `NotifyResult::ignored()` | 204 No Content |
+| `NotifyResult::handled($status, Acknowledgement::ok('[accepted]'))` | 200, body `[accepted]` |
+| `throw new WebhookNotVerifiedException(...)` | 400, empty body |
+
+Most PSPs accept any 2xx, so leave the acknowledgement out unless yours is particular — Adyen accepts
+only the body `[accepted]`:
+
+```php
+use Payum\Core\Result\Acknowledgement;
+
+Acknowledgement::noContent();               // 204
+Acknowledgement::ok('[accepted]');          // 200 with a body
+new Acknowledgement(200, '{"ok":true}', ['Content-Type' => 'application/json']);
+```
+
+Return `NotifyResult::ignored()` for an event type your gateway has no interest in. Rejecting a message
+because you did not recognise it makes the PSP redeliver it on a backoff schedule for as long as it
+keeps failing.
+
+### The notify URL
+
+Gateways that take a notification address per payment ask for it when the payment is created. Ask the
+context:
+
+```php
+$checkout = $this->api->createCheckout([
+    'return_url' => $context->token()?->getTargetUrl(),
+    'notify_url' => $context->notifyUrl(),
+    'amount' => $context->payment()?->getTotalAmount(),
+]);
+```
+
+`notifyUrl()` mints a long-lived token pointed at this payment and returns its URL. `notifyToken()`
+gives you the token itself if you want its hash.
+
+It mints once per execution, not once per payment. A customer who abandons a checkout and starts again
+gets a second URL unless you keep the first:
+
+```php
+$state = $context->state();
+
+$state['notify_url'] ??= $context->notifyUrl();
+```
+
+Gateways with a single endpoint configured in the PSP's dashboard need none of this — point that
+endpoint at your notify script and Payum works out which gateway a message belongs to from the token in
+the URL.
+
+### Testing one
+
+A notify handler is two plain methods, so most of it needs no gateway at all:
+
+```php
+$handler = new NotifyHandler(new AcmeApi('secret'));
+
+$this->expectException(WebhookNotVerifiedException::class);
+
+$handler->verify($requestWithABadSignature);
+```
+
+For the whole path, register your own request so the body is one you control:
+
+```php
+$payum = (new PayumBuilder())
+    ->addDefaultStorages()
+    ->addGlobalService(ServerRequestInterface::class, $request)
+    ->registerGateway('acme', new AcmeConfig())
+    ->getPayum();
+
+$result = $payum->getGateway('acme')->execute(NotifyCommand::forPayment($payment));
+```
+
+Next: [Migrating a gateway from 1.x](migrating-from-v1.md).

--- a/docs/gateways/webhooks.md
+++ b/docs/gateways/webhooks.md
@@ -48,6 +48,11 @@ final class NotifyHandler implements NotifyHandlerInterface
             return NotifyResult::ignored();
         }
 
+        if ($context->state()['checkout_id'] !== $event->payload['checkout_id']) {
+            // Genuine, but about a different payment -- do not act on it.
+            return NotifyResult::ignored();
+        }
+
         return NotifyResult::handled(PaymentStatus::Captured, transactionId: $event->payload['transaction']);
     }
 }
@@ -67,6 +72,26 @@ disguise, and this is the method that has to stay fast.
 Throw `WebhookNotVerifiedException` when the message is not genuine. Payum answers the caller 400 with
 an empty body and leaves the payment untouched. The exception's message is for your log — telling
 whoever sent the message which check failed only helps them get it right next time.
+
+Verifying proves the message came from the PSP. It does not prove the message is about *this* payment.
+Core applies the result's status to the subject resolved from the notify token, never from the event —
+so a genuine, correctly signed event replayed against a different payment's notify URL would mark that
+payment captured too. Compare the PSP's own reference in the event against the one you stored when you
+created the checkout, as the handler above does, and decline the event on a mismatch.
+
+### The request body
+
+`Payum::notify($request)` uses the request you pass it only to verify the token in the URL. The PSR-7
+request a handler's `verify()` sees comes from the container instead, and by default that reads
+`php://input`. Under RoadRunner or FrankenPHP, where nothing lands in `php://input`, or once a framework
+has already consumed the body, that read comes back empty — every signature check then fails, and every
+message gets a silent 400 that is hard to debug.
+
+Register your own request and Payum uses that instead:
+
+```php
+$payumBuilder->addGlobalService(ServerRequestInterface::class, $request);
+```
 
 ### When the PSP signs nothing
 
@@ -150,9 +175,11 @@ $state = $context->state();
 $state['notify_url'] ??= $context->notifyUrl();
 ```
 
-Gateways with a single endpoint configured in the PSP's dashboard need none of this — point that
-endpoint at your notify script and Payum works out which gateway a message belongs to from the token in
-the URL.
+Gateways with a single endpoint configured in the PSP's dashboard can skip minting one of these per
+payment — point that one endpoint at your notify script and Payum still works out which gateway a
+message belongs to from the token in the URL. But a token minted for the gateway alone carries no
+payment: `$context->payment()` is null and `$context->state()` throws, so there is nothing for Payum to
+record a status onto. That handler has to find the payment itself from the event payload.
 
 ### Testing one
 

--- a/docs/gateways/webhooks.md
+++ b/docs/gateways/webhooks.md
@@ -75,7 +75,7 @@ Some do not. Say so, rather than leaving the check out:
 ```php
 public function verify(ServerRequestInterface $request): WebhookEvent
 {
-    return WebhookEvent::unverified($request->getParsedBody());
+    return WebhookEvent::unverified((array) $request->getParsedBody());
 }
 ```
 

--- a/docs/instant-payment-notification.md
+++ b/docs/instant-payment-notification.md
@@ -14,6 +14,8 @@ A notification is an HTTP request the PSP's servers make to yours, with nobody's
 
 `Payum::notify()` verifies the token in the URL, works out which gateway it belongs to, and hands the message to that gateway. A gateway built from handlers answers it with its notify handler; the payment is updated for you, and the PSP gets back whatever the handler decided to answer. You do not parse the request or write the response — call `notify()` and let it run.
 
+The request a notify handler verifies is not the one you pass to `notify()` — see [the request body](gateways/webhooks.md#the-request-body) if signature checks fail under RoadRunner, FrankenPHP, or any framework that reads the body before Payum does.
+
 ### Reacting to a change
 
 Read the status Payum recorded rather than asking the gateway again:

--- a/docs/instant-payment-notification.md
+++ b/docs/instant-payment-notification.md
@@ -27,7 +27,7 @@ $payment = $payum->getStorage(Payment::class)->find($identity);
 PaymentStatuses::of($payment);   // the status Payum recorded after the last command
 ```
 
-This works because your payment implements `Payum\Core\Model\StatusAwareInterface`. A subject implementing it has its status kept current automatically, so it is readable without a gateway and queryable straight from storage — list every payment stuck `Pending`, or every one that reached `Captured` today, without executing anything.
+`PaymentStatuses::of()` returns `null` unless your payment implements `Payum\Core\Model\StatusAwareInterface` — nothing is recorded to read otherwise. Implement it on your own payment class and Payum keeps the status current after every command, so it becomes readable without a gateway and queryable straight from storage — list every payment stuck `Pending`, or every one that reached `Captured` today, without executing anything. See [Keeping the status on the payment](gateways/results.md#keeping-the-status-on-the-payment) for how.
 
 ### If a notification never arrives
 

--- a/docs/instant-payment-notification.md
+++ b/docs/instant-payment-notification.md
@@ -4,62 +4,48 @@ A notification is a callback. A gateway sends it back to you to let you know abo
 
 ![notification](http://www.websequencediagrams.com/cgi-bin/cdraw?lz=cGFydGljaXBhbnQgUGF5cGFsCgAHDGNhcHR1cmUucGhwAAsNbm90aWZ5ABIFCgAZCy0-KwA\_BjogYSBwdXJjYWhzZQoAUgYtPi0AQws6IHBlbmRpbmcAFggtPgBKCjogc3VjY2VzcwBiBmljYXRpb24AMTkARgcAVBZjYW5jZWxlZCAodXNlciB2b2lkIG9uIHAAggcFIHNpZGUp\&s=default)
 
-If you follow [get it started](get-it-started.md) and used a payum builder to create paypal gateway, you do not have to care about notify url. Payum does it for you. You just have to make sure [notify script](examples/notify-script.md) is accessible from web.
+A refund settling days after the customer left, a bank transfer finally clearing, a dispute the merchant only sees in the PSP's dashboard: none of these happen while anyone is looking at your site. The PSP has to call you back on its own, whenever it has something to say. That call is a notification.
 
-The model will be updated automatically once the notification is sent. What you have to do is add an extension to detect payment status changes, and act accordingly.
+### Making the endpoint reachable
 
-Here's an example of the extension:
+A notification is an HTTP request the PSP's servers make to yours, with nobody's browser involved. It has to reach a URL that is public, answers over plain HTTP or HTTPS, and never redirects or challenges the caller with a login — a PSP retries a failing delivery, it does not follow a redirect or fill in a form. See [notify script](examples/notify-script.md) for the endpoint itself.
+
+### What Payum does with one
+
+`Payum::notify()` verifies the token in the URL, works out which gateway it belongs to, and hands the message to that gateway. A gateway built from handlers answers it with its notify handler; the payment is updated for you, and the PSP gets back whatever the handler decided to answer. You do not parse the request or write the response — call `notify()` and let it run.
+
+### Reacting to a change
+
+Read the status Payum recorded rather than asking the gateway again:
 
 ```php
 <?php
+use Payum\Core\Model\PaymentStatuses;
 
-use Payum\Core\Extension\Context;
-use Payum\Core\Extension\ExtensionInterface;
-use Payum\Core\Model\PaymentInterface;
-use Payum\Core\Request\Generic;
-use Payum\Core\Request\GetHumanStatus;
-use Payum\Core\Request\GetStatusInterface;
+$payment = $payum->getStorage(Payment::class)->find($identity);
 
-class PaymentStatusExtension implements ExtensionInterface
-{
-    /**
-     * {@inheritDoc}
-     */
-    public function onPostExecute(Context $context)
-    {
-        $request = $context->getRequest();
-        if (! $request instanceof Generic) {
-            return;
-        }
-        if ($request instanceof GetStatusInterface) {
-            return;
-        }
-
-        $payment = $request->getModel();
-        if (! $payment instanceof PaymentInterface) {
-            return;
-        }
-
-        $context->getGateway()->execute($status = new GetHumanStatus($payment));
-
-        // check the status and act accordingly
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function onPreExecute(Context $context)
-    {
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function onExecute(Context $context)
-    {
-    }
-}
+PaymentStatuses::of($payment);   // the status Payum recorded after the last command
 ```
+
+This works because your payment implements `Payum\Core\Model\StatusAwareInterface`. A subject implementing it has its status kept current automatically, so it is readable without a gateway and queryable straight from storage — list every payment stuck `Pending`, or every one that reached `Captured` today, without executing anything.
+
+### If a notification never arrives
+
+Networks drop requests and PSPs have outages. When a payment sits in a status that should have moved on, ask the PSP directly instead of waiting for a notification that may not come:
+
+```php
+<?php
+use Payum\Core\Command\SyncCommand;
+
+$gateway = $payum->getGateway('acme');
+$gateway->execute(SyncCommand::forPayment($payment));
+```
+
+That is what a reconciliation job does: walk the payments still open, dispatch a `SyncCommand` for each, and let Payum record whatever the PSP answers. See [Commands](gateways/commands.md).
+
+### Writing a gateway that receives them
+
+A gateway receives notifications by shipping a notify handler — see [Webhooks](gateways/webhooks.md).
 
 ***
 

--- a/rector.php
+++ b/rector.php
@@ -12,6 +12,7 @@ use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\PHPUnit\CodeQuality\Rector\Expression\AssertArrayCastedObjectToAssertSameRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEmptyNullableObjectToAssertInstanceofRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\NarrowIdenticalWithConsecutiveRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\SingleWithConsecutiveToWithRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
@@ -66,6 +67,10 @@ return RectorConfig::configure()
         //  - the PHPUnit 10 matcher idiom compares constraints with assertSame().
         NarrowIdenticalWithConsecutiveRector::class,
         SingleWithConsecutiveToWithRector::class,
+
+        // assertNotInstanceOf(PaymentStatus::class, $x) passes for null AND for any other object,
+        // whereas assertNull($x) pins the one value these tests mean:
+        AssertEmptyNullableObjectToAssertInstanceofRector::class,
 
         AddVoidReturnTypeWhereNoReturnRector::class => [
             __DIR__ . '/src/Payum/Core/GatewayFactory.php',

--- a/src/Payum/Core/Command/NotifyCommand.php
+++ b/src/Payum/Core/Command/NotifyCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Command;
+
+use Payum\Core\Gateway\Capability;
+use Payum\Core\Model\PaymentInterface;
+use Payum\Core\Model\SubjectInterface;
+use Payum\Core\Result\NotifyResult;
+use Payum\Core\Security\TokenInterface;
+
+/**
+ * A PSP has sent word that something happened.
+ *
+ * Unlike every other command this one may carry neither a token nor a subject. Which payment an event
+ * belongs to is something verification works out, so a message arriving on an endpoint the application
+ * routed itself has nothing to point at until it has been read.
+ *
+ * It carries no idempotency key. A key stops the same instruction reaching a PSP twice, and a notify
+ * sends nothing; recognising a redelivery is de-duplication, which is a different job.
+ *
+ * @implements CommandInterface<NotifyResult>
+ */
+final class NotifyCommand implements CommandInterface
+{
+    private function __construct(
+        private readonly ?TokenInterface $token = null,
+        private readonly ?SubjectInterface $subject = null,
+    ) {
+    }
+
+    public static function capability(): Capability
+    {
+        return Capability::Webhooks;
+    }
+
+    /**
+     * The application routed the endpoint itself, so there is nothing to point at.
+     */
+    public static function forGateway(): self
+    {
+        return new self();
+    }
+
+    public static function forPayment(PaymentInterface $payment): self
+    {
+        return new self(subject: $payment);
+    }
+
+    public static function forToken(TokenInterface $token): self
+    {
+        return new self(token: $token);
+    }
+
+    public function payment(): ?PaymentInterface
+    {
+        return $this->subject instanceof PaymentInterface ? $this->subject : null;
+    }
+
+    public function subject(): ?SubjectInterface
+    {
+        return $this->subject;
+    }
+
+    public function token(): ?TokenInterface
+    {
+        return $this->token;
+    }
+}

--- a/src/Payum/Core/CoreGatewayFactory.php
+++ b/src/Payum/Core/CoreGatewayFactory.php
@@ -270,12 +270,17 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
                     $c->has(StorageRegistryInterface::class) ? $c->get(StorageRegistryInterface::class) : null,
                 ),
                 TemplateRenderMiddleware::class => static fn (): TemplateRenderMiddleware => new TemplateRenderMiddleware(),
+                // The body is read from php://input rather than left empty: a PSP signs the raw bytes,
+                // and $_POST is empty for the JSON payloads most of them send. An application with a
+                // framework should register its own request instead, through
+                // PayumBuilder::addGlobalService(), which overrides this.
                 ServerRequestInterface::class => static fn (ContainerInterface $c): ServerRequestInterface => $c
                     ->get(ServerRequestFactoryInterface::class)
                     ->createServerRequest($_SERVER['REQUEST_METHOD'] ?? 'GET', $_SERVER['REQUEST_URI'] ?? '/', $_SERVER)
                     ->withQueryParams($_GET)
                     ->withParsedBody($_POST)
-                    ->withCookieParams($_COOKIE),
+                    ->withCookieParams($_COOKIE)
+                    ->withBody($c->get(StreamFactoryInterface::class)->createStreamFromFile('php://input', 'r')),
 
                 // Legacy Payum service names - delegate to PSR interfaces
                 'payum.http_client' => static fn (ContainerInterface $c): HttplugClient => new HttplugClient($c->get(ClientInterface::class)),

--- a/src/Payum/Core/Exception/WebhookNotVerifiedException.php
+++ b/src/Payum/Core/Exception/WebhookNotVerifiedException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Exception;
+
+/**
+ * The message did not come from the PSP, or has been altered on the way.
+ *
+ * Its message belongs in your log rather than in the response: {@see \Payum\Core\Payum::notify()}
+ * answers 400 with an empty body, because whoever failed the check is either misconfigured or probing,
+ * and neither is helped by learning which check it was.
+ */
+class WebhookNotVerifiedException extends RuntimeException
+{
+}

--- a/src/Payum/Core/Gateway.php
+++ b/src/Payum/Core/Gateway.php
@@ -5,6 +5,7 @@ namespace Payum\Core;
 use Exception;
 use Payum\Core\Action\ActionInterface;
 use Payum\Core\Command\CommandInterface;
+use Payum\Core\Command\NotifyCommand;
 use Payum\Core\Exception\CommandNotSupportedException;
 use Payum\Core\Exception\LogicException;
 use Payum\Core\Exception\RequestNotSupportedException;
@@ -16,6 +17,7 @@ use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
 use Payum\Core\Handler\Context as HandlerContext;
 use Payum\Core\Handler\HandlerInterface;
 use Payum\Core\Handler\HandlerMap;
+use Payum\Core\Handler\NotifyHandlerInterface;
 use Payum\Core\Legacy\RequestToCommand;
 use Payum\Core\Legacy\ResultToReply;
 use Payum\Core\Legacy\StatusMarker;
@@ -381,7 +383,22 @@ class Gateway implements GatewayInterface
             throw new LogicException(sprintf('%s must be a handler declaring handle().', $serviceId));
         }
 
-        $result = $handler->handle($command, $context);
+        if ($handler instanceof NotifyHandlerInterface) {
+            if (! $command instanceof NotifyCommand) {
+                throw new LogicException(sprintf(
+                    '%s handles %s, but %s was dispatched.',
+                    $handler::class,
+                    NotifyCommand::class,
+                    $command::class,
+                ));
+            }
+
+            // Verification runs here rather than during dispatch so that middleware wraps it: a message
+            // that fails the check is something an application will want to see.
+            $result = $handler->handle($command, $handler->verify($context->httpRequest()), $context);
+        } else {
+            $result = $handler->handle($command, $context);
+        }
 
         if (! $result instanceof Result) {
             throw new LogicException(sprintf('%s::handle() must return a %s.', $handler::class, Result::class));

--- a/src/Payum/Core/Gateway.php
+++ b/src/Payum/Core/Gateway.php
@@ -432,6 +432,7 @@ class Gateway implements GatewayInterface
             $this->resolveSubject($command),
             $command->token(),
             $this->commandStack,
+            $this->name,
         );
     }
 

--- a/src/Payum/Core/Gateway/Capability.php
+++ b/src/Payum/Core/Gateway/Capability.php
@@ -29,6 +29,8 @@ enum Capability: string
 
     case Sync = 'sync';
 
+    case Webhooks = 'webhooks';
+
     // Nuance -- declared, because no handler list implies them.
     case MultiCurrency = 'multi_currency';
 
@@ -41,6 +43,4 @@ enum Capability: string
     case StoredPaymentMethods = 'stored_payment_methods';
 
     case ThreeDSecure = 'three_d_secure';
-
-    case Webhooks = 'webhooks';
 }

--- a/src/Payum/Core/Handler/Context.php
+++ b/src/Payum/Core/Handler/Context.php
@@ -38,6 +38,8 @@ final class Context
      */
     private ?ArrayObject $state = null;
 
+    private ?TokenInterface $mintedNotifyToken = null;
+
     /**
      * @param CommandInterface<Result> $command
      * @param list<self> $previous the enclosing executions, when a handler dispatches a sub-command
@@ -51,6 +53,7 @@ final class Context
         private readonly ?SubjectInterface $subject = null,
         private readonly ?TokenInterface $token = null,
         private readonly array $previous = [],
+        private readonly ?string $gatewayName = null,
     ) {
     }
 
@@ -204,5 +207,47 @@ final class Context
     public function tokens(): GenericTokenFactoryInterface
     {
         return $this->tokenFactory;
+    }
+
+    /**
+     * The name this gateway is registered under, which every token the factory mints needs.
+     *
+     * Null for a gateway assembled by hand rather than through PayumBuilder.
+     */
+    public function gatewayName(): ?string
+    {
+        return $this->gatewayName;
+    }
+
+    /**
+     * A long-lived token whose URL the PSP posts to when something happens.
+     *
+     * Points at this execution's subject, or at the gateway alone when there is none.
+     *
+     * @throws LogicException when the gateway is registered under no name
+     */
+    public function notifyToken(): TokenInterface
+    {
+        if (null === $this->gatewayName) {
+            throw new LogicException(
+                'This gateway is not registered under a name, so a notify token has nothing to name as its gateway. Register it with PayumBuilder::registerGateway().'
+            );
+        }
+
+        return $this->mintedNotifyToken ??= $this->tokenFactory->createNotifyToken($this->gatewayName, $this->subject);
+    }
+
+    /**
+     * The URL to hand a PSP that takes a notification address per payment.
+     *
+     * Minted once for this execution. Reusing it across requests is the gateway's own business: keep it
+     * in {@see self::state()} and mint only when it is absent, or a customer who retries gets a second
+     * token row.
+     *
+     * @throws LogicException when the gateway is registered under no name
+     */
+    public function notifyUrl(): string
+    {
+        return $this->notifyToken()->getTargetUrl();
     }
 }

--- a/src/Payum/Core/Handler/NotifyHandlerInterface.php
+++ b/src/Payum/Core/Handler/NotifyHandlerInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Handler;
+
+use Payum\Core\Command\NotifyCommand;
+use Payum\Core\Exception\WebhookNotVerifiedException;
+use Payum\Core\Result\NotifyResult;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Receives what a PSP sends when something happens to a payment.
+ *
+ * Checking that a message is genuine and acting on what it says are separate methods. Verification is
+ * cheap, security-critical and has to answer immediately; handling is the slow part. A gateway whose PSP
+ * signs nothing says so with {@see WebhookEvent::unverified()} rather than by leaving the check out.
+ */
+interface NotifyHandlerInterface extends HandlerInterface
+{
+    /**
+     * Establish that the message came from the PSP.
+     *
+     * Read the signed bytes with `(string) $request->getBody()`, which seeks to the start of the stream
+     * first. Do not reach for the payment here: verification that depends on stored state is handling in
+     * disguise, and this method is the one that has to stay cheap.
+     *
+     * @throws WebhookNotVerifiedException when the message is not genuine
+     */
+    public function verify(ServerRequestInterface $request): WebhookEvent;
+
+    public function handle(NotifyCommand $command, WebhookEvent $event, Context $context): NotifyResult;
+}

--- a/src/Payum/Core/Handler/WebhookEvent.php
+++ b/src/Payum/Core/Handler/WebhookEvent.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Handler;
+
+/**
+ * A message a PSP sent to say something happened, after a gateway has decided what to make of it.
+ *
+ * Produced by {@see NotifyHandlerInterface::verify()} and handed straight to handle(), so a handler
+ * cannot reach the payload without that decision having been made.
+ */
+final class WebhookEvent
+{
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function __construct(
+        private readonly bool $verified,
+        public readonly array $payload,
+        public readonly ?string $id = null,
+        public readonly ?string $type = null,
+    ) {
+    }
+
+    /**
+     * The message is genuine.
+     *
+     * @param array<string, mixed> $payload
+     * @param string|null $id the PSP's own event id, which is how a redelivery is recognised
+     * @param string|null $type the PSP's own event name, such as 'payment_intent.succeeded'
+     */
+    public static function verified(array $payload, ?string $id = null, ?string $type = null): self
+    {
+        return new self(true, $payload, $id, $type);
+    }
+
+    /**
+     * The PSP offers nothing to check, so the payload is taken on trust.
+     *
+     * A handler returning this should not act on what the message says. Re-read the state from the PSP
+     * instead, by dispatching a {@see \Payum\Core\Command\SyncCommand}.
+     *
+     * @param array<string, mixed> $payload
+     */
+    public static function unverified(array $payload, ?string $id = null, ?string $type = null): self
+    {
+        return new self(false, $payload, $id, $type);
+    }
+
+    public function isVerified(): bool
+    {
+        return $this->verified;
+    }
+}

--- a/src/Payum/Core/Legacy/RequestToCommand.php
+++ b/src/Payum/Core/Legacy/RequestToCommand.php
@@ -8,6 +8,7 @@ use Payum\Core\Command\AuthorizeCommand;
 use Payum\Core\Command\CancelCommand;
 use Payum\Core\Command\CaptureCommand;
 use Payum\Core\Command\CommandInterface;
+use Payum\Core\Command\NotifyCommand;
 use Payum\Core\Command\PayoutCommand;
 use Payum\Core\Command\RefundCommand;
 use Payum\Core\Command\SyncCommand;
@@ -18,6 +19,7 @@ use Payum\Core\Request\Authorize;
 use Payum\Core\Request\Cancel;
 use Payum\Core\Request\Capture;
 use Payum\Core\Request\Generic;
+use Payum\Core\Request\Notify;
 use Payum\Core\Request\Payout;
 use Payum\Core\Request\Refund;
 use Payum\Core\Request\Sync;
@@ -48,7 +50,9 @@ final class RequestToCommand
             || $request instanceof Refund
             || $request instanceof Cancel
             || $request instanceof Sync
-            || $request instanceof Payout;
+            || $request instanceof Payout
+            || $request instanceof Notify
+        ;
     }
 
     /**
@@ -101,6 +105,13 @@ final class RequestToCommand
                 $token instanceof TokenInterface => SyncCommand::forToken($token),
                 $payout instanceof PayoutInterface => SyncCommand::forPayout($payout),
                 $payment instanceof PaymentInterface => SyncCommand::forPayment($payment),
+                default => null,
+            },
+            // A notify may point at nothing at all, but a request that resolved to neither a token nor a
+            // payment is one of the 1.x actions that match on a details array. Leave it to them.
+            $request instanceof Notify => match (true) {
+                $token instanceof TokenInterface => NotifyCommand::forToken($token),
+                $payment instanceof PaymentInterface => NotifyCommand::forPayment($payment),
                 default => null,
             },
             $request instanceof Payout => match (true) {

--- a/src/Payum/Core/Legacy/ResultToReply.php
+++ b/src/Payum/Core/Legacy/ResultToReply.php
@@ -30,11 +30,11 @@ final class ResultToReply
      */
     public static function translate(Result $result): ?Base
     {
-        if ($result instanceof NotifyResult && $result->acknowledge instanceof Acknowledgement) {
+        if ($result instanceof NotifyResult && $result->acknowledgement instanceof Acknowledgement) {
             return new HttpResponse(
-                $result->acknowledge->body,
-                $result->acknowledge->status,
-                $result->acknowledge->headers,
+                $result->acknowledgement->body,
+                $result->acknowledgement->status,
+                $result->acknowledgement->headers,
             );
         }
 

--- a/src/Payum/Core/Legacy/ResultToReply.php
+++ b/src/Payum/Core/Legacy/ResultToReply.php
@@ -8,9 +8,12 @@ use Payum\Core\Exception\LogicException;
 use Payum\Core\Reply\Base;
 use Payum\Core\Reply\HttpPostRedirect;
 use Payum\Core\Reply\HttpRedirect;
+use Payum\Core\Reply\HttpResponse;
+use Payum\Core\Result\Acknowledgement;
 use Payum\Core\Result\NextAction;
 use Payum\Core\Result\NextAction\PostRedirect;
 use Payum\Core\Result\NextAction\Redirect;
+use Payum\Core\Result\NotifyResult;
 use Payum\Core\Result\Result;
 use function sprintf;
 
@@ -27,6 +30,14 @@ final class ResultToReply
      */
     public static function translate(Result $result): ?Base
     {
+        if ($result instanceof NotifyResult && $result->acknowledge instanceof Acknowledgement) {
+            return new HttpResponse(
+                $result->acknowledge->body,
+                $result->acknowledge->status,
+                $result->acknowledge->headers,
+            );
+        }
+
         $next = $result->next;
 
         return match (true) {

--- a/src/Payum/Core/Payum.php
+++ b/src/Payum/Core/Payum.php
@@ -302,8 +302,8 @@ class Payum implements RegistryInterface
             return new Response('', Response::HTTP_BAD_REQUEST);
         }
 
-        $acknowledgement = $result instanceof NotifyResult && $result->acknowledge instanceof Acknowledgement
-            ? $result->acknowledge
+        $acknowledgement = $result instanceof NotifyResult && $result->acknowledgement instanceof Acknowledgement
+            ? $result->acknowledgement
             : Acknowledgement::noContent();
 
         return new Response($acknowledgement->body, $acknowledgement->status, $acknowledgement->headers);

--- a/src/Payum/Core/Payum.php
+++ b/src/Payum/Core/Payum.php
@@ -4,8 +4,10 @@ namespace Payum\Core;
 
 use Exception;
 use Payum\Core\Command\CaptureCommand;
+use Payum\Core\Command\NotifyCommand;
 use Payum\Core\Exception\InvalidArgumentException;
 use Payum\Core\Exception\LogicException;
+use Payum\Core\Exception\WebhookNotVerifiedException;
 use Payum\Core\Model\PaymentInterface;
 use Payum\Core\Registry\RegistryInterface;
 use Payum\Core\Reply\HttpPostRedirect;
@@ -15,10 +17,12 @@ use Payum\Core\Reply\ReplyInterface;
 use Payum\Core\Request\Capture;
 use Payum\Core\Request\GetHumanStatus;
 use Payum\Core\Request\Notify;
+use Payum\Core\Result\Acknowledgement;
 use Payum\Core\Result\NextAction;
 use Payum\Core\Result\NextAction\PostRedirect;
 use Payum\Core\Result\NextAction\Redirect;
 use Payum\Core\Result\NextAction\RenderTemplate;
+use Payum\Core\Result\NotifyResult;
 use Payum\Core\Result\Result;
 use Payum\Core\Security\GenericTokenFactoryInterface;
 use Payum\Core\Security\HttpRequestVerifierInterface;
@@ -230,6 +234,10 @@ class Payum implements RegistryInterface
         $token = $this->httpRequestVerifier->verify($request ?: Request::createFromGlobals());
         $gateway = $this->getGateway($token->getGatewayName());
 
+        if ($gateway instanceof Gateway && $gateway->supportsCommand(NotifyCommand::class)) {
+            return $this->acknowledge($gateway, $token);
+        }
+
         try {
             $gateway->execute(new Notify($token));
 
@@ -277,5 +285,27 @@ class Payum implements RegistryInterface
             PostRedirect::class,
             RenderTemplate::class,
         ));
+    }
+
+    /**
+     * Runs a webhook and turns the handler's answer into the response the PSP is waiting for.
+     *
+     * A handler that named no acknowledgement gets 204, which every PSP accepts. A message that failed
+     * verification gets 400 with nothing in it; the exception carries the reason, for the application to
+     * log.
+     */
+    private function acknowledge(Gateway $gateway, TokenInterface $token): Response
+    {
+        try {
+            $result = $gateway->execute(NotifyCommand::forToken($token));
+        } catch (WebhookNotVerifiedException) {
+            return new Response('', Response::HTTP_BAD_REQUEST);
+        }
+
+        $acknowledgement = $result instanceof NotifyResult && $result->acknowledge instanceof Acknowledgement
+            ? $result->acknowledge
+            : Acknowledgement::noContent();
+
+        return new Response($acknowledgement->body, $acknowledgement->status, $acknowledgement->headers);
     }
 }

--- a/src/Payum/Core/Result/Acknowledgement.php
+++ b/src/Payum/Core/Result/Acknowledgement.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Result;
+
+/**
+ * What to answer the PSP with.
+ *
+ * Data rather than a response, so a handler names an answer without knowing which HTTP framework will
+ * send it. {@see \Payum\Core\Payum::notify()} turns it into one.
+ *
+ * Most PSPs accept any 2xx, which is why {@see NotifyResult} leaves it null and 204 is the answer. Set
+ * one when the PSP is particular: Adyen accepts only the body '[accepted]'.
+ */
+final class Acknowledgement
+{
+    /**
+     * @param array<string, string> $headers
+     */
+    public function __construct(
+        public readonly int $status = 204,
+        public readonly string $body = '',
+        public readonly array $headers = [],
+    ) {
+    }
+
+    public static function noContent(): self
+    {
+        return new self();
+    }
+
+    public static function ok(string $body = ''): self
+    {
+        return new self(200, $body);
+    }
+}

--- a/src/Payum/Core/Result/NotifyResult.php
+++ b/src/Payum/Core/Result/NotifyResult.php
@@ -17,13 +17,12 @@ final class NotifyResult extends Result
      */
     public function __construct(
         ?PaymentStatus $status,
-        ?NextAction $next = null,
         ?string $transactionId = null,
         ?Failure $failure = null,
         array $raw = [],
-        public readonly ?Acknowledgement $acknowledge = null,
+        public readonly ?Acknowledgement $acknowledgement = null,
     ) {
-        parent::__construct($status, $next, $transactionId, $failure, $raw);
+        parent::__construct($status, null, $transactionId, $failure, $raw);
     }
 
     /**
@@ -36,12 +35,12 @@ final class NotifyResult extends Result
      */
     public static function handled(
         ?PaymentStatus $status = null,
-        ?Acknowledgement $acknowledge = null,
+        ?Acknowledgement $acknowledgement = null,
         ?string $transactionId = null,
         ?Failure $failure = null,
         array $raw = [],
     ): self {
-        return new self($status, transactionId: $transactionId, failure: $failure, raw: $raw, acknowledge: $acknowledge);
+        return new self($status, transactionId: $transactionId, failure: $failure, raw: $raw, acknowledgement: $acknowledgement);
     }
 
     /**
@@ -51,8 +50,8 @@ final class NotifyResult extends Result
      * it was not recognised makes the PSP redeliver it on a backoff schedule for as long as it keeps
      * failing.
      */
-    public static function ignored(?Acknowledgement $acknowledge = null): self
+    public static function ignored(?Acknowledgement $acknowledgement = null): self
     {
-        return new self(null, acknowledge: $acknowledge);
+        return new self(null, acknowledgement: $acknowledgement);
     }
 }

--- a/src/Payum/Core/Result/NotifyResult.php
+++ b/src/Payum/Core/Result/NotifyResult.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Result;
+
+/**
+ * The outcome of a {@see \Payum\Core\Command\NotifyCommand}.
+ *
+ * Carries an {@see Acknowledgement} on top of the usual outcome, because a webhook is the one operation
+ * whose caller is the PSP rather than a customer.
+ */
+final class NotifyResult extends Result
+{
+    /**
+     * @param array<string, mixed> $raw
+     */
+    public function __construct(
+        ?PaymentStatus $status,
+        ?NextAction $next = null,
+        ?string $transactionId = null,
+        ?Failure $failure = null,
+        array $raw = [],
+        public readonly ?Acknowledgement $acknowledge = null,
+    ) {
+        parent::__construct($status, $next, $transactionId, $failure, $raw);
+    }
+
+    /**
+     * The event was read and acted on.
+     *
+     * A null status concludes nothing about the payment, which is right for an event that reports
+     * something the payment's state does not describe.
+     *
+     * @param array<string, mixed> $raw
+     */
+    public static function handled(
+        ?PaymentStatus $status = null,
+        ?Acknowledgement $acknowledge = null,
+        ?string $transactionId = null,
+        ?Failure $failure = null,
+        array $raw = [],
+    ): self {
+        return new self($status, transactionId: $transactionId, failure: $failure, raw: $raw, acknowledge: $acknowledge);
+    }
+
+    /**
+     * An event type this gateway has no interest in.
+     *
+     * The payment is left alone and the PSP is still answered successfully. Rejecting a message because
+     * it was not recognised makes the PSP redeliver it on a backoff schedule for as long as it keeps
+     * failing.
+     */
+    public static function ignored(?Acknowledgement $acknowledge = null): self
+    {
+        return new self(null, acknowledge: $acknowledge);
+    }
+}

--- a/src/Payum/Core/Tests/Command/NotifyCommandTest.php
+++ b/src/Payum/Core/Tests/Command/NotifyCommandTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests\Command;
+
+use Payum\Core\Command\NotifyCommand;
+use Payum\Core\Gateway\Capability;
+use Payum\Core\Model\Payment;
+use Payum\Core\Security\TokenInterface;
+use PHPUnit\Framework\TestCase;
+
+final class NotifyCommandTest extends TestCase
+{
+    public function testShouldExerciseTheWebhooksCapability(): void
+    {
+        $this->assertSame(Capability::Webhooks, NotifyCommand::capability());
+    }
+
+    public function testShouldCarryTheTokenItArrivedOn(): void
+    {
+        $token = $this->createMock(TokenInterface::class);
+
+        $command = NotifyCommand::forToken($token);
+
+        $this->assertSame($token, $command->token());
+        $this->assertNull($command->subject());
+    }
+
+    public function testShouldCarryAPaymentWhenTheCallerKnowsIt(): void
+    {
+        $payment = new Payment();
+
+        $command = NotifyCommand::forPayment($payment);
+
+        $this->assertSame($payment, $command->subject());
+        $this->assertSame($payment, $command->payment());
+        $this->assertNull($command->token());
+    }
+
+    public function testShouldAllowNeitherWhenTheApplicationRoutesTheEndpoint(): void
+    {
+        // Which payment an event belongs to is something verification works out, so unlike every other
+        // command this one may point at nothing.
+        $command = NotifyCommand::forGateway();
+
+        $this->assertNull($command->token());
+        $this->assertNull($command->subject());
+        $this->assertNull($command->payment());
+    }
+}

--- a/src/Payum/Core/Tests/CoreGatewayFactoryContainerConfigurationTest.php
+++ b/src/Payum/Core/Tests/CoreGatewayFactoryContainerConfigurationTest.php
@@ -36,6 +36,7 @@ use Psr\Container\ContainerInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use ReflectionClass;
 use stdClass;
@@ -168,6 +169,15 @@ final class CoreGatewayFactoryContainerConfigurationTest extends TestCase
         $this->assertInstanceOf(ClientInterface::class, $container->get(ClientInterface::class));
         $this->assertInstanceOf(StreamFactoryInterface::class, $container->get(StreamFactoryInterface::class));
         $this->assertInstanceOf(RequestFactoryInterface::class, $container->get(RequestFactoryInterface::class));
+    }
+
+    public function testShouldBuildARequestWhoseBodyCanBeRead(): void
+    {
+        $request = $this->buildContainer()->get(ServerRequestInterface::class);
+
+        // A PSP signs the raw body. A request built from superglobals alone has none.
+        $this->assertSame('php://input', $request->getBody()->getMetadata('uri'));
+        $this->assertTrue($request->getBody()->isReadable());
     }
 
     public function testShouldResolvePayumHttpClientAsHttplugClientWrappingThePsr18Client(): void

--- a/src/Payum/Core/Tests/Handler/ContextTest.php
+++ b/src/Payum/Core/Tests/Handler/ContextTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests\Handler;
+
+use Payum\Core\Command\CaptureCommand;
+use Payum\Core\Exception\LogicException;
+use Payum\Core\Gateway as Executor;
+use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
+use Payum\Core\Handler\Context;
+use Payum\Core\Model\Payment;
+use Payum\Core\Model\PaymentInterface;
+use Payum\Core\Security\GenericTokenFactoryInterface;
+use Payum\Core\Security\TokenInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class ContextTest extends TestCase
+{
+    public function testShouldMintANotifyTokenPointedAtTheSubject(): void
+    {
+        $payment = new Payment();
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getTargetUrl')->willReturn('https://payum.dev/notify.php?payum_token=abc');
+
+        $tokens = $this->createMock(GenericTokenFactoryInterface::class);
+        $tokens->expects($this->once())
+            ->method('createNotifyToken')
+            ->with('acme', $this->identicalTo($payment))
+            ->willReturn($token);
+
+        $context = $this->buildContext($tokens, $payment, 'acme');
+
+        $this->assertSame('https://payum.dev/notify.php?payum_token=abc', $context->notifyUrl());
+        $this->assertSame($token, $context->notifyToken());
+    }
+
+    public function testShouldMintOnceForOneExecution(): void
+    {
+        $payment = new Payment();
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getTargetUrl')->willReturn('https://payum.dev/notify.php');
+
+        $tokens = $this->createMock(GenericTokenFactoryInterface::class);
+        // Calling it twice must not leave two token rows behind.
+        $tokens->expects($this->once())
+            ->method('createNotifyToken')
+            ->willReturn($token);
+
+        $context = $this->buildContext($tokens, $payment, 'acme');
+
+        $context->notifyUrl();
+        $context->notifyUrl();
+    }
+
+    public function testShouldMintAGatewayLevelTokenWhenThereIsNoSubject(): void
+    {
+        $token = $this->createMock(TokenInterface::class);
+
+        $tokens = $this->createMock(GenericTokenFactoryInterface::class);
+        $tokens->expects($this->once())
+            ->method('createNotifyToken')
+            ->with('acme', null)
+            ->willReturn($token);
+
+        $this->buildContext($tokens, null, 'acme')->notifyToken();
+    }
+
+    public function testShouldExposeTheRegisteredGatewayName(): void
+    {
+        $context = $this->buildContext($this->createMock(GenericTokenFactoryInterface::class), null, 'acme');
+
+        $this->assertSame('acme', $context->gatewayName());
+    }
+
+    public function testShouldRefuseToMintForAGatewayRegisteredUnderNoName(): void
+    {
+        $context = $this->buildContext($this->createMock(GenericTokenFactoryInterface::class), null, null);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('is not registered under a name');
+
+        $context->notifyUrl();
+    }
+
+    private function buildContext(
+        GenericTokenFactoryInterface $tokens,
+        ?PaymentInterface $subject,
+        ?string $gatewayName
+    ): Context {
+        return new Context(
+            $this->createMock(Executor::class),
+            CaptureCommand::forPayment(new Payment()),
+            $this->createMock(PaymentGateway::class),
+            $this->createMock(ServerRequestInterface::class),
+            $tokens,
+            $subject,
+            null,
+            [],
+            $gatewayName,
+        );
+    }
+}

--- a/src/Payum/Core/Tests/Handler/HandlerMapTest.php
+++ b/src/Payum/Core/Tests/Handler/HandlerMapTest.php
@@ -6,6 +6,7 @@ namespace Payum\Core\Tests\Handler;
 
 use Payum\Core\Command\CancelCommand;
 use Payum\Core\Command\CaptureCommand;
+use Payum\Core\Command\NotifyCommand;
 use Payum\Core\Command\RefundCommand;
 use Payum\Core\Exception\LogicException;
 use Payum\Core\Gateway\Capability;
@@ -14,11 +15,15 @@ use Payum\Core\Handler\CaptureHandlerInterface;
 use Payum\Core\Handler\Context;
 use Payum\Core\Handler\HandlerInterface;
 use Payum\Core\Handler\HandlerMap;
+use Payum\Core\Handler\NotifyHandlerInterface;
 use Payum\Core\Handler\RefundHandlerInterface;
+use Payum\Core\Handler\WebhookEvent;
 use Payum\Core\Result\CancelResult;
 use Payum\Core\Result\CaptureResult;
+use Payum\Core\Result\NotifyResult;
 use Payum\Core\Result\RefundResult;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
 
 final class HandlerMapTest extends TestCase
 {
@@ -92,6 +97,21 @@ final class HandlerMapTest extends TestCase
 
         HandlerMap::fromHandlers([CaptureHandlerStub::class, AnotherCaptureHandlerStub::class]);
     }
+
+    public function testShouldMapAHandlerWhoseHandleTakesMoreThanTwoParameters(): void
+    {
+        $map = HandlerMap::fromHandlers([AcmeNotifyHandler::class]);
+
+        $this->assertSame(NotifyHandlerInterface::class, $map->serviceIdFor(NotifyCommand::class));
+        $this->assertSame([NotifyCommand::class], $map->commands());
+    }
+
+    public function testShouldDeriveTheWebhooksCapabilityFromANotifyHandler(): void
+    {
+        $map = HandlerMap::fromHandlers([AcmeNotifyHandler::class]);
+
+        $this->assertSame([Capability::Webhooks], $map->capabilities());
+    }
 }
 
 final class CaptureHandlerStub implements CaptureHandlerInterface
@@ -128,4 +148,17 @@ final class CancelHandlerStub implements CancelHandlerInterface
 
 final class HandlerWithoutACommand implements HandlerInterface
 {
+}
+
+final class AcmeNotifyHandler implements NotifyHandlerInterface
+{
+    public function handle(NotifyCommand $command, WebhookEvent $event, Context $context): NotifyResult
+    {
+        return NotifyResult::ignored();
+    }
+
+    public function verify(ServerRequestInterface $request): WebhookEvent
+    {
+        return WebhookEvent::verified([]);
+    }
 }

--- a/src/Payum/Core/Tests/Handler/WebhookEventTest.php
+++ b/src/Payum/Core/Tests/Handler/WebhookEventTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests\Handler;
+
+use Payum\Core\Handler\WebhookEvent;
+use PHPUnit\Framework\TestCase;
+
+final class WebhookEventTest extends TestCase
+{
+    public function testShouldCarryThePspsOwnIdentifiers(): void
+    {
+        $event = WebhookEvent::verified([
+            'id' => 'evt_1',
+        ], 'evt_1', 'payment_intent.succeeded');
+
+        $this->assertSame('evt_1', $event->id);
+        $this->assertSame('payment_intent.succeeded', $event->type);
+        $this->assertSame([
+            'id' => 'evt_1',
+        ], $event->payload);
+    }
+
+    public function testShouldKnowWhetherItWasChecked(): void
+    {
+        $this->assertTrue(WebhookEvent::verified([])->isVerified());
+        $this->assertFalse(WebhookEvent::unverified([])->isVerified());
+    }
+
+    public function testShouldTreatTheIdentifiersAsOptional(): void
+    {
+        $event = WebhookEvent::unverified([
+            'txn' => '1',
+        ]);
+
+        $this->assertNull($event->id);
+        $this->assertNull($event->type);
+    }
+}

--- a/src/Payum/Core/Tests/Legacy/ResultToReplyTest.php
+++ b/src/Payum/Core/Tests/Legacy/ResultToReplyTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests\Legacy;
+
+use Payum\Core\Legacy\ResultToReply;
+use Payum\Core\Reply\HttpResponse;
+use Payum\Core\Result\Acknowledgement;
+use Payum\Core\Result\CaptureResult;
+use Payum\Core\Result\NotifyResult;
+use Payum\Core\Result\PaymentStatus;
+use PHPUnit\Framework\TestCase;
+
+final class ResultToReplyTest extends TestCase
+{
+    public function testShouldTurnAnAcknowledgementIntoTheReplyAOneXScriptCatches(): void
+    {
+        $reply = ResultToReply::translate(
+            NotifyResult::handled(PaymentStatus::Captured, new Acknowledgement(200, 'OK', [
+                'X-Acme' => '1',
+            ]))
+        );
+
+        $this->assertInstanceOf(HttpResponse::class, $reply);
+        $this->assertSame('OK', $reply->getContent());
+        $this->assertSame(200, $reply->getStatusCode());
+        $this->assertSame([
+            'X-Acme' => '1',
+        ], $reply->getHeaders());
+    }
+
+    public function testShouldProduceNoReplyForANotifyThatNamedNoAcknowledgement(): void
+    {
+        // A 1.x notify script reads "nothing thrown" as 204, which is the same answer.
+        $this->assertNull(ResultToReply::translate(NotifyResult::handled(PaymentStatus::Captured)));
+    }
+
+    public function testShouldProduceNoReplyForAFinishedOperation(): void
+    {
+        $this->assertNull(ResultToReply::translate(CaptureResult::captured('txn_1')));
+    }
+}

--- a/src/Payum/Core/Tests/LegacyRequestTest.php
+++ b/src/Payum/Core/Tests/LegacyRequestTest.php
@@ -5,14 +5,17 @@ declare(strict_types=1);
 namespace Payum\Core\Tests;
 
 use League\Uri\Uri;
+use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Command\CancelCommand;
 use Payum\Core\Command\CaptureCommand;
+use Payum\Core\Command\NotifyCommand;
 use Payum\Core\Config\GatewayConfig;
 use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
 use Payum\Core\Handler\CancelHandlerInterface;
 use Payum\Core\Handler\CaptureHandlerInterface;
 use Payum\Core\Handler\Context;
+use Payum\Core\Legacy\RequestToCommand;
 use Payum\Core\Metadata\Logo;
 use Payum\Core\Metadata\Logo\Url;
 use Payum\Core\Model\Payment;
@@ -102,6 +105,32 @@ final class LegacyRequestTest extends TestCase
         $this->expectException(RequestNotSupportedException::class);
 
         $gateway->execute(new Notify($this->buildPayment()));
+    }
+
+    public function testShouldTranslateANotifyRequestCarryingAToken(): void
+    {
+        $token = $this->createMock(TokenInterface::class);
+
+        $command = RequestToCommand::translate(new Notify($token));
+
+        $this->assertInstanceOf(NotifyCommand::class, $command);
+        $this->assertSame($token, $command->token());
+    }
+
+    public function testShouldTranslateANotifyRequestCarryingAPayment(): void
+    {
+        $payment = new Payment();
+
+        $command = RequestToCommand::translate(new Notify($payment));
+
+        $this->assertInstanceOf(NotifyCommand::class, $command);
+        $this->assertSame($payment, $command->subject());
+    }
+
+    public function testShouldNotTranslateANotifyRequestCarryingOnlyDetails(): void
+    {
+        // The surviving 1.x NotifyActions match on an ArrayAccess model. Leave those requests to them.
+        $this->assertNull(RequestToCommand::translate(new Notify(new ArrayObject())));
     }
 
     public function testShouldAnswerAOneXStatusRequestFromTheRecordedStatus(): void

--- a/src/Payum/Core/Tests/LegacyRequestTest.php
+++ b/src/Payum/Core/Tests/LegacyRequestTest.php
@@ -97,11 +97,11 @@ final class LegacyRequestTest extends TestCase
         $this->assertTrue(LegacyCancelHandler::$dispatched);
     }
 
-    public function testShouldReportARequestWithNoEquivalentAsUnsupported(): void
+    public function testShouldReportNotifyAsUnsupportedWhenTheGatewayShipsNoHandlerForIt(): void
     {
         $gateway = $this->buildPayum()->getGateway('acme');
 
-        // Notify has no command behind it yet, so nothing changes for it.
+        // The request translates to NotifyCommand fine; this gateway just ships no handler for it.
         $this->expectException(RequestNotSupportedException::class);
 
         $gateway->execute(new Notify($this->buildPayment()));

--- a/src/Payum/Core/Tests/NotifyTest.php
+++ b/src/Payum/Core/Tests/NotifyTest.php
@@ -1,0 +1,342 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests;
+
+use Http\Discovery\Psr17FactoryDiscovery;
+use League\Uri\Uri;
+use Payum\Core\Command\NotifyCommand;
+use Payum\Core\Command\SyncCommand;
+use Payum\Core\Config\GatewayConfig;
+use Payum\Core\Exception\WebhookNotVerifiedException;
+use Payum\Core\Gateway\Capability;
+use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
+use Payum\Core\Handler\Context;
+use Payum\Core\Handler\NotifyHandlerInterface;
+use Payum\Core\Handler\SyncHandlerInterface;
+use Payum\Core\Handler\WebhookEvent;
+use Payum\Core\Metadata\Logo;
+use Payum\Core\Metadata\Logo\Url;
+use Payum\Core\Model\Payment;
+use Payum\Core\Model\PaymentInterface;
+use Payum\Core\Model\StatusAwareInterface;
+use Payum\Core\Payum;
+use Payum\Core\PayumBuilder;
+use Payum\Core\Registry\StorageRegistryInterface;
+use Payum\Core\Result\Acknowledgement;
+use Payum\Core\Result\NotifyResult;
+use Payum\Core\Result\PaymentStatus;
+use Payum\Core\Result\SyncResult;
+use Payum\Core\Security\TokenInterface;
+use Payum\Core\Storage\StorageInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * End to end: a PSP posts to the notify endpoint, the gateway checks the message is genuine, and what
+ * it says is recorded against the payment.
+ */
+final class NotifyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_SERVER = [
+            'HTTP_HOST' => 'payum.dev',
+        ];
+
+        AcmeNotifyHandler::$signature = 'good-signature';
+    }
+
+    public function testShouldExerciseTheWebhooksCapability(): void
+    {
+        $this->assertSame(Capability::Webhooks, NotifyCommand::capability());
+    }
+
+    public function testShouldHandleAVerifiedEvent(): void
+    {
+        $payment = $this->buildPayment();
+        $payum = $this->buildPayum($this->buildRequest('good-signature'));
+
+        $result = $payum->getGateway('acme')->execute(NotifyCommand::forPayment($payment));
+
+        $this->assertInstanceOf(NotifyResult::class, $result);
+        $this->assertSame(PaymentStatus::Captured, $result->status);
+        $this->assertSame('txn_1', $result->transactionId);
+    }
+
+    public function testShouldRecordWhatTheEventSaidAboutThePayment(): void
+    {
+        $payment = new TrackedNotifyPayment();
+        $payment->setNumber(uniqid());
+        $payment->setStatus(PaymentStatus::Pending);
+
+        $payum = $this->buildPayum($this->buildRequest('good-signature'));
+
+        $payum->getGateway('acme')->execute(NotifyCommand::forPayment($payment));
+
+        $this->assertSame(PaymentStatus::Captured, $payment->getStatus());
+    }
+
+    public function testShouldRefuseAMessageThatIsNotGenuine(): void
+    {
+        $payum = $this->buildPayum($this->buildRequest('forged'));
+
+        $this->expectException(WebhookNotVerifiedException::class);
+
+        $payum->getGateway('acme')->execute(NotifyCommand::forPayment($this->buildPayment()));
+    }
+
+    public function testShouldLeaveTheStatusAloneWhenTheMessageIsNotGenuine(): void
+    {
+        $payment = new TrackedNotifyPayment();
+        $payment->setNumber(uniqid());
+        $payment->setStatus(PaymentStatus::Pending);
+
+        $payum = $this->buildPayum($this->buildRequest('forged'));
+
+        try {
+            $payum->getGateway('acme')->execute(NotifyCommand::forPayment($payment));
+        } catch (WebhookNotVerifiedException) {
+            // The point of the test is what did not happen.
+        }
+
+        $this->assertSame(PaymentStatus::Pending, $payment->getStatus());
+    }
+
+    public function testShouldLeaveThePaymentAloneForAnEventItIgnores(): void
+    {
+        $payment = new TrackedNotifyPayment();
+        $payment->setNumber(uniqid());
+        $payment->setStatus(PaymentStatus::Pending);
+
+        $payum = $this->buildPayum($this->buildRequest('good-signature', 'invoice.drafted'));
+
+        $result = $payum->getGateway('acme')->execute(NotifyCommand::forPayment($payment));
+
+        $this->assertNull($result->status);
+        $this->assertSame(PaymentStatus::Pending, $payment->getStatus());
+    }
+
+    public function testShouldReadTheStateAPreviousCommandWrote(): void
+    {
+        $payment = $this->buildPayment();
+        $payment->setDetails([
+            'checkout_id' => 'chk_1',
+        ]);
+
+        $payum = $this->buildPayum($this->buildRequest('good-signature'));
+
+        $result = $payum->getGateway('acme')->execute(NotifyCommand::forPayment($payment));
+
+        $this->assertSame('chk_1', $result->raw['seen_checkout']);
+    }
+
+    public function testShouldLetAGatewayThatCannotVerifyReReadFromThePsp(): void
+    {
+        $payment = $this->buildPayment();
+
+        $payum = (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addGlobalService(ServerRequestInterface::class, $this->buildRequest('irrelevant'))
+            ->registerGateway('trusting', new TrustingNotifyConfig())
+            ->getPayum();
+
+        $result = $payum->getGateway('trusting')->execute(NotifyCommand::forPayment($payment));
+
+        // The event was taken on trust, so the answer comes from asking the PSP rather than from the
+        // message.
+        $this->assertSame(PaymentStatus::Refunded, $result->status);
+    }
+
+    private function buildPayment(): Payment
+    {
+        $payment = new Payment();
+        $payment->setNumber(uniqid());
+        $payment->setCurrencyCode('EUR');
+        $payment->setTotalAmount(123);
+        $payment->setDescription('An order');
+
+        return $payment;
+    }
+
+    private function buildRequest(string $signature, string $type = 'payment.captured'): ServerRequestInterface
+    {
+        $body = json_encode([
+            'id' => 'evt_1',
+            'type' => $type,
+            'transaction' => 'txn_1',
+        ], JSON_THROW_ON_ERROR);
+
+        return Psr17FactoryDiscovery::findServerRequestFactory()
+            ->createServerRequest('POST', 'https://payum.dev/notify.php')
+            ->withHeader('Acme-Signature', $signature)
+            ->withBody(Psr17FactoryDiscovery::findStreamFactory()->createStream($body));
+    }
+
+    /**
+     * @return Payum<StorageRegistryInterface<StorageInterface<TokenInterface>>>
+     */
+    private function buildPayum(ServerRequestInterface $request): Payum
+    {
+        return (new PayumBuilder())
+            ->addDefaultStorages()
+            // What a framework does: hand Payum the real request instead of the one built from globals.
+            ->addGlobalService(ServerRequestInterface::class, $request)
+            ->registerGateway('acme', new AcmeNotifyConfig())
+            ->getPayum();
+    }
+}
+
+final class AcmeNotifyConfig implements GatewayConfig
+{
+    public function getGatewayClass(): string
+    {
+        return AcmeNotifyGateway::class;
+    }
+}
+
+final class AcmeNotifyGateway implements PaymentGateway
+{
+    public function configClass(): string
+    {
+        return AcmeNotifyConfig::class;
+    }
+
+    public function handlers(): array
+    {
+        return [AcmeNotifyHandler::class];
+    }
+
+    public function logo(): Logo
+    {
+        return Url::create('https://acme.test/logo.svg');
+    }
+
+    public function name(): string
+    {
+        return 'Acme';
+    }
+
+    public function websiteUrl(): Uri
+    {
+        return Uri::new('https://acme.test');
+    }
+}
+
+final class AcmeNotifyHandler implements NotifyHandlerInterface
+{
+    public static string $signature = 'good-signature';
+
+    public function handle(NotifyCommand $command, WebhookEvent $event, Context $context): NotifyResult
+    {
+        if ('payment.captured' !== $event->type) {
+            return NotifyResult::ignored();
+        }
+
+        return NotifyResult::handled(
+            PaymentStatus::Captured,
+            Acknowledgement::ok('[accepted]'),
+            $event->payload['transaction'],
+            raw: [
+                'seen_checkout' => $context->state()['checkout_id'],
+            ],
+        );
+    }
+
+    public function verify(ServerRequestInterface $request): WebhookEvent
+    {
+        if (! hash_equals(self::$signature, $request->getHeaderLine('Acme-Signature'))) {
+            throw new WebhookNotVerifiedException('The signature does not match.');
+        }
+
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $request->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        return WebhookEvent::verified($payload, $payload['id'], $payload['type']);
+    }
+}
+
+final class TrustingNotifyConfig implements GatewayConfig
+{
+    public function getGatewayClass(): string
+    {
+        return TrustingNotifyGateway::class;
+    }
+}
+
+final class TrustingNotifyGateway implements PaymentGateway
+{
+    public function configClass(): string
+    {
+        return TrustingNotifyConfig::class;
+    }
+
+    public function handlers(): array
+    {
+        return [TrustingNotifyHandler::class, TrustingSyncHandler::class];
+    }
+
+    public function logo(): Logo
+    {
+        return Url::create('https://trusting.test/logo.svg');
+    }
+
+    public function name(): string
+    {
+        return 'Trusting';
+    }
+
+    public function websiteUrl(): Uri
+    {
+        return Uri::new('https://trusting.test');
+    }
+}
+
+final class TrustingNotifyHandler implements NotifyHandlerInterface
+{
+    public function handle(NotifyCommand $command, WebhookEvent $event, Context $context): NotifyResult
+    {
+        if ($event->isVerified()) {
+            return NotifyResult::handled(PaymentStatus::Captured);
+        }
+
+        $payment = $context->payment();
+
+        if (! $payment instanceof PaymentInterface) {
+            return NotifyResult::ignored();
+        }
+
+        $synced = $context->execute(SyncCommand::forPayment($payment));
+
+        return NotifyResult::handled($synced->status);
+    }
+
+    public function verify(ServerRequestInterface $request): WebhookEvent
+    {
+        return WebhookEvent::unverified([]);
+    }
+}
+
+final class TrustingSyncHandler implements SyncHandlerInterface
+{
+    public function handle(SyncCommand $command, Context $context): SyncResult
+    {
+        return SyncResult::synced(PaymentStatus::Refunded, 'txn_2');
+    }
+}
+
+class TrackedNotifyPayment extends Payment implements StatusAwareInterface
+{
+    private PaymentStatus $status = PaymentStatus::New;
+
+    public function getStatus(): PaymentStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(PaymentStatus $status): void
+    {
+        $this->status = $status;
+    }
+}

--- a/src/Payum/Core/Tests/NotifyTest.php
+++ b/src/Payum/Core/Tests/NotifyTest.php
@@ -6,6 +6,7 @@ namespace Payum\Core\Tests;
 
 use Http\Discovery\Psr17FactoryDiscovery;
 use League\Uri\Uri;
+use Payum\Core\Command\CommandInterface;
 use Payum\Core\Command\NotifyCommand;
 use Payum\Core\Command\SyncCommand;
 use Payum\Core\Config\GatewayConfig;
@@ -18,6 +19,7 @@ use Payum\Core\Handler\SyncHandlerInterface;
 use Payum\Core\Handler\WebhookEvent;
 use Payum\Core\Metadata\Logo;
 use Payum\Core\Metadata\Logo\Url;
+use Payum\Core\Middleware\MiddlewareInterface;
 use Payum\Core\Model\Payment;
 use Payum\Core\Model\PaymentInterface;
 use Payum\Core\Model\StatusAwareInterface;
@@ -27,6 +29,7 @@ use Payum\Core\Registry\StorageRegistryInterface;
 use Payum\Core\Result\Acknowledgement;
 use Payum\Core\Result\NotifyResult;
 use Payum\Core\Result\PaymentStatus;
+use Payum\Core\Result\Result;
 use Payum\Core\Result\SyncResult;
 use Payum\Core\Security\TokenInterface;
 use Payum\Core\Storage\StorageInterface;
@@ -46,6 +49,7 @@ final class NotifyTest extends TestCase
         ];
 
         AcmeNotifyHandler::$signature = 'good-signature';
+        VerificationRecordingMiddleware::$seen = null;
     }
 
     public function testShouldExerciseTheWebhooksCapability(): void
@@ -147,6 +151,24 @@ final class NotifyTest extends TestCase
         // The event was taken on trust, so the answer comes from asking the PSP rather than from the
         // message.
         $this->assertSame(PaymentStatus::Refunded, $result->status);
+    }
+
+    public function testShouldRunVerificationInsideThePipeline(): void
+    {
+        $payum = (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addGlobalService(ServerRequestInterface::class, $this->buildRequest('forged'))
+            ->addMiddleware(new VerificationRecordingMiddleware())
+            ->registerGateway('acme', new AcmeNotifyConfig())
+            ->getPayum();
+
+        try {
+            $payum->getGateway('acme')->execute(NotifyCommand::forPayment($this->buildPayment()));
+        } catch (WebhookNotVerifiedException) {
+            // The point of the test is what the middleware saw before this was rethrown.
+        }
+
+        $this->assertInstanceOf(WebhookNotVerifiedException::class, VerificationRecordingMiddleware::$seen);
     }
 
     private function buildPayment(): Payment
@@ -323,6 +345,22 @@ final class TrustingSyncHandler implements SyncHandlerInterface
     public function handle(SyncCommand $command, Context $context): SyncResult
     {
         return SyncResult::synced(PaymentStatus::Refunded, 'txn_2');
+    }
+}
+
+final class VerificationRecordingMiddleware implements MiddlewareInterface
+{
+    public static ?WebhookNotVerifiedException $seen = null;
+
+    public function process(CommandInterface $command, Context $context, callable $next): Result
+    {
+        try {
+            return $next($command, $context);
+        } catch (WebhookNotVerifiedException $e) {
+            self::$seen = $e;
+
+            throw $e;
+        }
     }
 }
 

--- a/src/Payum/Core/Tests/NotifyTest.php
+++ b/src/Payum/Core/Tests/NotifyTest.php
@@ -171,6 +171,56 @@ final class NotifyTest extends TestCase
         $this->assertInstanceOf(WebhookNotVerifiedException::class, VerificationRecordingMiddleware::$seen);
     }
 
+    public function testShouldAnswerThePspWithWhatTheHandlerAskedFor(): void
+    {
+        $payum = $this->buildPayum($this->buildRequest('good-signature'));
+        $token = $this->mintNotifyToken($payum);
+
+        $response = $payum->notify([
+            'payum_token' => $token,
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('[accepted]', $response->getContent());
+    }
+
+    public function testShouldAnswerNoContentWhenTheHandlerNamesNothing(): void
+    {
+        $payum = $this->buildPayum($this->buildRequest('good-signature', 'invoice.drafted'));
+        $token = $this->mintNotifyToken($payum);
+
+        $response = $payum->notify([
+            'payum_token' => $token,
+        ]);
+
+        $this->assertSame(204, $response->getStatusCode());
+    }
+
+    public function testShouldAnswerBadRequestWithoutSayingWhyWhenVerificationFails(): void
+    {
+        $payum = $this->buildPayum($this->buildRequest('forged'));
+        $token = $this->mintNotifyToken($payum);
+
+        $response = $payum->notify([
+            'payum_token' => $token,
+        ]);
+
+        // Whoever failed the check is misconfigured or probing. Neither is helped by the detail.
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame('', $response->getContent());
+    }
+
+    /**
+     * @param Payum<StorageRegistryInterface<StorageInterface<TokenInterface>>> $payum
+     */
+    private function mintNotifyToken(Payum $payum): TokenInterface
+    {
+        $payment = $this->buildPayment();
+        $payum->getStorage($payment::class)->update($payment);
+
+        return $payum->getTokenFactory()->createNotifyToken('acme', $payment);
+    }
+
     private function buildPayment(): Payment
     {
         $payment = new Payment();

--- a/src/Payum/Core/Tests/NotifyTest.php
+++ b/src/Payum/Core/Tests/NotifyTest.php
@@ -11,7 +11,6 @@ use Payum\Core\Command\NotifyCommand;
 use Payum\Core\Command\SyncCommand;
 use Payum\Core\Config\GatewayConfig;
 use Payum\Core\Exception\WebhookNotVerifiedException;
-use Payum\Core\Gateway\Capability;
 use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
 use Payum\Core\Handler\Context;
 use Payum\Core\Handler\NotifyHandlerInterface;
@@ -50,11 +49,6 @@ final class NotifyTest extends TestCase
 
         AcmeNotifyHandler::$signature = 'good-signature';
         VerificationRecordingMiddleware::$seen = null;
-    }
-
-    public function testShouldExerciseTheWebhooksCapability(): void
-    {
-        $this->assertSame(Capability::Webhooks, NotifyCommand::capability());
     }
 
     public function testShouldHandleAVerifiedEvent(): void

--- a/src/Payum/Core/Tests/Result/AcknowledgementTest.php
+++ b/src/Payum/Core/Tests/Result/AcknowledgementTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests\Result;
+
+use Payum\Core\Result\Acknowledgement;
+use PHPUnit\Framework\TestCase;
+
+final class AcknowledgementTest extends TestCase
+{
+    public function testShouldDefaultToNoContent(): void
+    {
+        $acknowledgement = Acknowledgement::noContent();
+
+        $this->assertSame(204, $acknowledgement->status);
+        $this->assertSame('', $acknowledgement->body);
+        $this->assertSame([], $acknowledgement->headers);
+    }
+
+    public function testShouldCarryABodyThePspInsistsOn(): void
+    {
+        $acknowledgement = Acknowledgement::ok('[accepted]');
+
+        $this->assertSame(200, $acknowledgement->status);
+        $this->assertSame('[accepted]', $acknowledgement->body);
+    }
+
+    public function testShouldCarryHeadersWhenBuiltDirectly(): void
+    {
+        $acknowledgement = new Acknowledgement(200, '{"ok":true}', [
+            'Content-Type' => 'application/json',
+        ]);
+
+        $this->assertSame(200, $acknowledgement->status);
+        $this->assertSame('{"ok":true}', $acknowledgement->body);
+        $this->assertSame([
+            'Content-Type' => 'application/json',
+        ], $acknowledgement->headers);
+    }
+}

--- a/src/Payum/Core/Tests/Result/NotifyResultTest.php
+++ b/src/Payum/Core/Tests/Result/NotifyResultTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests\Result;
+
+use Payum\Core\Result\Acknowledgement;
+use Payum\Core\Result\NotifyResult;
+use Payum\Core\Result\PaymentStatus;
+use PHPUnit\Framework\TestCase;
+
+final class NotifyResultTest extends TestCase
+{
+    public function testShouldReportWhatTheEventSaidAboutThePayment(): void
+    {
+        $result = NotifyResult::handled(PaymentStatus::Captured, transactionId: 'txn_1');
+
+        $this->assertSame(PaymentStatus::Captured, $result->status);
+        $this->assertSame('txn_1', $result->transactionId);
+        $this->assertTrue($result->isSuccessful());
+    }
+
+    public function testShouldCarryTheAnswerThePspInsistsOn(): void
+    {
+        $result = NotifyResult::handled(PaymentStatus::Captured, Acknowledgement::ok('[accepted]'));
+
+        $this->assertInstanceOf(Acknowledgement::class, $result->acknowledge);
+        $this->assertSame('[accepted]', $result->acknowledge->body);
+    }
+
+    public function testShouldLeaveThePaymentAloneForAnEventItDoesNotCareAbout(): void
+    {
+        $result = NotifyResult::ignored();
+
+        $this->assertNull($result->status);
+        $this->assertNull($result->acknowledge);
+        $this->assertFalse($result->isFailed());
+    }
+
+    public function testShouldConcludeNothingWhenNoStatusIsGiven(): void
+    {
+        $this->assertNull(NotifyResult::handled()->status);
+    }
+}

--- a/src/Payum/Core/Tests/Result/NotifyResultTest.php
+++ b/src/Payum/Core/Tests/Result/NotifyResultTest.php
@@ -24,8 +24,8 @@ final class NotifyResultTest extends TestCase
     {
         $result = NotifyResult::handled(PaymentStatus::Captured, Acknowledgement::ok('[accepted]'));
 
-        $this->assertInstanceOf(Acknowledgement::class, $result->acknowledge);
-        $this->assertSame('[accepted]', $result->acknowledge->body);
+        $this->assertInstanceOf(Acknowledgement::class, $result->acknowledgement);
+        $this->assertSame('[accepted]', $result->acknowledgement->body);
     }
 
     public function testShouldLeaveThePaymentAloneForAnEventItDoesNotCareAbout(): void
@@ -33,7 +33,7 @@ final class NotifyResultTest extends TestCase
         $result = NotifyResult::ignored();
 
         $this->assertNull($result->status);
-        $this->assertNull($result->acknowledge);
+        $this->assertNull($result->acknowledgement);
         $this->assertFalse($result->isFailed());
     }
 


### PR DESCRIPTION
Closes #1054.

`Payum::notify()` still dispatched `Payum\Core\Request\Notify`, which has no command behind it, so webhooks failed against any gateway built from handlers. This adds the missing piece.

## The handler contract

Verification and handling are separate methods, so a gateway cannot quietly skip the check — PHP will not let it implement the interface without a `verify()`:

```php
interface NotifyHandlerInterface extends HandlerInterface
{
    public function verify(ServerRequestInterface $request): WebhookEvent;

    public function handle(NotifyCommand $command, WebhookEvent $event, Context $context): NotifyResult;
}
```

`verify()` takes only the request: verification that reaches for the payment is handling in disguise, and a request-only `verify()` is what makes the deferred queue pass possible. It runs inside the middleware pipeline, so a failed check is visible to anything wrapping a command.

A gateway whose provider signs nothing says so with `WebhookEvent::unverified()` and re-reads the state with a `SyncCommand`, which makes the absence of a signature greppable rather than invisible.

## What else is here

- `NotifyResult` carries an `Acknowledgement`: data rather than a thrown reply, so a queued or replayed notify still works. Null means 204. `NotifyResult::ignored()` exists because answering 4xx to an unrecognised event makes the provider redeliver it forever.
- `Context::notifyUrl()` / `notifyToken()` / `gatewayName()`. A handler could not mint a notify token before, because that needs the name the gateway is *registered* under and nothing handed it over.
- `Notify` translates to `NotifyCommand`, and an acknowledgement translates back to the `HttpResponse` a 1.x notify script already catches, so `docs/examples/notify-script.md` keeps working against a ported gateway.
- `Capability::Webhooks` is now derived from shipping a notify handler rather than declared.

## Two fixes that came out of review

**The default PSR-7 request had no body.** `CoreGatewayFactory` built it from superglobals and never populated the body, so for a JSON webhook `$_POST` is empty and `getBody()` is an empty stream — every signature check would have compared an HMAC against `''`. It now reads `php://input` lazily. This is the one change here that touches every gateway rather than only webhook ones.

**Verification proves a message came from the provider; it does not prove it is about this payment.** Core applies the result's status to the subject resolved from the notify *token*, never from the event, so a genuine correctly-signed event replayed against another payment's notify URL would mark that payment captured. Core cannot enforce the binding — only the gateway knows which field of its provider's payload is the reference — so `docs/gateways/webhooks.md` documents it and the samples model the check.

## Not in this PR

De-duplication by event id, persisting verified events for replay, async dispatch, and tokenless routing. `WebhookEvent::$id` is in place so gateways populate it before anything depends on it, and `NotifyCommand::forGateway()` exists so the routing pass adds no constructor. Notify tokens stay: changing the URL a configured provider posts to is not a minor-version change.

One thing worth naming for whoever picks those up — the event is created and consumed inside `Gateway::handle()`, so no middleware can see it. A de-duplication or event-store pass will have to move it onto `Context` or change that method.

## Docs

New `docs/gateways/webhooks.md` for gateway authors; `docs/instant-payment-notification.md` rewritten for integrators (it was a 1.x extension example); rows added to the commands, handlers, results and migration pages; `CHANGELOG.md` and `UPGRADE.md`.

## Checks

3281 tests green, ECS clean, PHPStan unchanged (76 pre-existing Doctrine ODM errors locally), Rector dry-run clean. The six gateways still shipping 1.x `NotifyAction` classes are untouched and pass — they never reach the translation, since it is gated on the gateway having a handler map.