### PR TITLE
Deprecate every v1 entry point with a message naming its v2 replacement

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -42,9 +42,11 @@
     than once per dispatch. Dispatching one at a gateway that has moved to handlers still works: it is
     translated, run through the handler, and answered the way 1.x expects.
   * The sub-requests a 1.x action dispatches at its own gateway (`GetHttpRequest`, `RenderTemplate`,
-    `GetCurrency`, `GetToken`, `GetHumanStatus`, `GetBinaryStatus`), the replies it throws, core's own
-    actions and the extension mechanism carry a `@deprecated` naming their replacement, but emit
-    nothing at runtime: an application cannot act on a notice about a dependency's internals.
+    `GetCurrency`, `GetToken`, `GetHumanStatus`, `GetBinaryStatus`), the replies it throws, the
+    `Payum\Core\Action` classes and the extension mechanism carry a `@deprecated` naming their
+    replacement, but emit nothing at runtime: an application cannot act on a notice about a
+    dependency's internals. The classes an application registers itself — the bridge actions below
+    among them — do emit.
   * `Payum\Core\Request\Generic`, `Payum\Core\Action\ActionInterface` and `Payum\Core\Request\Convert`
     are **not** deprecated. Every third-party gateway extends the first two, and the third has no
     replacement — a handler builds its own payload.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -31,7 +31,23 @@
   * An application can hand its own PSR-11 container to `Payum\Core\PayumBuilder::setGlobalContainer()`, or register
     single services with `Payum\Core\PayumBuilder::addGlobalService()`. Implement
     `Payum\Core\DI\ListableContainerInterface` on your container to have its services autowired into gateway actions.
-* The whole `Payum\Core\Bridge\Symfony` namespace is deprecated. Use the same classes from `payum/payum-bundle` instead.
+* The whole `Payum\Core\Bridge\Symfony` namespace is deprecated. Every message now names the class in
+  `payum/payum-bundle` that replaces it — the same relative path under `Payum\Bundle\PayumBundle`.
+* The 1.x request, reply, action and extension surface is deprecated in favour of commands, handlers,
+  results and middleware. Everything still works in 2.0 and goes in 3.0; see
+  [Migrating a gateway from 1.x](docs/gateways/migrating-from-v1.md) for the whole map, and
+  [Deprecated APIs](docs/di/migration-guide.md#deprecated-apis) for the table.
+  * The seven operation requests — `Capture`, `Authorize`, `Refund`, `Cancel`, `Sync`, `Payout` and
+    `Notify` — emit a deprecation naming the command that means the same thing, once per class rather
+    than once per dispatch. Dispatching one at a gateway that has moved to handlers still works: it is
+    translated, run through the handler, and answered the way 1.x expects.
+  * The sub-requests a 1.x action dispatches at its own gateway (`GetHttpRequest`, `RenderTemplate`,
+    `GetCurrency`, `GetToken`, `GetHumanStatus`, `GetBinaryStatus`), the replies it throws, core's own
+    actions and the extension mechanism carry a `@deprecated` naming their replacement, but emit
+    nothing at runtime: an application cannot act on a notice about a dependency's internals.
+  * `Payum\Core\Request\Generic`, `Payum\Core\Action\ActionInterface` and `Payum\Core\Request\Convert`
+    are **not** deprecated. Every third-party gateway extends the first two, and the third has no
+    replacement — a handler builds its own payload.
 * Webhooks are handled by a command. `Payum::notify()` dispatches `Payum\Core\Command\NotifyCommand`
   against a gateway built from handlers, and falls back to `Payum\Core\Request\Notify` for one that
   still ships actions, so nothing needs changing to keep working.

--- a/docs/di/migration-guide.md
+++ b/docs/di/migration-guide.md
@@ -340,6 +340,31 @@ migrate at your own pace.
 | `'httplug.stream_factory'` | `Psr\Http\Message\StreamFactoryInterface` |
 | `'httplug.message_factory'` | `Psr\Http\Message\RequestFactoryInterface` |
 | `Payum\Core\Bridge\Spl\ArrayObject` as a service | `Psr\Container\ContainerInterface` |
+| `Payum\Core\PayumBuilder::addGateway()` | `registerGateway()`, given a `Payum\Core\Config\GatewayConfig` |
+| `Payum\Core\Request\Capture` and the six other operation requests | `Payum\Core\Command\CaptureCommand` and its siblings |
+| `Payum\Core\Request\GetHttpRequest` | `Payum\Core\Handler\Context::httpRequest()` |
+| `Payum\Core\Request\GetToken` | `Payum\Core\Handler\Context::token()` |
+| `Payum\Core\Request\RenderTemplate` | `Payum\Core\Result\NextAction\RenderTemplate` |
+| `Payum\Core\Request\GetCurrency` | `Payum\Core\ISO4217\Currency` |
+| `Payum\Core\Request\GetHumanStatus`, `GetBinaryStatus` | `Payum\Core\Result\PaymentStatus`, declared on the result |
+| `Payum\Core\Reply\HttpRedirect` | `Payum\Core\Result\NextAction\Redirect` |
+| `Payum\Core\Reply\HttpPostRedirect` | `Payum\Core\Result\NextAction\PostRedirect` |
+| `Payum\Core\Reply\HttpResponse` | `Payum\Core\Result\Acknowledgement` on a `NotifyResult` |
+| `Payum\Core\Action\GatewayAwareAction` | `GatewayAwareInterface` + `GatewayAwareTrait`, or `Context::execute()` |
+| `Payum\Core\Extension\ExtensionInterface` | `Payum\Core\Middleware\MiddlewareInterface` |
+| `Payum\Core\Extension\StorageExtension` | `Payum\Core\Middleware\PersistStateMiddleware` |
+| `Payum\Core\Extension\EndlessCycleDetectorExtension` | `Payum\Core\Middleware\EndlessCycleDetectorMiddleware` |
+| `Payum\Core\Security\GenericTokenFactoryAwareInterface` / `Trait` | `Payum\Core\Handler\Context::tokens()` |
+
+Only the entry points an application names itself emit a deprecation at runtime, and each does so once
+per class rather than once per call. The ones a gateway's own actions name — the sub-requests, the
+replies, core's actions, the extension mechanism — carry a `@deprecated` and nothing else: an
+application running an unported gateway cannot act on a notice about that gateway's internals, and its
+author reads the docblock.
+
+`Payum\Core\Request\Generic`, `Payum\Core\Action\ActionInterface` and `Payum\Core\Request\Convert` are
+not on the list. The first two are what every third-party gateway extends and are not going anywhere in
+2.x; the third has no replacement, because a handler builds its own payload.
 
 ## Testing Your Migration
 

--- a/src/Payum/Core/Action/AuthorizePaymentAction.php
+++ b/src/Payum/Core/Action/AuthorizePaymentAction.php
@@ -11,6 +11,11 @@ use Payum\Core\Request\Authorize;
 use Payum\Core\Request\Convert;
 use Payum\Core\Request\GetHumanStatus;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A gateway built from handlers implements
+ *             Payum\Core\Handler\AuthorizeHandlerInterface, and the details this action unwrapped are
+ *             Payum\Core\Handler\Context::state().
+ */
 class AuthorizePaymentAction implements ActionInterface, GatewayAwareInterface
 {
     use GatewayAwareTrait;

--- a/src/Payum/Core/Action/CapturePaymentAction.php
+++ b/src/Payum/Core/Action/CapturePaymentAction.php
@@ -11,6 +11,11 @@ use Payum\Core\Request\Capture;
 use Payum\Core\Request\Convert;
 use Payum\Core\Request\GetHumanStatus;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A gateway built from handlers implements
+ *             Payum\Core\Handler\CaptureHandlerInterface, and the details this action unwrapped are
+ *             Payum\Core\Handler\Context::state().
+ */
 class CapturePaymentAction implements ActionInterface, GatewayAwareInterface
 {
     use GatewayAwareTrait;

--- a/src/Payum/Core/Action/ExecuteSameRequestWithModelDetailsAction.php
+++ b/src/Payum/Core/Action/ExecuteSameRequestWithModelDetailsAction.php
@@ -11,6 +11,10 @@ use Payum\Core\Model\DetailsAwareInterface;
 use Payum\Core\Model\ModelAggregateInterface;
 use Payum\Core\Model\ModelAwareInterface;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A handler is given the details this action unwrapped
+ *             as Payum\Core\Handler\Context::state(), so nothing has to re-dispatch to reach them.
+ */
 class ExecuteSameRequestWithModelDetailsAction implements ActionInterface, GatewayAwareInterface
 {
     use GatewayAwareTrait;

--- a/src/Payum/Core/Action/GatewayAwareAction.php
+++ b/src/Payum/Core/Action/GatewayAwareAction.php
@@ -4,9 +4,15 @@ namespace Payum\Core\Action;
 
 use Payum\Core\GatewayAwareInterface;
 use Payum\Core\GatewayAwareTrait;
+use Payum\Core\Handler\Context;
+use function trigger_deprecation;
+
+trigger_deprecation('payum/core', '2.0.0', 'The %s class is deprecated and will be removed in 3.0. Implement %s and use %s on the action itself, or port it to a handler and dispatch through %s::execute().', GatewayAwareAction::class, GatewayAwareInterface::class, GatewayAwareTrait::class, Context::class);
 
 /**
- * @deprecated  since 1.3 will be removed in 2.0.  Use trait+interface in your classes.
+ * @deprecated since 2.0.0, will be removed in 3.0. Implement Payum\Core\GatewayAwareInterface and use
+ *             Payum\Core\GatewayAwareTrait on the action itself, or port it to a handler and dispatch
+ *             through Payum\Core\Handler\Context::execute().
  */
 abstract class GatewayAwareAction implements ActionInterface, GatewayAwareInterface
 {

--- a/src/Payum/Core/Action/GetCurrencyAction.php
+++ b/src/Payum/Core/Action/GetCurrencyAction.php
@@ -6,6 +6,11 @@ use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\ISO4217\Currency;
 use Payum\Core\Request\GetCurrency;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A handler calls
+ *             Payum\Core\ISO4217\Currency::createFromIso4217Alpha3() or ::createFromIso4217Numeric()
+ *             directly instead.
+ */
 class GetCurrencyAction implements ActionInterface
 {
     /**

--- a/src/Payum/Core/Action/GetTokenAction.php
+++ b/src/Payum/Core/Action/GetTokenAction.php
@@ -8,6 +8,11 @@ use Payum\Core\Request\GetToken;
 use Payum\Core\Security\TokenInterface;
 use Payum\Core\Storage\StorageInterface;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A handler reads the token this execution came in on
+ *             from Payum\Core\Handler\Context::token(); one that needs a different token looks it up in
+ *             the token storage, Payum\Core\Payum::getTokenStorage().
+ */
 class GetTokenAction implements ActionInterface
 {
     /**

--- a/src/Payum/Core/Action/PayoutPayoutAction.php
+++ b/src/Payum/Core/Action/PayoutPayoutAction.php
@@ -11,6 +11,11 @@ use Payum\Core\Request\Convert;
 use Payum\Core\Request\GetHumanStatus;
 use Payum\Core\Request\Payout;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A gateway built from handlers implements
+ *             Payum\Core\Handler\PayoutHandlerInterface, and the details this action unwrapped are
+ *             Payum\Core\Handler\Context::state().
+ */
 class PayoutPayoutAction implements ActionInterface, GatewayAwareInterface
 {
     use GatewayAwareTrait;

--- a/src/Payum/Core/ApiAwareInterface.php
+++ b/src/Payum/Core/ApiAwareInterface.php
@@ -5,10 +5,11 @@ namespace Payum\Core;
 use Payum\Core\Exception\UnsupportedApiException;
 use function trigger_error;
 
-@trigger_error('The ' . __NAMESPACE__ . '\ApiAwareInterface is deprecated since 2.0.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\ApiAwareInterface is deprecated since 2.0.0 and will be removed in 3.0. Take the api as a constructor argument instead, and let the container inject it.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use dependency-injection to inject the api class instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Take the api as a constructor argument instead, and
+ *             let the container inject it.
  */
 interface ApiAwareInterface
 {

--- a/src/Payum/Core/ApiAwareTrait.php
+++ b/src/Payum/Core/ApiAwareTrait.php
@@ -5,31 +5,32 @@ namespace Payum\Core;
 use Payum\Core\Exception\LogicException;
 use Payum\Core\Exception\UnsupportedApiException;
 use function is_object;
-use function trigger_error;
+use function trigger_deprecation;
+
+trigger_deprecation('payum/core', '2.0.0', 'The %s is deprecated and will be removed in 3.0. Take the api as a constructor argument instead, and let the container inject it.', ApiAwareTrait::class);
 
 /**
- * @deprecated since 2.0. Add the API class to the action constructor instead
+ * @deprecated since 2.0.0, will be removed in 3.0. Take the api as a constructor argument instead, and
+ *             let the container inject it.
  */
 trait ApiAwareTrait
 {
     /**
      * @var mixed
-     * @deprecated since 2.0. BC will be removed in 3.x. Use dependency-injection to inject the api instead.
+     * @deprecated since 2.0.0, will be removed in 3.0. Take the api as a constructor argument instead.
      */
     protected $api;
 
     /**
-     * @deprecated since 2.0. BC will be removed in 3.x. Use dependency-injection to inject the api instead.
+     * @deprecated since 2.0.0, will be removed in 3.0. Take the api as a constructor argument instead.
      */
     protected string|object|null $apiClass;
 
     /**
-     * @deprecated since 2.0. BC will be removed in 3.x. Use dependency-injection to inject the api instead.
+     * @deprecated since 2.0.0, will be removed in 3.0. Take the api as a constructor argument instead.
      */
     public function setApi($api): void
     {
-        @trigger_error(sprintf('The method %s is deprecated since 2.0. Use dependency-injection to inject the api instead.', __METHOD__), E_USER_DEPRECATED);
-
         if (empty($this->apiClass)) {
             throw new LogicException('You must configure apiClass in __constructor method of the class the trait is applied to.');
         }

--- a/src/Payum/Core/Bridge/Httplug/HttplugClient.php
+++ b/src/Payum/Core/Bridge/Httplug/HttplugClient.php
@@ -6,15 +6,16 @@ use Payum\Core\HttpClientInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use function trigger_error;
+use function trigger_deprecation;
 
-trigger_error('The ' . __NAMESPACE__ . '\HttplugClient is deprecated since 2.0.0 and will be removed in 3.0. Use Psr18ClientDiscovery::find() instead.', E_USER_DEPRECATED);
+trigger_deprecation('payum/core', '2.0.0', 'The %s is deprecated and will be removed in 3.0. Use a %s — the one Http\Discovery\Psr18ClientDiscovery::find() returns, or your own — instead.', HttplugClient::class, ClientInterface::class);
 
 /**
  * This is a HttpClient that support Httplug. This is an adapter class that make sure we can use Httplug without breaking
- * backward compatibility. At 2.0 we will be using Http\Client\HttpClient.
+ * backward compatibility.
  *
- * @deprecated This will be removed in 2.0. Consider using Http\Client\HttpClient.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use a Psr\Http\Client\ClientInterface — the one
+ *             Http\Discovery\Psr18ClientDiscovery::find() returns, or your own — instead.
  */
 class HttplugClient implements HttpClientInterface, ClientInterface
 {
@@ -26,11 +27,13 @@ class HttplugClient implements HttpClientInterface, ClientInterface
     }
 
     /**
-     * @deprecated since 2.0.0, will be removed in 3.0. Use sendRequest() instead.
+     * @deprecated since 2.0.0, will be removed in 3.0. Use
+     *             Psr\Http\Client\ClientInterface::sendRequest() instead.
      */
     public function send(RequestInterface $request): ResponseInterface
     {
-        trigger_error('The ' . self::class . '::send() is deprecated since 2.0.0 and will be removed in 3.0. Use sendRequest() instead.', E_USER_DEPRECATED);
+        trigger_deprecation('payum/core', '2.0.0', 'The %s::send() is deprecated and will be removed in 3.0. Use %s::sendRequest() instead.', self::class, ClientInterface::class);
+
         return $this->sendRequest($request);
     }
 

--- a/src/Payum/Core/Bridge/Symfony/Action/GetHttpRequestAction.php
+++ b/src/Payum/Core/Bridge/Symfony/Action/GetHttpRequestAction.php
@@ -8,10 +8,10 @@ use Payum\Core\Request\GetHttpRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-@trigger_error('The ' . __NAMESPACE__ . '\GetHttpRequestAction class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\GetHttpRequestAction class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\Action\GetHttpRequestAction from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\Action\GetHttpRequestAction from payum/payum-bundle instead.
  */
 class GetHttpRequestAction implements ActionInterface
 {
@@ -26,7 +26,7 @@ class GetHttpRequestAction implements ActionInterface
     protected $httpRequestStack;
 
     /**
-     * @deprecated
+     * @deprecated since 2.0.0, will be removed in 3.0. Use setHttpRequestStack() instead.
      */
     public function setHttpRequest(?Request $httpRequest = null): void
     {

--- a/src/Payum/Core/Bridge/Symfony/Action/ObtainCreditCardAction.php
+++ b/src/Payum/Core/Bridge/Symfony/Action/ObtainCreditCardAction.php
@@ -18,10 +18,10 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
-@trigger_error('The ' . __NAMESPACE__ . '\ObtainCreditCardAction class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\ObtainCreditCardAction class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\Action\ObtainCreditCardAction from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\Action\ObtainCreditCardAction from payum/payum-bundle instead.
  */
 class ObtainCreditCardAction implements ActionInterface, GatewayAwareInterface
 {
@@ -57,7 +57,7 @@ class ObtainCreditCardAction implements ActionInterface, GatewayAwareInterface
     }
 
     /**
-     * @deprecated
+     * @deprecated since 2.0.0, will be removed in 3.0. Use setRequestStack() instead.
      */
     public function setRequest(?Request $request = null): void
     {

--- a/src/Payum/Core/Bridge/Symfony/Action/RenderTemplateAction.php
+++ b/src/Payum/Core/Bridge/Symfony/Action/RenderTemplateAction.php
@@ -7,10 +7,10 @@ use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\Request\RenderTemplate;
 use Symfony\Component\Templating\EngineInterface;
 
-@trigger_error('The ' . __NAMESPACE__ . '\RenderTemplateAction class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\RenderTemplateAction class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\Action\RenderTemplateAction from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\Action\RenderTemplateAction from payum/payum-bundle instead.
  */
 class RenderTemplateAction implements ActionInterface
 {

--- a/src/Payum/Core/Bridge/Symfony/Builder/CoreGatewayFactoryBuilder.php
+++ b/src/Payum/Core/Bridge/Symfony/Builder/CoreGatewayFactoryBuilder.php
@@ -7,10 +7,10 @@ use Payum\Core\GatewayFactoryInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-@trigger_error('The ' . __NAMESPACE__ . '\CoreGatewayFactoryBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\CoreGatewayFactoryBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\Builder\CoreGatewayFactoryBuilder from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\Builder\CoreGatewayFactoryBuilder from payum/payum-bundle instead.
  */
 class CoreGatewayFactoryBuilder implements ContainerAwareInterface
 {

--- a/src/Payum/Core/Bridge/Symfony/Builder/GatewayFactoryBuilder.php
+++ b/src/Payum/Core/Bridge/Symfony/Builder/GatewayFactoryBuilder.php
@@ -4,10 +4,10 @@ namespace Payum\Core\Bridge\Symfony\Builder;
 
 use Payum\Core\GatewayFactoryInterface;
 
-@trigger_error('The ' . __NAMESPACE__ . '\GatewayFactoryBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\GatewayFactoryBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\Builder\GatewayFactoryBuilder from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\Builder\GatewayFactoryBuilder from payum/payum-bundle instead.
  */
 class GatewayFactoryBuilder
 {

--- a/src/Payum/Core/Bridge/Symfony/Builder/HttpRequestVerifierBuilder.php
+++ b/src/Payum/Core/Bridge/Symfony/Builder/HttpRequestVerifierBuilder.php
@@ -7,10 +7,10 @@ use Payum\Core\Security\HttpRequestVerifierInterface;
 use Payum\Core\Security\TokenInterface;
 use Payum\Core\Storage\StorageInterface;
 
-@trigger_error('The ' . __NAMESPACE__ . '\HttpRequestVerifierBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\HttpRequestVerifierBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\Builder\HttpRequestVerifierBuilder from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\Builder\HttpRequestVerifierBuilder from payum/payum-bundle instead.
  */
 class HttpRequestVerifierBuilder
 {

--- a/src/Payum/Core/Bridge/Symfony/Builder/ObtainCreditCardActionBuilder.php
+++ b/src/Payum/Core/Bridge/Symfony/Builder/ObtainCreditCardActionBuilder.php
@@ -7,10 +7,10 @@ use Payum\Core\Bridge\Symfony\Action\ObtainCreditCardAction;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-@trigger_error('The ' . __NAMESPACE__ . '\ObtainCreditCardActionBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\ObtainCreditCardActionBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\Builder\ObtainCreditCardActionBuilder from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\Builder\ObtainCreditCardActionBuilder from payum/payum-bundle instead.
  */
 class ObtainCreditCardActionBuilder
 {

--- a/src/Payum/Core/Bridge/Symfony/Builder/TokenFactoryBuilder.php
+++ b/src/Payum/Core/Bridge/Symfony/Builder/TokenFactoryBuilder.php
@@ -9,10 +9,10 @@ use Payum\Core\Security\TokenInterface;
 use Payum\Core\Storage\StorageInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-@trigger_error('The ' . __NAMESPACE__ . '\TokenFactoryBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\TokenFactoryBuilder class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\Builder\TokenFactoryBuilder from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\Builder\TokenFactoryBuilder from payum/payum-bundle instead.
  */
 class TokenFactoryBuilder
 {

--- a/src/Payum/Core/Bridge/Symfony/ContainerAwareCoreGatewayFactory.php
+++ b/src/Payum/Core/Bridge/Symfony/ContainerAwareCoreGatewayFactory.php
@@ -7,10 +7,10 @@ use Payum\Core\CoreGatewayFactory;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-@trigger_error('The ' . __NAMESPACE__ . '\ContainerAwareCoreGatewayFactory class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\ContainerAwareCoreGatewayFactory class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\ContainerAwareCoreGatewayFactory from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\ContainerAwareCoreGatewayFactory from payum/payum-bundle instead.
  */
 class ContainerAwareCoreGatewayFactory extends CoreGatewayFactory implements ContainerAwareInterface
 {

--- a/src/Payum/Core/Bridge/Symfony/ContainerAwareRegistry.php
+++ b/src/Payum/Core/Bridge/Symfony/ContainerAwareRegistry.php
@@ -6,14 +6,13 @@ use Payum\Core\Registry\AbstractRegistry;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-@trigger_error('The ' . __NAMESPACE__ . '\ContainerAwareRegistry class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\ContainerAwareRegistry class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\ContainerAwareRegistry from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
  * @template T of object
  * @extends AbstractRegistry<T>
  *
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
- * /
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\ContainerAwareRegistry from payum/payum-bundle instead.
  */
 class ContainerAwareRegistry extends AbstractRegistry implements ContainerAwareInterface
 {

--- a/src/Payum/Core/Bridge/Symfony/Event/ExecuteEvent.php
+++ b/src/Payum/Core/Bridge/Symfony/Event/ExecuteEvent.php
@@ -5,10 +5,10 @@ namespace Payum\Core\Bridge\Symfony\Event;
 use Payum\Core\Extension\Context;
 use Symfony\Contracts\EventDispatcher\Event;
 
-@trigger_error('The ' . __NAMESPACE__ . '\ExecuteEvent class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\ExecuteEvent class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\Event\ExecuteEvent from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\Event\ExecuteEvent from payum/payum-bundle instead.
  */
 class ExecuteEvent extends Event
 {

--- a/src/Payum/Core/Bridge/Symfony/Extension/EventDispatcherExtension.php
+++ b/src/Payum/Core/Bridge/Symfony/Extension/EventDispatcherExtension.php
@@ -8,10 +8,10 @@ use Payum\Core\Extension\Context;
 use Payum\Core\Extension\ExtensionInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
-@trigger_error('The ' . __NAMESPACE__ . '\EventDispatcherExtension class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\EventDispatcherExtension class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\Extension\EventDispatcherExtension from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\Extension\EventDispatcherExtension from payum/payum-bundle instead.
  */
 class EventDispatcherExtension implements ExtensionInterface
 {

--- a/src/Payum/Core/Bridge/Symfony/Form/Type/CreditCardExpirationDateType.php
+++ b/src/Payum/Core/Bridge/Symfony/Form/Type/CreditCardExpirationDateType.php
@@ -9,10 +9,10 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-@trigger_error('The ' . __NAMESPACE__ . '\CreditCardExpirationDateType class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\CreditCardExpirationDateType class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\Form\Type\CreditCardExpirationDateType from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\Form\Type\CreditCardExpirationDateType from payum/payum-bundle instead.
  */
 class CreditCardExpirationDateType extends AbstractType
 {

--- a/src/Payum/Core/Bridge/Symfony/Form/Type/CreditCardType.php
+++ b/src/Payum/Core/Bridge/Symfony/Form/Type/CreditCardType.php
@@ -8,10 +8,10 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-@trigger_error('The ' . __NAMESPACE__ . '\CreditCardType class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\CreditCardType class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\Form\Type\CreditCardType from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\Form\Type\CreditCardType from payum/payum-bundle instead.
  */
 class CreditCardType extends AbstractType
 {

--- a/src/Payum/Core/Bridge/Symfony/Form/Type/GatewayChoiceType.php
+++ b/src/Payum/Core/Bridge/Symfony/Form/Type/GatewayChoiceType.php
@@ -6,10 +6,10 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-@trigger_error('The ' . __NAMESPACE__ . '\GatewayChoiceType class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\GatewayChoiceType class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\Form\Type\GatewayChoiceType from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\Form\Type\GatewayChoiceType from payum/payum-bundle instead.
  */
 class GatewayChoiceType extends AbstractType
 {

--- a/src/Payum/Core/Bridge/Symfony/Form/Type/GatewayConfigType.php
+++ b/src/Payum/Core/Bridge/Symfony/Form/Type/GatewayConfigType.php
@@ -14,10 +14,10 @@ use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
-@trigger_error('The ' . __NAMESPACE__ . '\GatewayConfigType class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\GatewayConfigType class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\Form\Type\GatewayConfigType from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\Form\Type\GatewayConfigType from payum/payum-bundle instead.
  */
 class GatewayConfigType extends AbstractType
 {

--- a/src/Payum/Core/Bridge/Symfony/Form/Type/GatewayFactoriesChoiceType.php
+++ b/src/Payum/Core/Bridge/Symfony/Form/Type/GatewayFactoriesChoiceType.php
@@ -6,10 +6,10 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-@trigger_error('The ' . __NAMESPACE__ . '\GatewayFactoriesChoiceType class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\GatewayFactoriesChoiceType class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\Form\Type\GatewayFactoriesChoiceType from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\Form\Type\GatewayFactoriesChoiceType from payum/payum-bundle instead.
  */
 class GatewayFactoriesChoiceType extends AbstractType
 {

--- a/src/Payum/Core/Bridge/Symfony/PayumEvents.php
+++ b/src/Payum/Core/Bridge/Symfony/PayumEvents.php
@@ -2,10 +2,10 @@
 
 namespace Payum\Core\Bridge\Symfony;
 
-@trigger_error('The ' . __NAMESPACE__ . '\PayumEvents class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\PayumEvents class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\PayumEvents from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\PayumEvents from payum/payum-bundle instead.
  */
 final class PayumEvents
 {

--- a/src/Payum/Core/Bridge/Symfony/Reply/HttpResponse.php
+++ b/src/Payum/Core/Bridge/Symfony/Reply/HttpResponse.php
@@ -5,10 +5,10 @@ namespace Payum\Core\Bridge\Symfony\Reply;
 use Payum\Core\Reply\Base;
 use Symfony\Component\HttpFoundation\Response;
 
-@trigger_error('The ' . __NAMESPACE__ . '\HttpResponse class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\HttpResponse class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\Reply\HttpResponse from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\Reply\HttpResponse from payum/payum-bundle instead.
  */
 class HttpResponse extends Base
 {

--- a/src/Payum/Core/Bridge/Symfony/ReplyToSymfonyResponseConverter.php
+++ b/src/Payum/Core/Bridge/Symfony/ReplyToSymfonyResponseConverter.php
@@ -10,10 +10,10 @@ use ReflectionObject;
 use Symfony\Component\HttpFoundation\Response;
 use function trigger_error;
 
-@trigger_error('The ' . __NAMESPACE__ . '\ReplyToSymfonyResponseConverter class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\ReplyToSymfonyResponseConverter class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\ReplyToSymfonyResponseConverter from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\ReplyToSymfonyResponseConverter from payum/payum-bundle instead.
  */
 class ReplyToSymfonyResponseConverter
 {

--- a/src/Payum/Core/Bridge/Symfony/Security/HttpRequestVerifier.php
+++ b/src/Payum/Core/Bridge/Symfony/Security/HttpRequestVerifier.php
@@ -11,10 +11,10 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-@trigger_error('The ' . __NAMESPACE__ . '\HttpRequestVerifier class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\HttpRequestVerifier class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\Security\HttpRequestVerifier from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\Security\HttpRequestVerifier from payum/payum-bundle instead.
  */
 class HttpRequestVerifier implements HttpRequestVerifierInterface
 {

--- a/src/Payum/Core/Bridge/Symfony/Security/TokenFactory.php
+++ b/src/Payum/Core/Bridge/Symfony/Security/TokenFactory.php
@@ -7,10 +7,10 @@ use Payum\Core\Security\AbstractTokenFactory;
 use Payum\Core\Storage\StorageInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-@trigger_error('The ' . __NAMESPACE__ . '\TokenFactory class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\TokenFactory class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\Security\TokenFactory from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\Security\TokenFactory from payum/payum-bundle instead.
  */
 class TokenFactory extends AbstractTokenFactory
 {

--- a/src/Payum/Core/Bridge/Symfony/Validator/Constraints/CreditCardDate.php
+++ b/src/Payum/Core/Bridge/Symfony/Validator/Constraints/CreditCardDate.php
@@ -10,10 +10,10 @@ use DateTime;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\MissingOptionsException;
 
-@trigger_error('The ' . __NAMESPACE__ . '\CreditCardDate class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\CreditCardDate class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\Validator\Constraints\CreditCardDate from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\Validator\Constraints\CreditCardDate from payum/payum-bundle instead.
  */
 class CreditCardDate extends Constraint
 {

--- a/src/Payum/Core/Bridge/Symfony/Validator/Constraints/CreditCardDateValidator.php
+++ b/src/Payum/Core/Bridge/Symfony/Validator/Constraints/CreditCardDateValidator.php
@@ -10,10 +10,10 @@ use DateTime;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
-@trigger_error('The ' . __NAMESPACE__ . '\CreditCardDateValidator class is deprecated since version 2.0 and will be removed in 3.0. Use the same class from Payum/PayumBundle instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\CreditCardDateValidator class is deprecated since version 2.0 and will be removed in 3.0. Use Payum\Bundle\PayumBundle\Validator\Constraints\CreditCardDateValidator from payum/payum-bundle instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated since 2.0. Use the same class from Payum/PayumBundle instead.
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Bundle\PayumBundle\Validator\Constraints\CreditCardDateValidator from payum/payum-bundle instead.
  *
  * Validate if the Credit Card is not expired
  */

--- a/src/Payum/Core/Bridge/Twig/TwigFactory.php
+++ b/src/Payum/Core/Bridge/Twig/TwigFactory.php
@@ -11,7 +11,8 @@ use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
 /**
- * @deprecated since 1.0.0-BETA4
+ * @deprecated since 2.0.0, will be removed in 3.0. Register a gateway's template paths on the
+ *             application's own Twig environment with Payum\Core\Bridge\Twig\TwigUtil::registerPaths().
  */
 class TwigFactory
 {

--- a/src/Payum/Core/CoreGatewayFactory.php
+++ b/src/Payum/Core/CoreGatewayFactory.php
@@ -102,7 +102,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
      */
     public function create(array $config = []): Gateway
     {
-        trigger_deprecation('payum/core', '2.0.0', 'The %s is deprecated. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class);
+        trigger_deprecation('payum/core', '2.0.0', 'The %s is deprecated and will be removed in 3.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class);
 
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->addDefinitions($config);
@@ -160,7 +160,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
      */
     public function createConfig(array $config = []): array
     {
-        trigger_deprecation('payum/core', '2.0.0', 'The %s is deprecated. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class);
+        trigger_deprecation('payum/core', '2.0.0', 'The %s is deprecated and will be removed in 3.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class);
 
         $containerConfig = $this->configureContainer();
 
@@ -181,7 +181,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
         return array_merge(
             [
                 'httplug.message_factory' => static function (): MessageFactory {
-                    @trigger_error('Using "httplug.message_factory" is deprecated, use "payum.http_message_factory" instead, which will return a PSR-17 RequestFactoryInterface since payum/core 2.0.0', E_USER_DEPRECATED);
+                    @trigger_error('The "httplug.message_factory" config is deprecated since payum/core 2.0.0 and will be removed in 3.0. Use "payum.http_message_factory", which returns a Psr\Http\Message\RequestFactoryInterface.', E_USER_DEPRECATED);
 
                     if (class_exists(MessageFactoryDiscovery::class)) {
                         return MessageFactoryDiscovery::find();
@@ -202,7 +202,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
                     throw new LogicException('The httplug.message_factory could not be guessed. Install one of the following packages: php-http/guzzle7-adapter. You can also overwrite the config option with your implementation.');
                 },
                 'httplug.stream_factory' => static function () {
-                    @trigger_error('Using "httplug.stream_factory" is deprecated, use "payum.http_stream_factory" instead which will return a PSR-17 StreamFactoryInterface since payum/core 2.0.0', E_USER_DEPRECATED);
+                    @trigger_error('The "httplug.stream_factory" config is deprecated since payum/core 2.0.0 and will be removed in 3.0. Use "payum.http_stream_factory", which returns a Psr\Http\Message\StreamFactoryInterface.', E_USER_DEPRECATED);
                     if (class_exists(StreamFactoryDiscovery::class)) {
                         return StreamFactoryDiscovery::find();
                     }
@@ -218,7 +218,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
                     throw new LogicException('The httplug.stream_factory could not be guessed. Install one of the following packages: php-http/guzzle7-adapter. You can also overwrite the config option with your implementation.');
                 },
                 'httplug.client' => static function (ArrayObject $config) {
-                    @trigger_error('Using "httplug.client" is deprecated, use "payum.http_client" instead which will return a PSR-18 ClientInterface since payum/core 2.0.0', E_USER_DEPRECATED);
+                    @trigger_error('The "httplug.client" config is deprecated since payum/core 2.0.0 and will be removed in 3.0. Use "payum.http_client", which returns a Psr\Http\Client\ClientInterface.', E_USER_DEPRECATED);
 
                     if (class_exists(HttpClientDiscovery::class)) {
                         return HttpClientDiscovery::find();
@@ -442,11 +442,12 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
     }
 
     /**
-     * @deprecated since 2.0. Implement the ContainerConfiguration interface instead.
+     * @deprecated since 2.0.0, will be removed in 3.0. Implement
+     *             Payum\Core\DI\ContainerConfiguration instead.
      */
     protected function buildClosures(ArrayObject $config): void
     {
-        trigger_deprecation('payum/core', '2.0.0', 'The %s is deprecated. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class);
+        trigger_deprecation('payum/core', '2.0.0', 'The %s is deprecated and will be removed in 3.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class);
 
         // Helper to check if closure expects ArrayObject
         $canInvokeWithArrayObject = static function ($value): bool {
@@ -483,11 +484,12 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
     }
 
     /**
-     * @deprecated since 2.0. Implement the ContainerConfiguration interface instead.
+     * @deprecated since 2.0.0, will be removed in 3.0. Implement
+     *             Payum\Core\DI\ContainerConfiguration instead.
      */
     protected function buildActions(Gateway $gateway, ArrayObject $config): void
     {
-        trigger_deprecation('payum/core', '2.0.0', 'The %s is deprecated. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class);
+        trigger_deprecation('payum/core', '2.0.0', 'The %s is deprecated and will be removed in 3.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class);
         foreach ($config as $name => $value) {
             if (str_starts_with($name, 'payum.action') && null !== $value) {
                 $prepend = in_array($name, $config['payum.prepend_actions'], true) || $value instanceof PrependActionInterface;
@@ -498,14 +500,15 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
     }
 
     /**
-     * @deprecated since 2.0. Implement the ContainerConfiguration interface instead.
+     * @deprecated since 2.0.0, will be removed in 3.0. Implement
+     *             Payum\Core\DI\ContainerConfiguration instead.
      */
     protected function buildApis(Gateway $gateway, ArrayObject $config): void
     {
-        trigger_deprecation('payum/core', '2.0.0', 'The %s is deprecated. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class);
+        trigger_deprecation('payum/core', '2.0.0', 'The %s is deprecated and will be removed in 3.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class);
         foreach ($config as $name => $value) {
             if (str_starts_with($name, 'payum.api')) {
-                @trigger_error('The payum.api.* config is deprecated and will be removed in 3.0. Use dependency-injection to inject the api into the action instead.', E_USER_DEPRECATED);
+                @trigger_error('The payum.api.* config is deprecated and will be removed in 3.0. Take the api as a constructor argument on the action instead, and let the container inject it.', E_USER_DEPRECATED);
                 $prepend = in_array($name, $config['payum.prepend_apis'], true);
 
                 $gateway->addApi($value, $prepend);
@@ -514,11 +517,12 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
     }
 
     /**
-     * @deprecated since 2.0. Implement the ContainerConfiguration interface instead.
+     * @deprecated since 2.0.0, will be removed in 3.0. Implement
+     *             Payum\Core\DI\ContainerConfiguration instead.
      */
     protected function buildExtensions(Gateway $gateway, ArrayObject $config): void
     {
-        trigger_deprecation('payum/core', '2.0.0', 'The %s is deprecated. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class);
+        trigger_deprecation('payum/core', '2.0.0', 'The %s is deprecated and will be removed in 3.0. Implement the %s interface instead.', __METHOD__, ContainerConfiguration::class);
         foreach ($config as $name => $value) {
             if (str_starts_with($name, 'payum.extension')) {
                 $prepend = in_array($name, $config['payum.prepend_extensions'], true) || $value instanceof PrependExtensionInterface;

--- a/src/Payum/Core/Extension/Context.php
+++ b/src/Payum/Core/Extension/Context.php
@@ -7,6 +7,11 @@ use Payum\Core\Action\ActionInterface;
 use Payum\Core\GatewayInterface;
 use Payum\Core\Reply\ReplyInterface;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A middleware is given
+ *             Payum\Core\Handler\Context, which describes the execution rather than the action and
+ *             reply this one is typed to.
+ */
 class Context
 {
     /**

--- a/src/Payum/Core/Extension/EndlessCycleDetectorExtension.php
+++ b/src/Payum/Core/Extension/EndlessCycleDetectorExtension.php
@@ -4,6 +4,10 @@ namespace Payum\Core\Extension;
 
 use Payum\Core\Exception\LogicException;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. Use
+ *             Payum\Core\Middleware\EndlessCycleDetectorMiddleware instead.
+ */
 class EndlessCycleDetectorExtension implements ExtensionInterface
 {
     /**

--- a/src/Payum/Core/Extension/ExtensionCollection.php
+++ b/src/Payum/Core/Extension/ExtensionCollection.php
@@ -2,6 +2,10 @@
 
 namespace Payum\Core\Extension;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. Use
+ *             Payum\Core\Middleware\MiddlewareCollection instead.
+ */
 class ExtensionCollection implements ExtensionInterface
 {
     /**

--- a/src/Payum/Core/Extension/ExtensionInterface.php
+++ b/src/Payum/Core/Extension/ExtensionInterface.php
@@ -2,6 +2,11 @@
 
 namespace Payum\Core\Extension;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A cross-cutting concern on the command path is a
+ *             Payum\Core\Middleware\MiddlewareInterface, which wraps the whole execution rather than
+ *             observing it at three points.
+ */
 interface ExtensionInterface
 {
     /**

--- a/src/Payum/Core/Extension/GenericTokenFactoryExtension.php
+++ b/src/Payum/Core/Extension/GenericTokenFactoryExtension.php
@@ -5,6 +5,10 @@ namespace Payum\Core\Extension;
 use Payum\Core\Security\GenericTokenFactoryAwareInterface;
 use Payum\Core\Security\GenericTokenFactoryInterface;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A handler is given the token factory as
+ *             Payum\Core\Handler\Context::tokens(), so nothing has to be injected into it.
+ */
 class GenericTokenFactoryExtension implements ExtensionInterface
 {
     /**

--- a/src/Payum/Core/Extension/PrependExtensionInterface.php
+++ b/src/Payum/Core/Extension/PrependExtensionInterface.php
@@ -2,6 +2,10 @@
 
 namespace Payum\Core\Extension;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A middleware orders itself by implementing
+ *             Payum\Core\Middleware\HasPriority.
+ */
 interface PrependExtensionInterface
 {
 }

--- a/src/Payum/Core/Extension/StorageExtension.php
+++ b/src/Payum/Core/Extension/StorageExtension.php
@@ -6,6 +6,10 @@ use Payum\Core\Model\ModelAggregateInterface;
 use Payum\Core\Storage\IdentityInterface;
 use Payum\Core\Storage\StorageInterface;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. Use
+ *             Payum\Core\Middleware\PersistStateMiddleware instead.
+ */
 class StorageExtension implements ExtensionInterface
 {
     /**

--- a/src/Payum/Core/Gateway.php
+++ b/src/Payum/Core/Gateway.php
@@ -42,6 +42,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use ReflectionProperty;
 use Throwable;
 use function func_num_args;
+use function get_debug_type;
 use function trigger_deprecation;
 
 class Gateway implements GatewayInterface
@@ -53,7 +54,8 @@ class Gateway implements GatewayInterface
 
     /**
      * @var mixed[]
-     * @deprecated since 2.0. BC will be removed in 3.x. Use dependency-injection to inject the api into the action instead.
+     * @deprecated since 2.0.0, will be removed in 3.0. Take the api as a constructor argument on the
+     *             action instead, and let the container inject it.
      */
     protected $apis = [];
 
@@ -83,6 +85,15 @@ class Gateway implements GatewayInterface
      */
     protected array $commandStack = [];
 
+    /**
+     * What has already been reported as 1.x, keyed by request class or by argument name. A gateway
+     * dispatches the same request on every payment, so reporting per call would bury the notice in
+     * repetitions of itself; the thing to change is the request, and there is one of those per class.
+     *
+     * @var array<string, true>
+     */
+    private static array $reportedLegacyUse = [];
+
     public function __construct()
     {
         $this->extensions = new ExtensionCollection();
@@ -94,12 +105,11 @@ class Gateway implements GatewayInterface
      */
     public function addApi($api, $forcePrepend = false): void
     {
-        @trigger_error(
-            sprintf(
-                'The %s method is deprecated and will be removed in 3.0. Use dependency-injection to inject the api into the action instead.',
-                __METHOD__
-            ),
-            E_USER_DEPRECATED
+        trigger_deprecation(
+            'payum/core',
+            '2.0.0',
+            'The %s method is deprecated and will be removed in 3.0. Take the api as a constructor argument on the action instead, and let the container inject it.',
+            __METHOD__
         );
 
         $forcePrepend ?
@@ -113,6 +123,17 @@ class Gateway implements GatewayInterface
      */
     public function addAction(ActionInterface $action, $forcePrepend = false): void
     {
+        // Registration happens once per action, and handing the api over happens on every execute().
+        if ($action instanceof ApiAwareInterface) {
+            trigger_deprecation(
+                'payum/core',
+                '2.0.0',
+                'Implementing %s in %s is deprecated and will be removed in 3.0. Take the api as a constructor argument instead, and let the container inject it.',
+                ApiAwareInterface::class,
+                $action::class,
+            );
+        }
+
         $forcePrepend ?
             array_unshift($this->actions, $action) :
             array_push($this->actions, $action)
@@ -134,13 +155,16 @@ class Gateway implements GatewayInterface
 
     public function execute(/* CommandInterface */ $request, $catchReply = false)
     {
-        if (func_num_args() > 1) {
+        if (func_num_args() > 1 && ! isset(self::$reportedLegacyUse['$catchReply'])) {
+            self::$reportedLegacyUse['$catchReply'] = true;
+
             trigger_deprecation(
                 'payum/core',
-                '2.0',
-                'Passing the $catchReply argument to %s is deprecated and will be removed in 3.0. Use %s::execute($request) instead.',
+                '2.0.0',
+                'Passing the $catchReply argument to %s is deprecated and will be removed in 3.0. Dispatch a %s and act on the %s it returns instead.',
                 __METHOD__,
-                self::class
+                CommandInterface::class,
+                Result::class,
             );
         }
 
@@ -148,14 +172,20 @@ class Gateway implements GatewayInterface
             return $this->dispatch($request);
         }
 
-        trigger_deprecation(
-            'payum/core',
-            '2.0',
-            'Not passing a %s instance to %s is deprecated and will not be supported in 3.0. Use %s::execute(CommandInterface $request) instead.',
-            CommandInterface::class,
-            __METHOD__,
-            self::class
-        );
+        $requestType = get_debug_type($request);
+
+        if (! isset(self::$reportedLegacyUse[$requestType])) {
+            self::$reportedLegacyUse[$requestType] = true;
+
+            trigger_deprecation(
+                'payum/core',
+                '2.0.0',
+                'Passing a %s to %s is deprecated and will not be supported in 3.0. Dispatch the %s that means the same thing instead.',
+                $requestType,
+                __METHOD__,
+                CommandInterface::class,
+            );
+        }
 
         // A 1.x request is answered by the handler that means the same thing, when the gateway has one.
         //
@@ -317,15 +347,6 @@ class Gateway implements GatewayInterface
             }
 
             if ($action instanceof ApiAwareInterface) {
-                @trigger_error(
-                    sprintf(
-                        'Implementing the %s interface in %s is deprecated and will be removed in 2.0. Use dependency-injection to inject the api into the action instead.',
-                        ApiAwareInterface::class,
-                        $action::class,
-                    ),
-                    E_USER_DEPRECATED
-                );
-
                 $apiSet = false;
                 $unsupportedException = null;
                 foreach ($this->apis as $api) {

--- a/src/Payum/Core/Model/CreditCard.php
+++ b/src/Payum/Core/Model/CreditCard.php
@@ -27,7 +27,9 @@ class CreditCard implements CreditCardInterface
     /**
      * @var SensitiveValue
      *
-     * @deprecated
+     * @deprecated since 2.0.0, will be removed in 3.0, when this and the plain property beside it
+     *             collapse into one. A subclass reads and writes through the accessors, which wrap
+     *             what they are given in a Payum\Core\Security\SensitiveValue.
      */
     protected $securedHolder;
 
@@ -44,7 +46,9 @@ class CreditCard implements CreditCardInterface
     /**
      * @var SensitiveValue
      *
-     * @deprecated
+     * @deprecated since 2.0.0, will be removed in 3.0, when this and the plain property beside it
+     *             collapse into one. A subclass reads and writes through the accessors, which wrap
+     *             what they are given in a Payum\Core\Security\SensitiveValue.
      */
     protected $securedNumber;
 
@@ -61,7 +65,9 @@ class CreditCard implements CreditCardInterface
     /**
      * @var SensitiveValue
      *
-     * @deprecated
+     * @deprecated since 2.0.0, will be removed in 3.0, when this and the plain property beside it
+     *             collapse into one. A subclass reads and writes through the accessors, which wrap
+     *             what they are given in a Payum\Core\Security\SensitiveValue.
      */
     protected $securedSecurityCode;
 
@@ -73,7 +79,9 @@ class CreditCard implements CreditCardInterface
     /**
      * @var SensitiveValue
      *
-     * @deprecated
+     * @deprecated since 2.0.0, will be removed in 3.0, when this and the plain property beside it
+     *             collapse into one. A subclass reads and writes through the accessors, which wrap
+     *             what they are given in a Payum\Core\Security\SensitiveValue.
      */
     protected $securedExpireAt;
 

--- a/src/Payum/Core/Model/CreditCardInterface.php
+++ b/src/Payum/Core/Model/CreditCardInterface.php
@@ -88,7 +88,8 @@ interface CreditCardInterface
     public function setExpireAt($date = null);
 
     /**
-     * @deprecated the method will be removed in v2
+     * @deprecated since 2.0.0, will be removed in 3.0. Nothing has to call this: every setter already
+     *             wraps what it is given in a Payum\Core\Security\SensitiveValue.
      *
      * Wraps all sensitive values by SensitiveValue objects. Prevent accidental storing of them while serialization and so on.
      */

--- a/src/Payum/Core/Model/GatewayConfigInterface.php
+++ b/src/Payum/Core/Model/GatewayConfigInterface.php
@@ -15,14 +15,16 @@ interface GatewayConfigInterface
     public function setGatewayName($gatewayName);
 
     /**
-     * @deprecated since 1.3.3 will be removed in 2.0. set factory option inside the config
+     * @deprecated since 2.0.0, will be removed in 3.0. Set the 'factory' option inside the config
+     *             array instead, which setConfig() takes.
      *
      * @return string
      */
     public function getFactoryName();
 
     /**
-     * @deprecated since 1.3.3 will be removed in 2.0. set factory option inside the config
+     * @deprecated since 2.0.0, will be removed in 3.0. Set the 'factory' option inside the config
+     *             array instead, which setConfig() takes.
      *
      * @param string $name
      */

--- a/src/Payum/Core/Model/Identificator.php
+++ b/src/Payum/Core/Model/Identificator.php
@@ -3,7 +3,7 @@
 namespace Payum\Core\Model;
 
 /**
- * @deprecated since 1.3 will be removed in 2.0. Use
+ * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Core\Model\Identity instead.
  */
 class Identificator extends Identity
 {

--- a/src/Payum/Core/PayumBuilder.php
+++ b/src/Payum/Core/PayumBuilder.php
@@ -199,19 +199,21 @@ class PayumBuilder
     }
 
     /**
-     * @deprecated addGateway is deprecated and will be removed in 2.0. Use registerGateway() instead.
+     * @deprecated since 2.0.0, will be removed in 3.0. Use Payum\Core\PayumBuilder::registerGateway()
+     *             instead, passing the gateway's own Payum\Core\Config\GatewayConfig.
      *
      * @param GatewayInterface|array<string, mixed> $gateway
      */
-    #[Deprecated('addGateway is deprecated and will be removed in 2.0. Use registerGateway() instead.', '2.0.0')]
+    #[Deprecated('addGateway is deprecated and will be removed in 3.0. Use Payum\Core\PayumBuilder::registerGateway() instead.', '2.0.0')]
     public function addGateway(string $name, GatewayInterface | array $gateway): static
     {
         trigger_deprecation(
             'payum/core',
             '2.0.0',
-            '%s is deprecated and will be removed in 2.0. Use %s instead.',
+            '%s is deprecated and will be removed in 3.0. Use %s::registerGateway() instead, passing the gateway\'s own %s.',
             __METHOD__,
-            'registerGateway'
+            self::class,
+            GatewayConfig::class,
         );
         if ($gateway instanceof GatewayInterface) {
             $this->gateways[$name] = $gateway;
@@ -862,7 +864,9 @@ class PayumBuilder
     }
 
     /**
-     * @deprecated since 1.5 will be removed in 2.0
+     * @deprecated since 2.0.0, will be removed in 3.0 along with the Omnipay v2 bridge. Install
+     *             payum/omnipay-v3-bridge, whose factories are registered by
+     *             {@see self::buildOmnipayV3GatewayFactories()}.
      *
      * @return array<string, object>
      */

--- a/src/Payum/Core/Registry/DynamicRegistry.php
+++ b/src/Payum/Core/Registry/DynamicRegistry.php
@@ -30,7 +30,8 @@ class DynamicRegistry implements RegistryInterface
     private GatewayFactoryRegistryInterface | RegistryInterface $gatewayFactoryRegistry;
 
     /**
-     * @deprecated since 1.3.3 will be removed in 2.0
+     * @deprecated since 2.0.0, will be removed in 3.0. Wrap this registry in a
+     *             Payum\Core\Registry\FallbackRegistry to reach another registry's gateway factories.
      */
     private bool $backwardCompatibility = true;
 
@@ -45,7 +46,7 @@ class DynamicRegistry implements RegistryInterface
 
     public function getGatewayFactory(string $name): GatewayFactoryInterface
     {
-        // @deprecated It will throw invalid argument exception in 2.x
+        // @deprecated In 3.0 this throws instead of delegating.
         if ($this->backwardCompatibility && $this->gatewayFactoryRegistry instanceof RegistryInterface) {
             return $this->gatewayFactoryRegistry->getGatewayFactory($name);
         }
@@ -55,7 +56,7 @@ class DynamicRegistry implements RegistryInterface
 
     public function getGatewayFactories(): array
     {
-        // @deprecated It will return empty array here
+        // @deprecated In 3.0 this returns an empty array instead of delegating.
         if ($this->backwardCompatibility && $this->gatewayFactoryRegistry instanceof RegistryInterface) {
             return $this->gatewayFactoryRegistry->getGatewayFactories();
         }
@@ -78,7 +79,7 @@ class DynamicRegistry implements RegistryInterface
             return $gateway;
         }
 
-        // @deprecated It will throw invalid argument exception in 2.x
+        // @deprecated In 3.0 this throws instead of delegating.
         if ($this->backwardCompatibility && $this->gatewayFactoryRegistry instanceof RegistryInterface) {
             return $this->gatewayFactoryRegistry->getGateway($name);
         }
@@ -91,7 +92,7 @@ class DynamicRegistry implements RegistryInterface
      */
     public function getGateways(): array
     {
-        // @deprecated It will return empty array here
+        // @deprecated In 3.0 this returns an empty array instead of delegating.
         if ($this->backwardCompatibility && $this->gatewayFactoryRegistry instanceof RegistryInterface) {
             return $this->gatewayFactoryRegistry->getGateways();
         }
@@ -112,7 +113,7 @@ class DynamicRegistry implements RegistryInterface
      */
     public function getStorage($class): StorageInterface
     {
-        // @deprecated It will throw invalid argument exception in 2.x
+        // @deprecated In 3.0 this throws instead of delegating.
         if ($this->backwardCompatibility && $this->gatewayFactoryRegistry instanceof RegistryInterface) {
             return $this->gatewayFactoryRegistry->getStorage($class);
         }
@@ -128,7 +129,7 @@ class DynamicRegistry implements RegistryInterface
      */
     public function getStorages(): array
     {
-        // @deprecated It will return empty array here
+        // @deprecated In 3.0 this returns an empty array instead of delegating.
         if ($this->backwardCompatibility && $this->gatewayFactoryRegistry instanceof RegistryInterface) {
             return $this->gatewayFactoryRegistry->getStorages();
         }
@@ -137,7 +138,8 @@ class DynamicRegistry implements RegistryInterface
     }
 
     /**
-     * @deprecated since 1.3.3 will be removed in 2.0
+     * @deprecated since 2.0.0, will be removed in 3.0. Wrap this registry in a
+     *             Payum\Core\Registry\FallbackRegistry to reach another registry's gateway factories.
      *
      * @param bool $backwardCompatibility
      */

--- a/src/Payum/Core/Registry/SimpleRegistry.php
+++ b/src/Payum/Core/Registry/SimpleRegistry.php
@@ -18,12 +18,16 @@ class SimpleRegistry extends AbstractRegistry
     protected array $initializedStorageExtensions;
 
     /**
-     * @deprecated since 1.3.3 and ill be removed in 2.x. It is here for BC
+     * @deprecated since 2.0.0, will be removed in 3.0 together with
+     *             Payum\Core\Extension\StorageExtension, which a gateway built from handlers does not
+     *             get — it persists through Payum\Core\Middleware\PersistStateMiddleware instead.
      */
     protected bool $addStorageExtensions = true;
 
     /**
-     * @deprecated since 1.3.3 and will be removed in 2.x. It is here for BC
+     * @deprecated since 2.0.0, will be removed in 3.0 together with
+     *             Payum\Core\Extension\StorageExtension, which a gateway built from handlers does not
+     *             get — it persists through Payum\Core\Middleware\PersistStateMiddleware instead.
      *
      * @param bool $bool
      */
@@ -49,7 +53,9 @@ class SimpleRegistry extends AbstractRegistry
     }
 
     /**
-     * @deprecated since 1.3.3 and will be removed in 2.x.
+     * @deprecated since 2.0.0, will be removed in 3.0 together with
+     *             Payum\Core\Extension\StorageExtension, which a gateway built from handlers does not
+     *             get — it persists through Payum\Core\Middleware\PersistStateMiddleware instead.
      */
     protected function addStorageToGateway(string $name, GatewayInterface $gateway): void
     {

--- a/src/Payum/Core/Reply/Base.php
+++ b/src/Payum/Core/Reply/Base.php
@@ -4,6 +4,10 @@ namespace Payum\Core\Reply;
 
 use Payum\Core\Exception\LogicException;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A handler returns a Payum\Core\Result\Result
+ *             carrying a Payum\Core\Result\NextAction instead of throwing a reply.
+ */
 abstract class Base extends LogicException implements ReplyInterface
 {
 }

--- a/src/Payum/Core/Reply/BaseModelAware.php
+++ b/src/Payum/Core/Reply/BaseModelAware.php
@@ -7,6 +7,11 @@ use Payum\Core\Exception\LogicException;
 use Payum\Core\Model\ModelAggregateInterface;
 use Payum\Core\Model\ModelAwareInterface;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A handler returns a Payum\Core\Result\Result
+ *             carrying a Payum\Core\Result\NextAction instead of throwing a reply; the model it used to
+ *             carry is Payum\Core\Handler\Context::subject().
+ */
 abstract class BaseModelAware extends LogicException implements ReplyInterface, ModelAwareInterface, ModelAggregateInterface
 {
     /**

--- a/src/Payum/Core/Reply/HttpPostRedirect.php
+++ b/src/Payum/Core/Reply/HttpPostRedirect.php
@@ -2,6 +2,10 @@
 
 namespace Payum\Core\Reply;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A handler returns
+ *             Payum\Core\Result\NextAction\PostRedirect on its result instead.
+ */
 class HttpPostRedirect extends HttpResponse
 {
     /**

--- a/src/Payum/Core/Reply/HttpRedirect.php
+++ b/src/Payum/Core/Reply/HttpRedirect.php
@@ -4,6 +4,10 @@ namespace Payum\Core\Reply;
 
 use InvalidArgumentException;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A handler returns
+ *             Payum\Core\Result\NextAction\Redirect on its result instead.
+ */
 class HttpRedirect extends HttpResponse
 {
     /**

--- a/src/Payum/Core/Reply/HttpResponse.php
+++ b/src/Payum/Core/Reply/HttpResponse.php
@@ -2,6 +2,11 @@
 
 namespace Payum\Core\Reply;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A notify handler answers the PSP with a
+ *             Payum\Core\Result\Acknowledgement on its Payum\Core\Result\NotifyResult; a handler with a
+ *             page to show returns Payum\Core\Result\NextAction\RenderTemplate.
+ */
 class HttpResponse extends Base
 {
     /**

--- a/src/Payum/Core/Reply/ReplyInterface.php
+++ b/src/Payum/Core/Reply/ReplyInterface.php
@@ -4,6 +4,10 @@ namespace Payum\Core\Reply;
 
 use Payum\Core\Exception\ExceptionInterface;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A handler returns a Payum\Core\Result\Result
+ *             carrying a Payum\Core\Result\NextAction instead of throwing a reply.
+ */
 interface ReplyInterface extends ExceptionInterface
 {
 }

--- a/src/Payum/Core/Request/Authorize.php
+++ b/src/Payum/Core/Request/Authorize.php
@@ -2,6 +2,14 @@
 
 namespace Payum\Core\Request;
 
+use Payum\Core\Command\AuthorizeCommand;
+use function trigger_deprecation;
+
+trigger_deprecation('payum/core', '2.0.0', 'The %s request is deprecated and will be removed in 3.0. Dispatch %s instead.', Authorize::class, AuthorizeCommand::class);
+
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. Dispatch Payum\Core\Command\AuthorizeCommand instead.
+ */
 class Authorize extends Generic
 {
 }

--- a/src/Payum/Core/Request/BaseGetStatus.php
+++ b/src/Payum/Core/Request/BaseGetStatus.php
@@ -2,6 +2,11 @@
 
 namespace Payum\Core\Request;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A handler declares the status on its result —
+ *             Payum\Core\Result\CaptureResult::captured() and friends — and it is read back as a
+ *             Payum\Core\Result\PaymentStatus.
+ */
 abstract class BaseGetStatus extends Generic implements GetStatusInterface
 {
     /**

--- a/src/Payum/Core/Request/Cancel.php
+++ b/src/Payum/Core/Request/Cancel.php
@@ -2,6 +2,14 @@
 
 namespace Payum\Core\Request;
 
+use Payum\Core\Command\CancelCommand;
+use function trigger_deprecation;
+
+trigger_deprecation('payum/core', '2.0.0', 'The %s request is deprecated and will be removed in 3.0. Dispatch %s instead.', Cancel::class, CancelCommand::class);
+
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. Dispatch Payum\Core\Command\CancelCommand instead.
+ */
 class Cancel extends Generic
 {
 }

--- a/src/Payum/Core/Request/Capture.php
+++ b/src/Payum/Core/Request/Capture.php
@@ -2,6 +2,14 @@
 
 namespace Payum\Core\Request;
 
+use Payum\Core\Command\CaptureCommand;
+use function trigger_deprecation;
+
+trigger_deprecation('payum/core', '2.0.0', 'The %s request is deprecated and will be removed in 3.0. Dispatch %s instead.', Capture::class, CaptureCommand::class);
+
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. Dispatch Payum\Core\Command\CaptureCommand instead.
+ */
 class Capture extends Generic
 {
 }

--- a/src/Payum/Core/Request/GetBinaryStatus.php
+++ b/src/Payum/Core/Request/GetBinaryStatus.php
@@ -2,6 +2,11 @@
 
 namespace Payum\Core\Request;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A handler declares the status on its result —
+ *             Payum\Core\Result\CaptureResult::captured() and friends — and it is read back as a
+ *             Payum\Core\Result\PaymentStatus.
+ */
 class GetBinaryStatus extends BaseGetStatus
 {
     public const STATUS_PAYEDOUT = 4_194_304; // 2^22

--- a/src/Payum/Core/Request/GetCurrency.php
+++ b/src/Payum/Core/Request/GetCurrency.php
@@ -2,6 +2,11 @@
 
 namespace Payum\Core\Request;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A handler calls
+ *             Payum\Core\ISO4217\Currency::createFromIso4217Alpha3() or ::createFromIso4217Numeric()
+ *             directly instead.
+ */
 class GetCurrency
 {
     /**

--- a/src/Payum/Core/Request/GetHttpRequest.php
+++ b/src/Payum/Core/Request/GetHttpRequest.php
@@ -4,6 +4,10 @@ namespace Payum\Core\Request;
 
 use AllowDynamicProperties;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A handler reads the inbound request as PSR-7 from
+ *             Payum\Core\Handler\Context::httpRequest() instead.
+ */
 #[AllowDynamicProperties]
 class GetHttpRequest
 {

--- a/src/Payum/Core/Request/GetHumanStatus.php
+++ b/src/Payum/Core/Request/GetHumanStatus.php
@@ -2,6 +2,11 @@
 
 namespace Payum\Core\Request;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A handler declares the status on its result —
+ *             Payum\Core\Result\CaptureResult::captured() and friends — and it is read back as a
+ *             Payum\Core\Result\PaymentStatus.
+ */
 class GetHumanStatus extends BaseGetStatus
 {
     public const STATUS_CAPTURED = 'captured';

--- a/src/Payum/Core/Request/GetStatusInterface.php
+++ b/src/Payum/Core/Request/GetStatusInterface.php
@@ -5,6 +5,11 @@ namespace Payum\Core\Request;
 use Payum\Core\Model\ModelAggregateInterface;
 use Payum\Core\Model\ModelAwareInterface;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A handler declares the status on its result —
+ *             Payum\Core\Result\CaptureResult::captured() and friends — and it is read back as a
+ *             Payum\Core\Result\PaymentStatus.
+ */
 interface GetStatusInterface extends ModelAwareInterface, ModelAggregateInterface
 {
     /**

--- a/src/Payum/Core/Request/GetToken.php
+++ b/src/Payum/Core/Request/GetToken.php
@@ -4,6 +4,11 @@ namespace Payum\Core\Request;
 
 use Payum\Core\Security\TokenInterface;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A handler reads the token this execution came in on
+ *             from Payum\Core\Handler\Context::token(); one that needs a different token looks it up in
+ *             the token storage, Payum\Core\Payum::getTokenStorage().
+ */
 class GetToken
 {
     /**

--- a/src/Payum/Core/Request/Notify.php
+++ b/src/Payum/Core/Request/Notify.php
@@ -2,6 +2,14 @@
 
 namespace Payum\Core\Request;
 
+use Payum\Core\Command\NotifyCommand;
+use function trigger_deprecation;
+
+trigger_deprecation('payum/core', '2.0.0', 'The %s request is deprecated and will be removed in 3.0. Dispatch %s instead.', Notify::class, NotifyCommand::class);
+
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. Dispatch Payum\Core\Command\NotifyCommand instead.
+ */
 class Notify extends Generic
 {
 }

--- a/src/Payum/Core/Request/Payout.php
+++ b/src/Payum/Core/Request/Payout.php
@@ -2,8 +2,15 @@
 
 namespace Payum\Core\Request;
 
+use Payum\Core\Command\PayoutCommand;
+use function trigger_deprecation;
+
+trigger_deprecation('payum/core', '2.0.0', 'The %s request is deprecated and will be removed in 3.0. Dispatch %s instead.', Payout::class, PayoutCommand::class);
+
 /**
  * Pay a large sum of money from funds under one’s control
+ *
+ * @deprecated since 2.0.0, will be removed in 3.0. Dispatch Payum\Core\Command\PayoutCommand instead.
  */
 class Payout extends Generic
 {

--- a/src/Payum/Core/Request/Refund.php
+++ b/src/Payum/Core/Request/Refund.php
@@ -2,6 +2,14 @@
 
 namespace Payum\Core\Request;
 
+use Payum\Core\Command\RefundCommand;
+use function trigger_deprecation;
+
+trigger_deprecation('payum/core', '2.0.0', 'The %s request is deprecated and will be removed in 3.0. Dispatch %s instead.', Refund::class, RefundCommand::class);
+
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. Dispatch Payum\Core\Command\RefundCommand instead.
+ */
 class Refund extends Generic
 {
 }

--- a/src/Payum/Core/Request/RenderTemplate.php
+++ b/src/Payum/Core/Request/RenderTemplate.php
@@ -4,6 +4,10 @@ namespace Payum\Core\Request;
 
 use InvalidArgumentException;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A handler returns
+ *             Payum\Core\Result\NextAction\RenderTemplate on its result instead.
+ */
 class RenderTemplate
 {
     /**

--- a/src/Payum/Core/Request/Sync.php
+++ b/src/Payum/Core/Request/Sync.php
@@ -2,6 +2,14 @@
 
 namespace Payum\Core\Request;
 
+use Payum\Core\Command\SyncCommand;
+use function trigger_deprecation;
+
+trigger_deprecation('payum/core', '2.0.0', 'The %s request is deprecated and will be removed in 3.0. Dispatch %s instead.', Sync::class, SyncCommand::class);
+
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. Dispatch Payum\Core\Command\SyncCommand instead.
+ */
 class Sync extends Generic
 {
 }

--- a/src/Payum/Core/Security/GenericTokenFactoryAwareInterface.php
+++ b/src/Payum/Core/Security/GenericTokenFactoryAwareInterface.php
@@ -2,6 +2,10 @@
 
 namespace Payum\Core\Security;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A handler is given the token factory as
+ *             Payum\Core\Handler\Context::tokens(), so nothing has to be injected into it.
+ */
 interface GenericTokenFactoryAwareInterface
 {
     public function setGenericTokenFactory(?GenericTokenFactoryInterface $genericTokenFactory = null);

--- a/src/Payum/Core/Security/GenericTokenFactoryAwareTrait.php
+++ b/src/Payum/Core/Security/GenericTokenFactoryAwareTrait.php
@@ -2,6 +2,10 @@
 
 namespace Payum\Core\Security;
 
+/**
+ * @deprecated since 2.0.0, will be removed in 3.0. A handler is given the token factory as
+ *             Payum\Core\Handler\Context::tokens(), so nothing has to be injected into it.
+ */
 trait GenericTokenFactoryAwareTrait
 {
     /**

--- a/src/Payum/Core/Security/GenericTokenFactoryInterface.php
+++ b/src/Payum/Core/Security/GenericTokenFactoryInterface.php
@@ -2,9 +2,6 @@
 
 namespace Payum\Core\Security;
 
-/**
- * @deprecated since 1.3.7 and will be removed in 2.0
- */
 interface GenericTokenFactoryInterface extends TokenFactoryInterface
 {
     /**

--- a/src/Payum/Core/Tests/CoreGatewayFactoryContainerConfigurationTest.php
+++ b/src/Payum/Core/Tests/CoreGatewayFactoryContainerConfigurationTest.php
@@ -327,7 +327,7 @@ final class CoreGatewayFactoryContainerConfigurationTest extends TestCase
 
         $this->assertInstanceOf(MessageFactory::class, $messageFactory);
         $this->assertContains(
-            'Using "httplug.message_factory" is deprecated, use "payum.http_message_factory" instead, which will return a PSR-17 RequestFactoryInterface since payum/core 2.0.0',
+            'The "httplug.message_factory" config is deprecated since payum/core 2.0.0 and will be removed in 3.0. Use "payum.http_message_factory", which returns a Psr\Http\Message\RequestFactoryInterface.',
             $deprecations
         );
     }
@@ -342,7 +342,7 @@ final class CoreGatewayFactoryContainerConfigurationTest extends TestCase
 
         $this->assertInstanceOf(StreamFactory::class, $streamFactory);
         $this->assertContains(
-            'Using "httplug.stream_factory" is deprecated, use "payum.http_stream_factory" instead which will return a PSR-17 StreamFactoryInterface since payum/core 2.0.0',
+            'The "httplug.stream_factory" config is deprecated since payum/core 2.0.0 and will be removed in 3.0. Use "payum.http_stream_factory", which returns a Psr\Http\Message\StreamFactoryInterface.',
             $deprecations
         );
     }
@@ -357,7 +357,7 @@ final class CoreGatewayFactoryContainerConfigurationTest extends TestCase
 
         $this->assertInstanceOf(ClientInterface::class, $client);
         $this->assertContains(
-            'Using "httplug.client" is deprecated, use "payum.http_client" instead which will return a PSR-18 ClientInterface since payum/core 2.0.0',
+            'The "httplug.client" config is deprecated since payum/core 2.0.0 and will be removed in 3.0. Use "payum.http_client", which returns a Psr\Http\Client\ClientInterface.',
             $deprecations
         );
     }
@@ -587,7 +587,7 @@ final class CoreGatewayFactoryContainerConfigurationTest extends TestCase
         });
 
         $this->assertContains(
-            'Since payum/core 2.0.0: The Payum\Core\CoreGatewayFactory::create is deprecated. Implement the Payum\Core\DI\ContainerConfiguration interface instead.',
+            'Since payum/core 2.0.0: The Payum\Core\CoreGatewayFactory::create is deprecated and will be removed in 3.0. Implement the Payum\Core\DI\ContainerConfiguration interface instead.',
             $deprecations
         );
     }
@@ -603,7 +603,7 @@ final class CoreGatewayFactoryContainerConfigurationTest extends TestCase
         foreach (['buildClosures', 'buildActions', 'buildApis', 'buildExtensions'] as $method) {
             $this->assertContains(
                 sprintf(
-                    'Since payum/core 2.0.0: The Payum\Core\CoreGatewayFactory::%s is deprecated. Implement the Payum\Core\DI\ContainerConfiguration interface instead.',
+                    'Since payum/core 2.0.0: The Payum\Core\CoreGatewayFactory::%s is deprecated and will be removed in 3.0. Implement the Payum\Core\DI\ContainerConfiguration interface instead.',
                     $method
                 ),
                 $deprecations
@@ -620,7 +620,7 @@ final class CoreGatewayFactoryContainerConfigurationTest extends TestCase
         });
 
         $this->assertContains(
-            'The payum.api.* config is deprecated and will be removed in 3.0. Use dependency-injection to inject the api into the action instead.',
+            'The payum.api.* config is deprecated and will be removed in 3.0. Take the api as a constructor argument on the action instead, and let the container inject it.',
             $deprecations
         );
     }
@@ -786,7 +786,7 @@ final class CoreGatewayFactoryContainerConfigurationTest extends TestCase
         });
 
         $this->assertContains(
-            'Since payum/core 2.0.0: The Payum\Core\CoreGatewayFactory::createConfig is deprecated. Implement the Payum\Core\DI\ContainerConfiguration interface instead.',
+            'Since payum/core 2.0.0: The Payum\Core\CoreGatewayFactory::createConfig is deprecated and will be removed in 3.0. Implement the Payum\Core\DI\ContainerConfiguration interface instead.',
             $deprecations
         );
     }

--- a/src/Payum/Core/Tests/DeprecationMessagesTest.php
+++ b/src/Payum/Core/Tests/DeprecationMessagesTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests;
+
+use FilesystemIterator;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use function class_exists;
+use function dirname;
+use function enum_exists;
+use function interface_exists;
+use function preg_match_all;
+use function preg_replace;
+use function sprintf;
+use function str_starts_with;
+use function trait_exists;
+use function trim;
+
+/**
+ * A deprecation that names no replacement, or that claims a removal which has already happened, is worse
+ * than no deprecation at all: it costs the reader a lookup and gives them nothing to act on. Both kinds
+ * were shipped in 1.x and survived into 2.0, so the rules are pinned here rather than left to review.
+ */
+final class DeprecationMessagesTest extends TestCase
+{
+    /**
+     * @dataProvider provideDeprecations
+     */
+    public function testShouldSayWhenTheDeprecatedThingGoes(string $where, string $message): void
+    {
+        $this->assertStringContainsString(
+            'in 3.0',
+            $message,
+            sprintf('%s does not say that it goes in 3.0: "%s"', $where, $message)
+        );
+    }
+
+    /**
+     * @dataProvider provideDeprecations
+     */
+    public function testShouldSayWhatToUseInstead(string $where, string $message): void
+    {
+        $forwardPath = trim((string) preg_replace('#^since [^.]+\.#', '', $message));
+
+        $this->assertNotSame(
+            '',
+            $forwardPath,
+            sprintf('%s says only that it is deprecated, and nothing about what to use instead', $where)
+        );
+    }
+
+    /**
+     * @dataProvider provideDeprecations
+     */
+    public function testShouldOnlyNamePayumClassesThatExist(string $where, string $message): void
+    {
+        preg_match_all('#Payum\\\\Core(?:\\\\[A-Za-z_][A-Za-z0-9_]*)+#', $message, $matches);
+
+        foreach ($matches[0] as $class) {
+            $this->assertTrue(
+                class_exists($class) || interface_exists($class) || trait_exists($class) || enum_exists($class),
+                sprintf('%s points at %s, which does not exist', $where, $class)
+            );
+        }
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * Every `@deprecated` docblock in the Payum\Core sources, as "file:line" and the text after the tag.
+     *
+     * Scoped to Core because the replacements a gateway package names live in that package, and several
+     * of those are `$this->api` rather than a class — nothing this test can resolve.
+     *
+     * @return iterable<string, array{string, string}>
+     */
+    public static function provideDeprecations(): iterable
+    {
+        $root = dirname(__DIR__);
+
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($files as $file) {
+            /** @var SplFileInfo $file */
+            if ('php' !== $file->getExtension()) {
+                continue;
+            }
+
+            $path = $file->getPathname();
+
+            if (str_starts_with($path, $root . '/Tests/') || str_starts_with($path, $root . '/Resources/')) {
+                continue;
+            }
+
+            foreach (self::readDeprecations((string) file_get_contents($path)) as $line => $message) {
+                yield sprintf('%s:%d', $file->getFilename(), $line) => [
+                    sprintf('%s:%d', $path, $line),
+                    $message,
+                ];
+            }
+        }
+    }
+
+    /**
+     * The text of each `@deprecated` docblock tag, keyed by the line it starts on.
+     *
+     * A tag runs until the next tag or the end of its docblock, so a wrapped message is read whole —
+     * which matters, since the replacement is usually what got wrapped onto the second line.
+     *
+     * @return array<int, string>
+     */
+    private static function readDeprecations(string $source): array
+    {
+        $found = [];
+
+        if (! preg_match_all('#/\*\*.*?\*/#s', $source, $blocks, PREG_OFFSET_CAPTURE)) {
+            return $found;
+        }
+
+        foreach ($blocks[0] as [$block, $offset]) {
+            $startLine = 1 + substr_count($source, "\n", 0, $offset);
+
+            $lines = explode("\n", $block);
+            $collecting = null;
+
+            foreach ($lines as $index => $rawLine) {
+                $line = trim((string) preg_replace('#^\s*(/\*\*|\*/|\*)\s?#', '', $rawLine));
+
+                if (str_starts_with($line, '@deprecated')) {
+                    $collecting = $startLine + $index;
+                    $found[$collecting] = trim(substr($line, 11));
+
+                    continue;
+                }
+
+                if (null === $collecting) {
+                    continue;
+                }
+
+                if (str_starts_with($line, '@') || '' === $line) {
+                    $collecting = null;
+
+                    continue;
+                }
+
+                $found[$collecting] = trim($found[$collecting] . ' ' . $line);
+            }
+        }
+
+        return $found;
+    }
+}

--- a/src/Payum/Core/Tests/DeprecationMessagesTest.php
+++ b/src/Payum/Core/Tests/DeprecationMessagesTest.php
@@ -6,17 +6,21 @@ namespace Payum\Core\Tests;
 
 use FilesystemIterator;
 use PHPUnit\Framework\TestCase;
+use RecursiveCallbackFilterIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
 use function class_exists;
 use function dirname;
 use function enum_exists;
+use function in_array;
 use function interface_exists;
+use function ksort;
 use function preg_match_all;
 use function preg_replace;
 use function sprintf;
-use function str_starts_with;
+use function strlen;
+use function substr;
 use function trait_exists;
 use function trim;
 
@@ -71,20 +75,31 @@ final class DeprecationMessagesTest extends TestCase
     }
 
     /**
-     * Every `@deprecated` docblock in the Payum\Core sources, as "file:line" and the text after the tag.
+     * Every `@deprecated` docblock in the Payum\Core sources, keyed by the path it sits at relative to
+     * Core and the line it starts on.
+     *
+     * The key has to be the whole relative path, not the file name: Core has several same-named classes
+     * across its bridges, and two of them carrying a deprecation on the same line is enough for PHPUnit
+     * to reject the whole data set as ambiguous.
      *
      * Scoped to Core because the replacements a gateway package names live in that package, and several
      * of those are `$this->api` rather than a class — nothing this test can resolve.
      *
-     * @return iterable<string, array{string, string}>
+     * @return array<string, array{string, string}>
      */
-    public static function provideDeprecations(): iterable
+    public static function provideDeprecations(): array
     {
         $root = dirname(__DIR__);
 
         $files = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS)
+            new RecursiveCallbackFilterIterator(
+                new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+                static fn (SplFileInfo $file): bool => ! $file->isDir()
+                    || ! in_array($file->getFilename(), ['Tests', 'Resources'], true)
+            )
         );
+
+        $found = [];
 
         foreach ($files as $file) {
             /** @var SplFileInfo $file */
@@ -93,18 +108,19 @@ final class DeprecationMessagesTest extends TestCase
             }
 
             $path = $file->getPathname();
-
-            if (str_starts_with($path, $root . '/Tests/') || str_starts_with($path, $root . '/Resources/')) {
-                continue;
-            }
+            $relative = substr($path, strlen($root) + 1);
 
             foreach (self::readDeprecations((string) file_get_contents($path)) as $line => $message) {
-                yield sprintf('%s:%d', $file->getFilename(), $line) => [
+                $found[sprintf('%s:%d', $relative, $line)] = [
                     sprintf('%s:%d', $path, $line),
                     $message,
                 ];
             }
         }
+
+        ksort($found);
+
+        return $found;
     }
 
     /**

--- a/src/Payum/Klarna/Checkout/Action/Api/BaseApiAwareAction.php
+++ b/src/Payum/Klarna/Checkout/Action/Api/BaseApiAwareAction.php
@@ -20,7 +20,7 @@ abstract class BaseApiAwareAction implements ActionInterface, ApiAwareInterface
     }
 
     /**
-     * @deprecated BC. will be removed in 2.x. Use $this->api
+     * @deprecated since 2.0.0, will be removed in 3.0. Use $this->api
      *
      * @var Config
      */
@@ -32,7 +32,7 @@ abstract class BaseApiAwareAction implements ActionInterface, ApiAwareInterface
     {
         $this->connector = $connector;
 
-        // BC. will be removed in 2.x. Use $this->api
+        // BC. will be removed in 3.0. Use $this->api
         $this->apiClass = Config::class;
     }
 

--- a/src/Payum/Klarna/Checkout/Action/AuthorizeRecurringAction.php
+++ b/src/Payum/Klarna/Checkout/Action/AuthorizeRecurringAction.php
@@ -28,7 +28,7 @@ class AuthorizeRecurringAction implements ActionInterface, ApiAwareInterface, Ga
     use GatewayAwareTrait;
 
     /**
-     * @deprecated BC. will be removed in 2.x. Use $this->api
+     * @deprecated since 2.0.0, will be removed in 3.0. Use $this->api
      *
      * @var Config
      */
@@ -43,7 +43,7 @@ class AuthorizeRecurringAction implements ActionInterface, ApiAwareInterface, Ga
     {
         $this->_setApi($api);
 
-        // BC. will be removed in 2.x. Use $this->api
+        // BC. will be removed in 3.0. Use $this->api
         $this->config = $this->api;
     }
 

--- a/src/Payum/Klarna/Invoice/Action/Api/BaseApiAwareAction.php
+++ b/src/Payum/Klarna/Invoice/Action/Api/BaseApiAwareAction.php
@@ -19,7 +19,7 @@ abstract class BaseApiAwareAction implements ApiAwareInterface, ActionInterface
     }
 
     /**
-     * @deprecated BC. will be removed in 2.x. Use $this->api
+     * @deprecated since 2.0.0, will be removed in 3.0. Use $this->api
      *
      * @var Config
      */
@@ -43,7 +43,7 @@ abstract class BaseApiAwareAction implements ApiAwareInterface, ActionInterface
     {
         $this->_setApi($api);
 
-        // BC. will be removed in 2.x. Use $this->api
+        // BC. will be removed in 3.0. Use $this->api
         $this->config = $this->api;
     }
 

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Action/Api/BaseApiAwareAction.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Action/Api/BaseApiAwareAction.php
@@ -6,10 +6,11 @@ use Payum\Core\Action\ActionInterface;
 use Payum\Core\ApiAwareInterface;
 use Payum\Core\Exception\UnsupportedApiException;
 use Payum\Paypal\ExpressCheckout\Nvp\Api;
-use function trigger_error;
 
 /**
- * @deprecated since 1.4.1 will be removed in 3.x
+ * @deprecated since 1.4.1, will be removed in 3.0. Take the
+ *             Payum\Paypal\ExpressCheckout\Nvp\Api as a constructor argument instead, and let the
+ *             container inject it.
  */
 abstract class BaseApiAwareAction implements ActionInterface, ApiAwareInterface
 {
@@ -18,10 +19,13 @@ abstract class BaseApiAwareAction implements ActionInterface, ApiAwareInterface
      */
     protected $api;
 
+    /**
+     * @deprecated since 1.4.1, will be removed in 3.0. Take the
+     *             Payum\Paypal\ExpressCheckout\Nvp\Api as a constructor argument instead, and let the
+     *             container inject it.
+     */
     public function setApi($api): void
     {
-        @trigger_error('The ' . self::class . '::setApi is deprecated since 1.4.1 and will be removed in 3.x.', E_USER_DEPRECATED);
-
         if (! $api instanceof Api) {
             throw new UnsupportedApiException('Not supported.');
         }

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Action/Api/CancelRecurringPaymentsProfileAction.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Action/Api/CancelRecurringPaymentsProfileAction.php
@@ -7,12 +7,12 @@ use Payum\Core\ApiAwareTrait;
 use Payum\Paypal\ExpressCheckout\Nvp\Action\CancelRecurringPaymentsProfileAction as NewCancelAction;
 use Payum\Paypal\ExpressCheckout\Nvp\Api;
 
-@trigger_error('The ' . CancelRecurringPaymentsProfileAction::class . ' class is deprecated since version 1.4 and will be removed in 2.0. Use ' . NewCancelAction::class . ' class instead.', E_USER_DEPRECATED);
+@trigger_error('The ' . CancelRecurringPaymentsProfileAction::class . ' class is deprecated since version 1.4 and will be removed in 3.0. Use ' . NewCancelAction::class . ' class instead.', E_USER_DEPRECATED);
 
 /**
  * Class CancelRecurringPaymentsProfileAction.
  *
- * @deprecated since version 1.4, to be removed in 2.0.
+ * @deprecated since version 1.4, will be removed in 3.0.
  *             Use {@link Payum\Paypal\ExpressCheckout\Nvp\Action\CancelRecurringPaymentsProfileAction} instead.
  */
 class CancelRecurringPaymentsProfileAction extends NewCancelAction implements ApiAwareInterface

--- a/src/Payum/Sofort/Action/Api/BaseApiAwareAction.php
+++ b/src/Payum/Sofort/Action/Api/BaseApiAwareAction.php
@@ -8,7 +8,8 @@ use Payum\Core\Exception\UnsupportedApiException;
 use Payum\Sofort\Api;
 
 /**
- * @deprecated since 1.4.1 will be removed in 2.x
+ * @deprecated since 1.4.1, will be removed in 3.0. Take the Payum\Sofort\Api as a constructor
+ *             argument instead, and let the container inject it.
  */
 abstract class BaseApiAwareAction implements ActionInterface, ApiAwareInterface
 {

--- a/src/Payum/Stripe/Action/Api/CreateChargeAction.php
+++ b/src/Payum/Stripe/Action/Api/CreateChargeAction.php
@@ -26,7 +26,7 @@ class CreateChargeAction implements ActionInterface, ApiAwareInterface
     use GatewayAwareTrait;
 
     /**
-     * @deprecated BC will be removed in 2.x. Use $this->api
+     * @deprecated since 2.0.0, will be removed in 3.0. Use $this->api
      *
      * @var Keys
      */
@@ -41,7 +41,7 @@ class CreateChargeAction implements ActionInterface, ApiAwareInterface
     {
         $this->_setApi($api);
 
-        // BC. will be removed in 2.x
+        // BC. will be removed in 3.0
         $this->keys = $this->api;
     }
 

--- a/src/Payum/Stripe/Action/Api/CreateCustomerAction.php
+++ b/src/Payum/Stripe/Action/Api/CreateCustomerAction.php
@@ -30,7 +30,7 @@ class CreateCustomerAction implements ActionInterface, ApiAwareInterface, Gatewa
     use GatewayAwareTrait;
 
     /**
-     * @deprecated BC will be removed in 2.x. Use $this->api
+     * @deprecated since 2.0.0, will be removed in 3.0. Use $this->api
      *
      * @var Keys
      */
@@ -45,7 +45,7 @@ class CreateCustomerAction implements ActionInterface, ApiAwareInterface, Gatewa
     {
         $this->_setApi($api);
 
-        // BC. will be removed in 2.x
+        // BC. will be removed in 3.0
         $this->keys = $this->api;
     }
 

--- a/src/Payum/Stripe/Action/Api/CreatePlanAction.php
+++ b/src/Payum/Stripe/Action/Api/CreatePlanAction.php
@@ -30,7 +30,7 @@ class CreatePlanAction implements ActionInterface, GatewayAwareInterface, ApiAwa
     use GatewayAwareTrait;
 
     /**
-     * @deprecated BC will be removed in 2.x. Use $this->api
+     * @deprecated since 2.0.0, will be removed in 3.0. Use $this->api
      *
      * @var Keys
      */
@@ -45,7 +45,7 @@ class CreatePlanAction implements ActionInterface, GatewayAwareInterface, ApiAwa
     {
         $this->_setApi($api);
 
-        // BC. will be removed in 2.x
+        // BC. will be removed in 3.0
         $this->keys = $this->api;
     }
 

--- a/src/Payum/Stripe/Action/Api/CreateSubscriptionAction.php
+++ b/src/Payum/Stripe/Action/Api/CreateSubscriptionAction.php
@@ -27,7 +27,7 @@ class CreateSubscriptionAction implements ActionInterface, ApiAwareInterface
     }
 
     /**
-     * @deprecated BC will be removed in 2.x. Use $this->api
+     * @deprecated since 2.0.0, will be removed in 3.0. Use $this->api
      *
      * @var Keys
      */
@@ -42,7 +42,7 @@ class CreateSubscriptionAction implements ActionInterface, ApiAwareInterface
     {
         $this->_setApi($api);
 
-        // BC. will be removed in 2.x
+        // BC. will be removed in 3.0
         $this->keys = $this->api;
     }
 

--- a/src/Payum/Stripe/Action/Api/CreateTokenAction.php
+++ b/src/Payum/Stripe/Action/Api/CreateTokenAction.php
@@ -26,7 +26,7 @@ class CreateTokenAction implements ActionInterface, GatewayAwareInterface, ApiAw
     use GatewayAwareTrait;
 
     /**
-     * @deprecated BC will be removed in 2.x. Use $this->api
+     * @deprecated since 2.0.0, will be removed in 3.0. Use $this->api
      *
      * @var Keys
      */
@@ -41,7 +41,7 @@ class CreateTokenAction implements ActionInterface, GatewayAwareInterface, ApiAw
     {
         $this->_setApi($api);
 
-        // BC. will be removed in 2.x
+        // BC. will be removed in 3.0
         $this->keys = $this->api;
     }
 

--- a/src/Payum/Stripe/Action/Api/ObtainTokenAction.php
+++ b/src/Payum/Stripe/Action/Api/ObtainTokenAction.php
@@ -34,7 +34,7 @@ class ObtainTokenAction implements ActionInterface, GatewayAwareInterface, ApiAw
     protected $templateName;
 
     /**
-     * @deprecated BC will be removed in 2.x. Use $this->api
+     * @deprecated since 2.0.0, will be removed in 3.0. Use $this->api
      *
      * @var Keys
      */
@@ -54,7 +54,7 @@ class ObtainTokenAction implements ActionInterface, GatewayAwareInterface, ApiAw
     {
         $this->_setApi($api);
 
-        // BC. will be removed in 2.x
+        // BC. will be removed in 3.0
         $this->keys = $this->api;
     }
 

--- a/src/Payum/Stripe/Action/Api/ObtainTokenForCreditCardAction.php
+++ b/src/Payum/Stripe/Action/Api/ObtainTokenForCreditCardAction.php
@@ -29,7 +29,7 @@ class ObtainTokenForCreditCardAction implements ActionInterface, GatewayAwareInt
     use GatewayAwareTrait;
 
     /**
-     * @deprecated BC will be removed in 2.x. Use $this->api
+     * @deprecated since 2.0.0, will be removed in 3.0. Use $this->api
      *
      * @var Keys
      */
@@ -44,7 +44,7 @@ class ObtainTokenForCreditCardAction implements ActionInterface, GatewayAwareInt
     {
         $this->_setApi($api);
 
-        // BC. will be removed in 2.x
+        // BC. will be removed in 3.0
         $this->keys = $this->api;
     }
 


### PR DESCRIPTION
A deprecation that names no replacement, or that claims a removal which has already happened, costs the reader a lookup and gives them nothing to act on. Both kinds shipped in 1.x and survived into 2.0 — #949 is the clearest example: `Security\GenericTokenFactoryInterface` was marked *"deprecated since 1.3.7 and will be removed in 2.0"* while being live 2.0 API.

## The rule

**A v1 entry point gets a runtime deprecation when the code that must change is the code that names it.** Where Payum itself still names the class on a path a 2.0 application takes, it gets a `@deprecated` docblock only — a notice nobody in the call chain can act on is exactly the noise a gateway package's users would drown in.

**One notice per entry point, not one per call.** Runtime notices fire at class load, or at registration.

## Runtime deprecations

| Entry point | Replacement |
|---|---|
| `Request\Capture`, `Authorize`, `Refund`, `Cancel`, `Sync`, `Payout`, `Notify` | the matching `Payum\Core\Command\*Command` |
| `Action\GatewayAwareAction` | `GatewayAwareInterface` + `GatewayAwareTrait`, or `Handler\Context::execute()` |
| `ApiAwareTrait` | the api as a constructor argument |

Two existing per-call notices moved to once-per-entry-point:

- The `ApiAwareInterface` report moves from `findActionSupported()` (every `execute()`) to `Gateway::addAction()` (once per action).
- `Gateway::execute()` dedupes its two legacy notices by request class.

Net effect on the suite: **self deprecation notices drop 924 → 810 and legacy 132 → 125**, despite the new ones. The per-call notices were the volume.

## Docblock only

`GetHttpRequest`, `RenderTemplate`, `GetCurrency`, `GetToken`, the status requests, all of `Reply\*`, core's six actions and all of `Extension\*` — each naming its handler / `Context` / `NextAction` / middleware replacement in full. These are dispatched by a gateway's own actions; the author reads the docblock, and their users get nothing they cannot act on.

## Message fixes

- `Security\GenericTokenFactoryInterface`'s deprecation is **removed** — `Handler\Context::tokens()` returns one, so it is v2 API. The `*Aware` interface/trait beside it got the real deprecation instead.
- All 24 `Bridge\Symfony` messages now name the FQCN. The 1:1 mapping to `Payum\Bundle\PayumBundle\…` was checked against the actual PayumBundle tree — all 24 exist.
- Every message claiming removal "in 2.0" / "2.x" corrected to 3.0, and every bare `@deprecated` given a forward path (`Model\Identificator` said literally `Use` with nothing after it).
- `Bridge\Httplug\HttplugClient` used an *unsilenced* `trigger_error`; converted to `trigger_deprecation`.

## Deliberately not deprecated

`Request\Generic` and `Action\ActionInterface` — every third-party gateway extends them and they are not going anywhere in 2.x. `Request\Convert` — no replacement exists; a handler builds its own payload. Both stated explicitly in the docs.

## Tests and docs

`Tests/DeprecationMessagesTest.php` walks all 96 `@deprecated` docblocks in `Payum\Core` and pins three things: it says 3.0, it says what to use instead, and every `Payum\Core\…` class it names actually exists. That last one is what stops a renamed class turning a deprecation back into a dead end.

`UPGRADE.md` and the `docs/di/migration-guide.md` "Deprecated APIs" table carry the full map and explain the runtime-vs-docblock split.

Seven existing tests asserted exact old message strings and were updated.

## Verification

- `XDEBUG_MODE=off SYMFONY_DEPRECATIONS_HELPER=weak vendor/bin/phpunit` — **3569 tests, 6175 assertions, OK**
- `vendor/bin/ecs check` — clean
- `vendor/bin/rector process --dry-run` — clean
- `vendor/bin/phpstan` — 79 errors, byte-identical to the pre-change baseline (verified by diffing JSON output). All are the documented doctrine/mongodb-odm results that only appear locally.

## One thing worth a second opinion

I left the four bare `@deprecated` markers on `Model\CreditCard`'s `$secured*` properties. Git history shows they were added alongside `ensureSensitive()`, but the class reads and writes those properties everywhere today while the *plain* properties beside them are the BC ones — so the markers look inverted. Rather than guess at the original intent, I gave them a message saying the pair collapses in 3.0 and that a subclass should use the accessors, which is true either way.