### PR TITLE
Adapt an action to a handler, and a handler to an action

### DIFF
--- a/docs/gateways/migrating-from-v1.md
+++ b/docs/gateways/migrating-from-v1.md
@@ -194,10 +194,6 @@ final class CaptureHandler implements CaptureHandlerInterface
 +return CaptureResult::captured($details['charge_id']);
 ```
 
-### Moving one operation at a time
-
-You do not have to port everything at once. A gateway can keep its factory and actions while a single handler moves across — `execute()` routes by argument type, so the two coexist in the same package.
-
 ### Dispatching a command at a gateway you have not ported
 
 You get a `CommandNotSupportedException` saying so, rather than one that reads like a missing handler:
@@ -277,6 +273,71 @@ Two ordering rules worth knowing:
 
 - **Handlers are asked before actions.** They have to be: a token is a `DetailsAggregateInterface`, so core's `ExecuteSameRequestWithModelDetailsAction` claims `Capture($token)`. Asking actions first would swallow almost every request before a handler saw it.
 - **Except for status requests**, where an action wins. A gateway still holding a status action reads the details of whatever has not moved, which is more than the recorded status knows.
+
+### Driving an action you have not rewritten yet
+
+`DeclaresActions` covers a whole operation: an unported action keeps answering the 1.x request it always answered. What it does not cover is an application that has adopted commands — a `CaptureCommand` sent at your gateway finds no handler and fails, even though your capture action is sitting right there.
+
+Wrap the action instead. There is one adapter per operation in `Payum\Core\Legacy\Handler` — `CaptureActionHandler`, `AuthorizeActionHandler`, `RefundActionHandler`, `CancelActionHandler`, `SyncActionHandler`, `PayoutActionHandler`, `NotifyActionHandler`:
+
+```php
+use Payum\Core\DI\ContainerConfiguration;
+use Payum\Core\Legacy\Handler\CaptureActionHandler;
+use Psr\Container\ContainerInterface;
+
+final class AcmeGateway implements GatewayInterface, ContainerConfiguration
+{
+    public function handlers(): array
+    {
+        return [CaptureActionHandler::class];
+    }
+
+    public function configureContainer(): array
+    {
+        return [
+            CaptureActionHandler::class => fn (ContainerInterface $c) => new CaptureActionHandler(
+                new CaptureAction($c->get(AcmeApi::class)),
+            ),
+        ];
+    }
+}
+```
+
+The action itself does not change. It gets the details array as its model, the token the command arrived on, the gateway to dispatch sub-requests at, and the token factory if it asks for one. `HttpRedirect` and `HttpPostRedirect` come back out as `Redirect` and `PostRedirect` on the result.
+
+Four things to know before relying on it:
+
+- **Status is still read the 1.x way.** Once the action returns, the adapter dispatches `GetHumanStatus` and puts the answer on the result. Keep your status action until the operation is properly ported, or the result reports no status at all.
+- **The 1.x machinery comes with it.** Core's own actions and extensions stay on a gateway whose handler list contains an adapter, the same as one implementing `DeclaresActions` — an action dispatching `GetHttpRequest` still expects an answer.
+- **A rendered `HttpResponse` is rethrown.** No next action means "here is a page". A 1.x caller catches it exactly as before; a caller working with results sees it escape, which is honest rather than reporting a payment finished when it is not.
+- **A notify action goes on verifying itself.** 2.0 splits deciding a message is genuine from acting on it and 1.x does both inside `execute()`, so `NotifyActionHandler::verify()` reports `WebhookEvent::unverified()` and leaves the check where it is. The response the action throws becomes the result's `Acknowledgement`.
+
+### Reaching a handler from a gateway your factory still assembles
+
+The other direction, for a gateway that has not moved off `GatewayFactory` yet. Register a `HandlerToActionAdapter` where the action used to be, and the handler behind it answers everything that already talks to your gateway:
+
+```php
+use Payum\Core\Legacy\HandlerToActionAdapter;
+
+protected function populateConfig(ArrayObject $config): void
+{
+    $config->defaults([
+        'payum.action.capture' => fn (ArrayObject $config) => new HandlerToActionAdapter(
+            new CaptureHandler($config['payum.api']),
+        ),
+        'payum.action.refund' => new RefundAction(),   // not yet
+    ]);
+}
+```
+
+Which request it answers is read off the handler, so there is nothing to keep in step. `Capture` reaches the handler; everything else goes on reaching the actions it always did.
+
+The handler gets a real `Context` — state, token, HTTP request, token factory — and the middleware that persists what it writes and records the status it declares. What it returns is turned back into a reply and thrown, so callers catch what they always caught.
+
+Two limits:
+
+- `$context->gateway()` is null. There is no gateway class describing a gateway a factory assembled.
+- `$context->execute()` cannot dispatch a sub-command, because the gateway has no handlers registered on it. A handler that needs one is past what this adapter is for — port the gateway.
 
 ### Moving your own code across
 

--- a/src/Payum/Core/CoreGatewayFactory.php
+++ b/src/Payum/Core/CoreGatewayFactory.php
@@ -43,6 +43,7 @@ use Payum\Core\Extension\PrependExtensionInterface;
 use Payum\Core\Gateway\DeclaresActions;
 use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
 use Payum\Core\Handler\HandlerMap;
+use Payum\Core\Legacy\ActionToHandlerAdapter;
 use Payum\Core\Middleware\EndlessCycleDetectorMiddleware;
 use Payum\Core\Middleware\LegacyExtensionMiddleware;
 use Payum\Core\Middleware\MiddlewareCollection;
@@ -72,6 +73,7 @@ use function class_exists;
 use function func_get_args;
 use function func_num_args;
 use function in_array;
+use function is_a;
 use function is_string;
 use function str_starts_with;
 use function trigger_deprecation;
@@ -368,16 +370,21 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
         if ($container->has(PaymentGateway::class)) {
             $paymentGateway = $container->get(PaymentGateway::class);
 
-            $gateway->setHandlerMap(HandlerMap::fromHandlers($paymentGateway->handlers()));
+            $handlerMap = HandlerMap::fromHandlers($paymentGateway->handlers());
+
+            $gateway->setHandlerMap($handlerMap);
 
             // A gateway that has finished moving gets nothing else: no actions, no extensions, no Twig
             // environment it will never render with. One still holding actions says so, and then needs
             // core's own alongside them, since an action dispatching GetHttpRequest expects an answer.
-            if (! $paymentGateway instanceof DeclaresActions) {
+            //
+            // A handler that is an adapted action needs the same, and says so by being one, which is why
+            // this asks the handler list as well as the interface.
+            if (! $paymentGateway instanceof DeclaresActions && ! self::adaptsActions($handlerMap)) {
                 return $gateway;
             }
 
-            $declaredActions = $paymentGateway->actions();
+            $declaredActions = $paymentGateway instanceof DeclaresActions ? $paymentGateway->actions() : [];
         }
 
         if ($container->has('twig.env')) {
@@ -512,6 +519,20 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
                 $gateway->addExtension($value, $prepend);
             }
         }
+    }
+
+    /**
+     * Whether any of this gateway's handlers is a 1.x action in a handler's clothing.
+     */
+    private static function adaptsActions(HandlerMap $handlerMap): bool
+    {
+        foreach ($handlerMap->bindings() as $handlerClass) {
+            if (is_a($handlerClass, ActionToHandlerAdapter::class, true)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Payum/Core/Gateway.php
+++ b/src/Payum/Core/Gateway.php
@@ -383,6 +383,12 @@ class Gateway implements GatewayInterface
             throw new LogicException(sprintf('%s must be a handler declaring handle().', $serviceId));
         }
 
+        // Only a handler wrapping a 1.x action asks for this: the action it holds still dispatches
+        // GetHttpRequest and RenderTemplate at the gateway, and something has to be there to dispatch on.
+        if ($handler instanceof GatewayAwareInterface) {
+            $handler->setGateway($this);
+        }
+
         if ($handler instanceof NotifyHandlerInterface) {
             if (! $command instanceof NotifyCommand) {
                 throw new LogicException(sprintf(

--- a/src/Payum/Core/Handler/Context.php
+++ b/src/Payum/Core/Handler/Context.php
@@ -47,9 +47,9 @@ final class Context
     public function __construct(
         private readonly Executor $executor,
         private readonly CommandInterface $command,
-        private readonly GatewayInterface $gateway,
+        private readonly ?GatewayInterface $gateway,
         private readonly ServerRequestInterface $httpRequest,
-        private readonly GenericTokenFactoryInterface $tokenFactory,
+        private readonly ?GenericTokenFactoryInterface $tokenFactory,
         private readonly ?SubjectInterface $subject = null,
         private readonly ?TokenInterface $token = null,
         private readonly array $previous = [],
@@ -83,9 +83,13 @@ final class Context
     }
 
     /**
-     * The gateway currently executing
+     * The gateway currently executing.
+     *
+     * Null only when there is no gateway class to describe it, which happens when a
+     * {@see \Payum\Core\Legacy\HandlerToActionAdapter} runs this handler inside a gateway a 1.x factory
+     * assembled.
      */
-    public function gateway(): GatewayInterface
+    public function gateway(): ?GatewayInterface
     {
         return $this->gateway;
     }
@@ -203,10 +207,14 @@ final class Context
      * Mints tokens, for gateways that need a notify URL or a second hop.
      *
      * Replaces v1's GenericTokenFactoryAwareInterface / GenericTokenFactoryExtension pair.
+     *
+     * @throws LogicException when the gateway was assembled without one, which only a 1.x factory does
      */
     public function tokens(): GenericTokenFactoryInterface
     {
-        return $this->tokenFactory;
+        return $this->tokenFactory ?? throw new LogicException(
+            'This gateway has no token factory on it, so there is nothing to mint a token with. It was assembled by a 1.x factory: register a Payum\Core\Extension\GenericTokenFactoryExtension on it, or build it with PayumBuilder.'
+        );
     }
 
     /**

--- a/src/Payum/Core/Legacy/ActionToHandlerAdapter.php
+++ b/src/Payum/Core/Legacy/ActionToHandlerAdapter.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Legacy;
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\GatewayAwareInterface;
+use Payum\Core\GatewayInterface as Executor;
+use Payum\Core\Handler\Context;
+use Payum\Core\Handler\HandlerInterface;
+use Payum\Core\Model\SubjectInterface;
+use Payum\Core\Reply\Base;
+use Payum\Core\Request\Generic;
+use Payum\Core\Request\GetHumanStatus;
+use Payum\Core\Result\NextAction;
+use Payum\Core\Result\PaymentStatus;
+use Payum\Core\Security\GenericTokenFactoryAwareInterface;
+
+/**
+ * Presents a 1.x action as the handler for the command that means the same thing.
+ *
+ * {@see \Payum\Core\Gateway\DeclaresActions} moves a gateway across in one direction: an action nobody has
+ * ported keeps answering the 1.x request it always answered. This moves it in the other: the action stays
+ * exactly as it is and answers a command, so an application that has adopted commands reaches it too.
+ *
+ * Subclass per command -- {@see Handler\CaptureActionHandler} and friends -- because PHP will not let one
+ * class declare handle() twice.
+ *
+ * Three things are worth knowing before reaching for this:
+ *
+ *   - The action still runs on 1.x machinery, so the gateway has to keep it. Core arranges that: a gateway
+ *     whose handler list contains an adapter gets core's own actions and extensions, the same as one
+ *     implementing DeclaresActions.
+ *   - Status is read the 1.x way, by asking the gateway for {@see GetHumanStatus} once the action has run.
+ *     A gateway that has already deleted its status action will report nothing, which is honest rather
+ *     than a guess.
+ *   - A reply the action throws that no {@see NextAction} means the same as -- a rendered HttpResponse --
+ *     is rethrown rather than swallowed.
+ *
+ * @deprecated since 2.0, removed in 3.0 along with actions.
+ */
+abstract class ActionToHandlerAdapter implements HandlerInterface, GatewayAwareInterface
+{
+    protected ?Executor $gateway = null;
+
+    public function __construct(
+        private readonly ActionInterface $action
+    ) {
+    }
+
+    public function setGateway(Executor $gateway): void
+    {
+        $this->gateway = $gateway;
+    }
+
+    /**
+     * Runs the action and reports what it decided, in the two pieces every result is built from.
+     *
+     * @param class-string<Generic> $requestClass
+     *
+     * @return array{PaymentStatus|null, NextAction|null}
+     *
+     * @throws Base when the action threw a reply no next action means the same as
+     */
+    final protected function run(string $requestClass, Context $context): array
+    {
+        $reply = $this->dispatch($requestClass, $context);
+
+        if (! $reply instanceof Base) {
+            return [$this->status($context), null];
+        }
+
+        $next = ReplyToResult::translate($reply);
+
+        if (! $next instanceof NextAction) {
+            throw $reply;
+        }
+
+        // The customer has somewhere to be, so the operation is not finished. A status action still on the
+        // gateway knows better and wins.
+        return [$this->status($context) ?? PaymentStatus::Pending, $next];
+    }
+
+    /**
+     * Runs the action against the 1.x request it expects, returning the reply it threw.
+     *
+     * @param class-string<Generic> $requestClass
+     */
+    final protected function dispatch(string $requestClass, Context $context): ?Base
+    {
+        if ($this->action instanceof GatewayAwareInterface && $this->gateway instanceof Executor) {
+            $this->action->setGateway($this->gateway);
+        }
+
+        if ($this->action instanceof GenericTokenFactoryAwareInterface) {
+            $this->action->setGenericTokenFactory($context->tokens());
+        }
+
+        try {
+            $this->action->execute($this->request($requestClass, $context));
+        } catch (Base $reply) {
+            // Only the replies core ships are caught. A reply that implements ReplyInterface without
+            // extending Base is not a Throwable as far as the type system is concerned, so it could not
+            // be rethrown -- and propagating it untouched is what would happen to it anyway.
+            return $reply;
+        }
+
+        return null;
+    }
+
+    /**
+     * What the gateway's status action makes of the state the action left behind.
+     *
+     * Null when nothing answered, which is what a gateway that has finished porting its status action
+     * looks like. Unknown collapses to null too: a result whose status is null concluded nothing, and
+     * that is the same statement.
+     */
+    final protected function status(Context $context): ?PaymentStatus
+    {
+        if (! $this->gateway instanceof Executor) {
+            return null;
+        }
+
+        $this->gateway->execute($status = new GetHumanStatus($this->state($context)));
+
+        $value = PaymentStatus::tryFrom((string) $status->getValue());
+
+        return PaymentStatus::Unknown === $value ? null : $value;
+    }
+
+    /**
+     * The 1.x request the action is waiting for: the details array it reads and writes, plus the token it
+     * came in on, which is what a redirect action hands the PSP as its return URL.
+     *
+     * @param class-string<Generic> $requestClass
+     */
+    private function request(string $requestClass, Context $context): Generic
+    {
+        $state = $this->state($context);
+
+        // Constructing with the token is the only way to set one -- Generic has no setter -- and setModel()
+        // then puts the details in front of it, which is what the action matches on.
+        $request = new $requestClass($context->token() ?? $state);
+        $request->setModel($state);
+
+        return $request;
+    }
+
+    /**
+     * @return ArrayObject<string, mixed>
+     */
+    private function state(Context $context): ArrayObject
+    {
+        // A notify may point at nothing at all, and state() has nothing to read from in that case.
+        return $context->subject() instanceof SubjectInterface ? $context->state() : new ArrayObject();
+    }
+}

--- a/src/Payum/Core/Legacy/Handler/AuthorizeActionHandler.php
+++ b/src/Payum/Core/Legacy/Handler/AuthorizeActionHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Legacy\Handler;
+
+use Payum\Core\Command\AuthorizeCommand;
+use Payum\Core\Handler\AuthorizeHandlerInterface;
+use Payum\Core\Handler\Context;
+use Payum\Core\Legacy\ActionToHandlerAdapter;
+use Payum\Core\Request\Authorize;
+use Payum\Core\Result\AuthorizeResult;
+
+/**
+ * A 1.x authorize action, answering a {@see AuthorizeCommand}.
+ *
+ * @deprecated since 2.0, removed in 3.0 along with actions.
+ */
+final class AuthorizeActionHandler extends ActionToHandlerAdapter implements AuthorizeHandlerInterface
+{
+    public function handle(AuthorizeCommand $command, Context $context): AuthorizeResult
+    {
+        [$status, $next] = $this->run(Authorize::class, $context);
+
+        return new AuthorizeResult($status, $next);
+    }
+}

--- a/src/Payum/Core/Legacy/Handler/CancelActionHandler.php
+++ b/src/Payum/Core/Legacy/Handler/CancelActionHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Legacy\Handler;
+
+use Payum\Core\Command\CancelCommand;
+use Payum\Core\Handler\CancelHandlerInterface;
+use Payum\Core\Handler\Context;
+use Payum\Core\Legacy\ActionToHandlerAdapter;
+use Payum\Core\Request\Cancel;
+use Payum\Core\Result\CancelResult;
+
+/**
+ * A 1.x cancel action, answering a {@see CancelCommand}.
+ *
+ * @deprecated since 2.0, removed in 3.0 along with actions.
+ */
+final class CancelActionHandler extends ActionToHandlerAdapter implements CancelHandlerInterface
+{
+    public function handle(CancelCommand $command, Context $context): CancelResult
+    {
+        [$status, $next] = $this->run(Cancel::class, $context);
+
+        return new CancelResult($status, $next);
+    }
+}

--- a/src/Payum/Core/Legacy/Handler/CaptureActionHandler.php
+++ b/src/Payum/Core/Legacy/Handler/CaptureActionHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Legacy\Handler;
+
+use Payum\Core\Command\CaptureCommand;
+use Payum\Core\Handler\CaptureHandlerInterface;
+use Payum\Core\Handler\Context;
+use Payum\Core\Legacy\ActionToHandlerAdapter;
+use Payum\Core\Request\Capture;
+use Payum\Core\Result\CaptureResult;
+
+/**
+ * A 1.x capture action, answering a {@see CaptureCommand}.
+ *
+ * @deprecated since 2.0, removed in 3.0 along with actions.
+ */
+final class CaptureActionHandler extends ActionToHandlerAdapter implements CaptureHandlerInterface
+{
+    public function handle(CaptureCommand $command, Context $context): CaptureResult
+    {
+        [$status, $next] = $this->run(Capture::class, $context);
+
+        return new CaptureResult($status, $next);
+    }
+}

--- a/src/Payum/Core/Legacy/Handler/NotifyActionHandler.php
+++ b/src/Payum/Core/Legacy/Handler/NotifyActionHandler.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Legacy\Handler;
+
+use Payum\Core\Command\NotifyCommand;
+use Payum\Core\Handler\Context;
+use Payum\Core\Handler\NotifyHandlerInterface;
+use Payum\Core\Handler\WebhookEvent;
+use Payum\Core\Legacy\ActionToHandlerAdapter;
+use Payum\Core\Reply\Base;
+use Payum\Core\Reply\HttpResponse;
+use Payum\Core\Request\Notify;
+use Payum\Core\Result\Acknowledgement;
+use Payum\Core\Result\NotifyResult;
+use Psr\Http\Message\ServerRequestInterface;
+use function is_array;
+
+/**
+ * A 1.x notify action, answering a {@see NotifyCommand}.
+ *
+ * The one adapter that cannot honour the interface it implements. 2.0 splits deciding a message is genuine
+ * from acting on it, and a 1.x action does both inside execute(); there is no seam to pull them apart on.
+ * So verification is reported as {@see WebhookEvent::unverified()} and the action goes on checking the
+ * message itself, exactly as it did before -- which is no weaker than 1.x was, and no stronger.
+ *
+ * @deprecated since 2.0, removed in 3.0 along with actions.
+ */
+final class NotifyActionHandler extends ActionToHandlerAdapter implements NotifyHandlerInterface
+{
+    public function verify(ServerRequestInterface $request): WebhookEvent
+    {
+        $body = $request->getParsedBody();
+
+        return WebhookEvent::unverified(is_array($body) ? $body : []);
+    }
+
+    public function handle(NotifyCommand $command, WebhookEvent $event, Context $context): NotifyResult
+    {
+        $reply = $this->dispatch(Notify::class, $context);
+
+        // A 1.x action answers the PSP by throwing the response it wants sent back.
+        if ($reply instanceof Base && ! $reply instanceof HttpResponse) {
+            throw $reply;
+        }
+
+        /** @var array<string, string> $headers */
+        $headers = $reply instanceof HttpResponse ? $reply->getHeaders() : [];
+
+        return NotifyResult::handled(
+            $this->status($context),
+            $reply instanceof HttpResponse
+                ? new Acknowledgement($reply->getStatusCode(), $reply->getContent(), $headers)
+                : null,
+        );
+    }
+}

--- a/src/Payum/Core/Legacy/Handler/PayoutActionHandler.php
+++ b/src/Payum/Core/Legacy/Handler/PayoutActionHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Legacy\Handler;
+
+use Payum\Core\Command\PayoutCommand;
+use Payum\Core\Handler\Context;
+use Payum\Core\Handler\PayoutHandlerInterface;
+use Payum\Core\Legacy\ActionToHandlerAdapter;
+use Payum\Core\Request\Payout;
+use Payum\Core\Result\PayoutResult;
+
+/**
+ * A 1.x payout action, answering a {@see PayoutCommand}.
+ *
+ * @deprecated since 2.0, removed in 3.0 along with actions.
+ */
+final class PayoutActionHandler extends ActionToHandlerAdapter implements PayoutHandlerInterface
+{
+    public function handle(PayoutCommand $command, Context $context): PayoutResult
+    {
+        [$status, $next] = $this->run(Payout::class, $context);
+
+        return new PayoutResult($status, $next);
+    }
+}

--- a/src/Payum/Core/Legacy/Handler/RefundActionHandler.php
+++ b/src/Payum/Core/Legacy/Handler/RefundActionHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Legacy\Handler;
+
+use Payum\Core\Command\RefundCommand;
+use Payum\Core\Handler\Context;
+use Payum\Core\Handler\RefundHandlerInterface;
+use Payum\Core\Legacy\ActionToHandlerAdapter;
+use Payum\Core\Request\Refund;
+use Payum\Core\Result\RefundResult;
+
+/**
+ * A 1.x refund action, answering a {@see RefundCommand}.
+ *
+ * @deprecated since 2.0, removed in 3.0 along with actions.
+ */
+final class RefundActionHandler extends ActionToHandlerAdapter implements RefundHandlerInterface
+{
+    public function handle(RefundCommand $command, Context $context): RefundResult
+    {
+        [$status, $next] = $this->run(Refund::class, $context);
+
+        return new RefundResult($status, $next);
+    }
+}

--- a/src/Payum/Core/Legacy/Handler/SyncActionHandler.php
+++ b/src/Payum/Core/Legacy/Handler/SyncActionHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Legacy\Handler;
+
+use Payum\Core\Command\SyncCommand;
+use Payum\Core\Handler\Context;
+use Payum\Core\Handler\SyncHandlerInterface;
+use Payum\Core\Legacy\ActionToHandlerAdapter;
+use Payum\Core\Request\Sync;
+use Payum\Core\Result\SyncResult;
+
+/**
+ * A 1.x sync action, answering a {@see SyncCommand}.
+ *
+ * @deprecated since 2.0, removed in 3.0 along with actions.
+ */
+final class SyncActionHandler extends ActionToHandlerAdapter implements SyncHandlerInterface
+{
+    public function handle(SyncCommand $command, Context $context): SyncResult
+    {
+        [$status, $next] = $this->run(Sync::class, $context);
+
+        return new SyncResult($status, $next);
+    }
+}

--- a/src/Payum/Core/Legacy/HandlerToActionAdapter.php
+++ b/src/Payum/Core/Legacy/HandlerToActionAdapter.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Legacy;
+
+use Http\Discovery\Psr17FactoryDiscovery;
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Action\PrependActionInterface;
+use Payum\Core\Command\CommandInterface;
+use Payum\Core\Command\NotifyCommand;
+use Payum\Core\Exception\LogicException;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Gateway as Executor;
+use Payum\Core\GatewayAwareInterface;
+use Payum\Core\GatewayInterface;
+use Payum\Core\Handler\Context;
+use Payum\Core\Handler\HandlerInterface;
+use Payum\Core\Handler\HandlerMap;
+use Payum\Core\Handler\NotifyHandlerInterface;
+use Payum\Core\Middleware\PersistStateMiddleware;
+use Payum\Core\Middleware\Pipeline;
+use Payum\Core\Middleware\RecordPaymentStatusMiddleware;
+use Payum\Core\Middleware\TemplateRenderMiddleware;
+use Payum\Core\Model\SubjectInterface;
+use Payum\Core\Reply\Base;
+use Payum\Core\Reply\HttpResponse;
+use Payum\Core\Request\Generic;
+use Payum\Core\Request\GetHttpRequest;
+use Payum\Core\Request\RenderTemplate;
+use Payum\Core\Result\NextAction\RenderTemplate as RenderTemplateAction;
+use Payum\Core\Result\Result;
+use Payum\Core\Security\GenericTokenFactoryAwareInterface;
+use Payum\Core\Security\GenericTokenFactoryInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use function sprintf;
+
+/**
+ * Presents a 2.0 handler as the 1.x action for the request that means the same thing.
+ *
+ * The other half of {@see ActionToHandlerAdapter}: a gateway a 1.x factory still assembles registers one of
+ * these where it used to register an action, and the handler behind it is reached by everything that
+ * already talks to that gateway. Nothing else about the gateway has to change, so the first handler can
+ * land on its own.
+ *
+ * ```php
+ * protected function populateConfig(ArrayObject $config): void
+ * {
+ *     $config->defaults([
+ *         'payum.action.capture' => fn (ArrayObject $config) => new HandlerToActionAdapter(
+ *             new CaptureHandler($config['payum.api']),
+ *         ),
+ *     ]);
+ * }
+ * ```
+ *
+ * Which request it answers is read off the handler, so there is nothing to keep in step. It is prepended,
+ * because a handler wants the payment the request is about and core's own actions would otherwise have
+ * unwrapped it down to a details array first.
+ *
+ * What the handler gets is a real {@see Context} -- state, token, HTTP request, token factory -- and the
+ * middleware that persists what it decides. Two things it does not get:
+ *
+ *   - {@see Context::gateway()}, which is null: there is no gateway class describing a gateway a factory
+ *     assembled.
+ *   - {@see Context::execute()}, which needs the gateway to have handlers registered on it. A handler
+ *     dispatching sub-commands is past what this adapter is for; port the gateway.
+ *
+ * @deprecated since 2.0, removed in 3.0 along with actions.
+ */
+final class HandlerToActionAdapter implements ActionInterface, PrependActionInterface, GatewayAwareInterface, GenericTokenFactoryAwareInterface
+{
+    /**
+     * @var class-string<CommandInterface<Result>>
+     */
+    private readonly string $commandClass;
+
+    private ?Executor $executor = null;
+
+    private ?GenericTokenFactoryInterface $tokenFactory = null;
+
+    public function __construct(
+        private readonly HandlerInterface $handler
+    ) {
+        $commands = HandlerMap::fromHandlers([$handler::class])->commands();
+
+        $this->commandClass = $commands[0];
+    }
+
+    public function execute($request): void
+    {
+        $executor = $this->executor;
+
+        if (! $executor instanceof Executor) {
+            throw new LogicException(sprintf(
+                '%s has not been given the gateway it runs on, so it cannot build the context %s needs. Add it to a %s.',
+                self::class,
+                $this->handler::class,
+                Executor::class,
+            ));
+        }
+
+        $command = RequestToCommand::translate($request);
+
+        if (! $command instanceof CommandInterface || ! $command instanceof $this->commandClass) {
+            throw RequestNotSupportedException::createActionNotSupported($this, $request);
+        }
+
+        $result = $this->pipeline()->process(
+            $command,
+            $this->context($executor, $command, $request),
+            $this->handle(...),
+        );
+
+        $this->reply($executor, $result);
+    }
+
+    public function setGateway(GatewayInterface $gateway): void
+    {
+        // Building a context needs the executor itself, not merely something that can execute.
+        $this->executor = $gateway instanceof Executor ? $gateway : null;
+    }
+
+    public function setGenericTokenFactory(?GenericTokenFactoryInterface $genericTokenFactory = null): void
+    {
+        $this->tokenFactory = $genericTokenFactory;
+    }
+
+    public function supports($request): bool
+    {
+        return RequestToCommand::supports($request)
+            && RequestToCommand::translate($request) instanceof $this->commandClass;
+    }
+
+    /**
+     * @param CommandInterface<Result> $command
+     */
+    private function context(Executor $executor, CommandInterface $command, object $request): Context
+    {
+        $model = $request instanceof Generic ? $request->getFirstModel() : null;
+
+        return new Context(
+            $executor,
+            $command,
+            null,
+            $this->httpRequest($executor),
+            $this->tokenFactory,
+            $model instanceof SubjectInterface ? $model : $command->subject(),
+            $command->token(),
+            [],
+            $executor->getName(),
+        );
+    }
+
+    /**
+     * @param CommandInterface<Result> $command
+     */
+    private function handle(CommandInterface $command, Context $context): Result
+    {
+        if ($this->handler instanceof NotifyHandlerInterface && $command instanceof NotifyCommand) {
+            return $this->handler->handle($command, $this->handler->verify($context->httpRequest()), $context);
+        }
+
+        if (! method_exists($this->handler, 'handle')) {
+            throw new LogicException(sprintf('%s must declare handle().', $this->handler::class));
+        }
+
+        $result = $this->handler->handle($command, $context);
+
+        if (! $result instanceof Result) {
+            throw new LogicException(sprintf('%s::handle() must return a %s.', $this->handler::class, Result::class));
+        }
+
+        return $result;
+    }
+
+    /**
+     * The inbound request as PSR-7, rebuilt from what 1.x knows about it.
+     *
+     * There is no PSR-7 request to be had inside a gateway a factory assembled, so this asks for the one
+     * shape that is always available and converts it. The body matters: a notify handler verifies a
+     * signature over the raw bytes.
+     */
+    private function httpRequest(Executor $executor): ServerRequestInterface
+    {
+        $executor->execute($http = new GetHttpRequest());
+
+        $request = Psr17FactoryDiscovery::findServerRequestFactory()
+            ->createServerRequest($http->method ?: 'GET', $http->uri ?: '/')
+            ->withQueryParams($http->query)
+            ->withParsedBody($http->request)
+            ->withBody(Psr17FactoryDiscovery::findStreamFactory()->createStream($http->content))
+        ;
+
+        foreach ($http->headers as $name => $value) {
+            $request = $request->withHeader((string) $name, $value);
+        }
+
+        return $request;
+    }
+
+    /**
+     * The middleware a handler is entitled to whichever way it was reached. The gateway's own extensions
+     * already run around this, on the action path, and the storage extension is what writes the payment
+     * away -- which is why nothing is passed to PersistStateMiddleware.
+     */
+    private function pipeline(): Pipeline
+    {
+        return new Pipeline([
+            new TemplateRenderMiddleware(),
+            new PersistStateMiddleware(),
+            new RecordPaymentStatusMiddleware(),
+        ]);
+    }
+
+    /**
+     * Answers the 1.x caller the way it expects to hear it: by throwing.
+     */
+    private function reply(Executor $executor, Result $result): void
+    {
+        if ($result->next instanceof RenderTemplateAction) {
+            $executor->execute($render = new RenderTemplate($result->next->template, $result->next->context));
+
+            throw new HttpResponse($render->getResult());
+        }
+
+        $reply = ResultToReply::translate($result);
+
+        if ($reply instanceof Base) {
+            throw $reply;
+        }
+    }
+}

--- a/src/Payum/Core/Legacy/ReplyToResult.php
+++ b/src/Payum/Core/Legacy/ReplyToResult.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Legacy;
+
+use Payum\Core\Reply\HttpPostRedirect;
+use Payum\Core\Reply\HttpRedirect;
+use Payum\Core\Reply\ReplyInterface;
+use Payum\Core\Result\NextAction;
+use Payum\Core\Result\NextAction\PostRedirect;
+use Payum\Core\Result\NextAction\Redirect;
+
+/**
+ * Turns the reply a 1.x action threw into the next action that means the same thing.
+ *
+ * The inverse of {@see ResultToReply}, and deliberately not its mirror image: a reply is a rendered HTTP
+ * response and a {@see NextAction} is intent, so only the replies that carry intent translate. Everything
+ * else answers null, and the caller rethrows -- which leaves a 1.x caller catching exactly what it caught
+ * before.
+ *
+ * @deprecated since 2.0, removed in 3.0 along with the replies it translates.
+ */
+final class ReplyToResult
+{
+    public static function translate(ReplyInterface $reply): ?NextAction
+    {
+        /** @var array<string, scalar> $fields */
+        $fields = $reply instanceof HttpPostRedirect ? $reply->getFields() : [];
+
+        return match (true) {
+            // Both of these extend HttpResponse, so the specific has to be asked before the general.
+            $reply instanceof HttpPostRedirect => new PostRedirect($reply->getUrl(), $fields),
+            $reply instanceof HttpRedirect => new Redirect($reply->getUrl(), $reply->getStatusCode(), $reply->getHeaders()),
+            default => null,
+        };
+    }
+}

--- a/src/Payum/Core/PayumBuilder.php
+++ b/src/Payum/Core/PayumBuilder.php
@@ -76,6 +76,7 @@ use Twig\Loader\ChainLoader;
 use function array_merge;
 use function array_replace;
 use function DI\autowire;
+use function DI\get;
 use function in_array;
 use function is_a;
 use function is_dir;
@@ -434,16 +435,25 @@ class PayumBuilder
 
             $containerBuilder = new ContainerBuilder();
 
-            // Core defaults first, then the services shared by every gateway, then what the gateway
-            // declares for itself. Last wins.
+            // Core defaults first, then the services shared by every gateway, then the handler bindings,
+            // then what the gateway declares for itself. Last wins.
             $containerBuilder->addDefinitions($coreGatewayFactory->configureContainer());
             $containerBuilder->addDefinitions($this->buildSharedDefinitions($globalContainer));
+
+            $handlerDefinitions = [];
+
+            foreach (HandlerMap::fromHandlers($gateway->handlers())->bindings() as $interface => $handlerClass) {
+                // The interface resolves to the entry, not to a fresh autowired instance, so that a gateway
+                // declaring the handler itself -- decorated, or wrapping a 1.x action -- is what gets used.
+                $handlerDefinitions[$handlerClass] = autowire($handlerClass);
+                $handlerDefinitions[$interface] = get($handlerClass);
+            }
+
+            $containerBuilder->addDefinitions($handlerDefinitions);
 
             if (null !== $gatewayDefinitions) {
                 $containerBuilder->addDefinitions($gatewayDefinitions);
             }
-
-            $handlerDefinitions = array_map(autowire(...), HandlerMap::fromHandlers($gateway->handlers())->bindings());
 
             // Core defaults first, then what the application registered, then the gateway's own, so a
             // gateway's middleware runs innermost on equal priority.
@@ -455,7 +465,6 @@ class PayumBuilder
                 }
             }
 
-            $containerBuilder->addDefinitions($handlerDefinitions);
             $containerBuilder->addDefinitions([
                 MiddlewareCollection::class => $middleware,
             ]);

--- a/src/Payum/Core/Tests/Legacy/ActionToHandlerAdapterTest.php
+++ b/src/Payum/Core/Tests/Legacy/ActionToHandlerAdapterTest.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests\Legacy;
+
+use ArrayAccess;
+use League\Uri\Uri;
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Command\CaptureCommand;
+use Payum\Core\Config\GatewayConfig;
+use Payum\Core\DI\ContainerConfiguration;
+use Payum\Core\Gateway\DeclaresActions;
+use Payum\Core\Gateway\GatewayInterface as PaymentGateway;
+use Payum\Core\GatewayAwareInterface;
+use Payum\Core\GatewayAwareTrait;
+use Payum\Core\Legacy\Handler\CaptureActionHandler;
+use Payum\Core\Metadata\Logo;
+use Payum\Core\Metadata\Logo\Url;
+use Payum\Core\Model\Payment;
+use Payum\Core\Payum;
+use Payum\Core\PayumBuilder;
+use Payum\Core\Registry\StorageRegistryInterface;
+use Payum\Core\Reply\HttpRedirect;
+use Payum\Core\Reply\HttpResponse;
+use Payum\Core\Request\Capture;
+use Payum\Core\Request\GetHttpRequest;
+use Payum\Core\Request\GetStatusInterface;
+use Payum\Core\Result\CaptureResult;
+use Payum\Core\Result\NextAction\Redirect;
+use Payum\Core\Result\PaymentStatus;
+use Payum\Core\Security\TokenInterface;
+use Payum\Core\Storage\StorageInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * An action nobody has ported yet, driven by the command that means the same thing.
+ */
+final class ActionToHandlerAdapterTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_SERVER = [
+            'HTTP_HOST' => 'payum.dev',
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/pay',
+        ];
+
+        $_GET = [];
+    }
+
+    public function testShouldDriveTheActionFromACommandAndReportWhatItThrew(): void
+    {
+        $payment = $this->buildPayment();
+
+        $result = $this->buildPayum()->getGateway('acme')->execute(CaptureCommand::forPayment($payment));
+
+        $this->assertInstanceOf(CaptureResult::class, $result);
+        $this->assertInstanceOf(Redirect::class, $result->next);
+        $this->assertSame('https://psp.test/checkout', $result->next->url);
+        $this->assertSame(PaymentStatus::Pending, $result->status);
+
+        // What the action wrote into the details is on the payment, the same as it would be after the
+        // 1.x request. That is what makes the second phase find it.
+        $this->assertSame('chk_1', $payment->getDetails()['checkout_id']);
+    }
+
+    public function testShouldReportTheStatusTheGatewaysOwnStatusActionAnswersWith(): void
+    {
+        $payment = $this->buildPayment();
+        $payment->setDetails([
+            'checkout_id' => 'chk_1',
+        ]);
+
+        $result = $this->buildPayum()->getGateway('acme')->execute(CaptureCommand::forPayment($payment));
+
+        $this->assertSame(PaymentStatus::Captured, $result->status);
+        $this->assertNull($result->next);
+    }
+
+    public function testShouldStillAnswerTheOneXRequestTheActionUsedToAnswer(): void
+    {
+        // The application has not moved, the gateway has: the request becomes a command, the command
+        // reaches the adapter, and the reply the action threw comes back out as a reply.
+        $this->expectException(HttpRedirect::class);
+
+        $this->buildPayum()->getGateway('acme')->execute(new Capture($this->buildPayment()));
+    }
+
+    public function testShouldRethrowAReplyNoNextActionMeansTheSameAs(): void
+    {
+        $payment = $this->buildPayment();
+        $payment->setDetails([
+            'render' => true,
+        ]);
+
+        $this->expectException(HttpResponse::class);
+
+        $this->buildPayum()->getGateway('acme')->execute(CaptureCommand::forPayment($payment));
+    }
+
+    public function testShouldKeepTheOneXMachineryForAGatewayWhoseOnlyLegacyIsAnAdapter(): void
+    {
+        // AloneCaptureAction dispatches GetHttpRequest, which only core's own action answers. A gateway
+        // declaring no actions of its own still gets those, or an adapted action could not run.
+        $payum = (new PayumBuilder())
+            ->addDefaultStorages()
+            ->registerGateway('alone', new AloneConfig())
+            ->getPayum();
+
+        $result = $payum->getGateway('alone')->execute(CaptureCommand::forPayment($this->buildPayment()));
+
+        $this->assertSame(PaymentStatus::Pending, $result->status);
+        $this->assertInstanceOf(Redirect::class, $result->next);
+    }
+
+    private function buildPayment(): Payment
+    {
+        $payment = new Payment();
+        $payment->setNumber(uniqid());
+        $payment->setTotalAmount(123);
+        $payment->setCurrencyCode('EUR');
+
+        return $payment;
+    }
+
+    /**
+     * @return Payum<StorageRegistryInterface<StorageInterface<TokenInterface>>>
+     */
+    private function buildPayum(): Payum
+    {
+        return (new PayumBuilder())
+            ->addDefaultStorages()
+            ->registerGateway('acme', new AdaptedConfig())
+            ->getPayum();
+    }
+}
+
+final class AdaptedConfig implements GatewayConfig
+{
+    public function getGatewayClass(): string
+    {
+        return AdaptedGateway::class;
+    }
+}
+
+final class AdaptedGateway implements PaymentGateway, DeclaresActions, ContainerConfiguration
+{
+    public function actions(): array
+    {
+        return [AdaptedStatusAction::class];
+    }
+
+    public function configClass(): string
+    {
+        return AdaptedConfig::class;
+    }
+
+    public function configureContainer(): array
+    {
+        return [
+            CaptureActionHandler::class => static fn (): CaptureActionHandler => new CaptureActionHandler(new AdaptedCaptureAction()),
+        ];
+    }
+
+    public function handlers(): array
+    {
+        return [CaptureActionHandler::class];
+    }
+
+    public function logo(): Logo
+    {
+        return Url::create('https://acme.test/logo.svg');
+    }
+
+    public function name(): string
+    {
+        return 'Acme';
+    }
+
+    public function websiteUrl(): Uri
+    {
+        return Uri::new('https://acme.test');
+    }
+}
+
+final class AloneConfig implements GatewayConfig
+{
+    public function getGatewayClass(): string
+    {
+        return AloneGateway::class;
+    }
+}
+
+final class AloneGateway implements PaymentGateway, ContainerConfiguration
+{
+    public function configClass(): string
+    {
+        return AloneConfig::class;
+    }
+
+    public function configureContainer(): array
+    {
+        return [
+            CaptureActionHandler::class => static fn (): CaptureActionHandler => new CaptureActionHandler(new AloneCaptureAction()),
+        ];
+    }
+
+    public function handlers(): array
+    {
+        return [CaptureActionHandler::class];
+    }
+
+    public function logo(): Logo
+    {
+        return Url::create('https://alone.test/logo.svg');
+    }
+
+    public function name(): string
+    {
+        return 'Alone';
+    }
+
+    public function websiteUrl(): Uri
+    {
+        return Uri::new('https://alone.test');
+    }
+}
+
+/**
+ * Untouched 1.x code: reads the details, dispatches a sub-request, throws a reply.
+ */
+final class AdaptedCaptureAction implements ActionInterface, GatewayAwareInterface
+{
+    use GatewayAwareTrait;
+
+    public function execute($request): void
+    {
+        $details = ArrayObject::ensureArrayObject($request->getModel());
+
+        $this->gateway->execute(new GetHttpRequest());
+
+        if ($details['render']) {
+            throw new HttpResponse('<form></form>');
+        }
+
+        if (! $details['checkout_id']) {
+            $details['checkout_id'] = 'chk_1';
+
+            throw new HttpRedirect('https://psp.test/checkout');
+        }
+
+        $details['paid'] = true;
+    }
+
+    public function supports($request): bool
+    {
+        return $request instanceof Capture && $request->getModel() instanceof ArrayAccess;
+    }
+}
+
+final class AloneCaptureAction implements ActionInterface, GatewayAwareInterface
+{
+    use GatewayAwareTrait;
+
+    public function execute($request): void
+    {
+        $this->gateway->execute(new GetHttpRequest());
+
+        throw new HttpRedirect('https://psp.test/checkout');
+    }
+
+    public function supports($request): bool
+    {
+        return $request instanceof Capture;
+    }
+}
+
+final class AdaptedStatusAction implements ActionInterface
+{
+    public function execute($request): void
+    {
+        /** @var GetStatusInterface $request */
+        $details = ArrayObject::ensureArrayObject($request->getModel());
+
+        $details['paid'] ? $request->markCaptured() : $request->markPending();
+    }
+
+    public function supports($request): bool
+    {
+        return $request instanceof GetStatusInterface && $request->getModel() instanceof ArrayAccess;
+    }
+}

--- a/src/Payum/Core/Tests/Legacy/HandlerToActionAdapterTest.php
+++ b/src/Payum/Core/Tests/Legacy/HandlerToActionAdapterTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests\Legacy;
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Command\CaptureCommand;
+use Payum\Core\GatewayFactory;
+use Payum\Core\GatewayFactoryInterface;
+use Payum\Core\Handler\CaptureHandlerInterface;
+use Payum\Core\Handler\Context;
+use Payum\Core\Legacy\HandlerToActionAdapter;
+use Payum\Core\Model\Payment;
+use Payum\Core\Model\StatusAwareInterface;
+use Payum\Core\Payum;
+use Payum\Core\PayumBuilder;
+use Payum\Core\Registry\StorageRegistryInterface;
+use Payum\Core\Reply\HttpRedirect;
+use Payum\Core\Request\Capture;
+use Payum\Core\Request\Refund;
+use Payum\Core\Result\CaptureResult;
+use Payum\Core\Result\NextAction\Redirect;
+use Payum\Core\Result\PaymentStatus;
+use Payum\Core\Security\TokenInterface;
+use Payum\Core\Storage\StorageInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A handler reached from a gateway a 1.x factory still assembles.
+ */
+final class HandlerToActionAdapterTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_SERVER = [
+            'HTTP_HOST' => 'payum.dev',
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/pay',
+        ];
+
+        $_GET = [];
+        $_POST = [];
+    }
+
+    public function testShouldAnswerTheOneXRequestFromTheHandlerBehindIt(): void
+    {
+        $payment = $this->buildPayment();
+
+        try {
+            $this->buildPayum()->getGateway('acme')->execute(new Capture($payment));
+
+            $this->fail('The handler asked for a redirect, so a reply was expected.');
+        } catch (HttpRedirect $reply) {
+            $this->assertSame('https://psp.test/checkout', $reply->getUrl());
+        }
+
+        // The pipeline the handler is entitled to ran: what it wrote is on the payment, and the status
+        // it declared was recorded.
+        $this->assertSame('chk_1', $payment->getDetails()['checkout_id']);
+        $this->assertSame(PaymentStatus::Pending, $payment->getStatus());
+    }
+
+    public function testShouldReturnTheReplyWhenTheCallerAsksToCatchIt(): void
+    {
+        $reply = $this->buildPayum()->getGateway('acme')->execute(new Capture($this->buildPayment()), true);
+
+        $this->assertInstanceOf(HttpRedirect::class, $reply);
+    }
+
+    public function testShouldThrowNothingOnceTheHandlerIsFinished(): void
+    {
+        $payment = $this->buildPayment();
+        $payment->setDetails([
+            'checkout_id' => 'chk_1',
+        ]);
+
+        $this->buildPayum()->getGateway('acme')->execute(new Capture($payment));
+
+        $this->assertSame(PaymentStatus::Captured, $payment->getStatus());
+    }
+
+    public function testShouldGiveTheHandlerTheTokenFactoryTheGatewayCarries(): void
+    {
+        $payment = $this->buildPayment();
+
+        $this->buildPayum()->getGateway('acme')->execute(new Capture($payment), true);
+
+        // The 1.x extension that hands the token factory out reaches the adapter, so a handler that has
+        // to mint a notify url can. Without it, tokens() throws rather than returning null.
+        $this->assertTrue($payment->getDetails()['has_tokens']);
+    }
+
+    public function testShouldBuildTheAdapterFromTheFactoryConfigTheOtherActionsUse(): void
+    {
+        $payment = $this->buildPayment();
+
+        $this->buildPayum()->getGateway('acme')->execute(new Capture($payment), true);
+
+        // Registered as a closure over the config, the way a 1.x factory builds anything that needs the
+        // api, so a handler is configured from exactly what the actions beside it are configured from.
+        $this->assertSame('sk_test', $payment->getDetails()['api_key']);
+    }
+
+    public function testShouldLeaveARequestItsHandlerDoesNotAnswerAlone(): void
+    {
+        // The adapter answers exactly the one command its handler handles, so a gateway can adopt handlers
+        // one operation at a time.
+        $gateway = $this->buildPayum()->getGateway('acme');
+
+        $gateway->execute(new Refund($this->buildPayment()));
+
+        $this->assertTrue(AdapterRefundAction::$ran);
+    }
+
+    private function buildPayment(): AdapterTrackedPayment
+    {
+        $payment = new AdapterTrackedPayment();
+        $payment->setNumber(uniqid());
+        $payment->setTotalAmount(123);
+        $payment->setCurrencyCode('EUR');
+
+        return $payment;
+    }
+
+    /**
+     * @return Payum<StorageRegistryInterface<StorageInterface<TokenInterface>>>
+     */
+    private function buildPayum(): Payum
+    {
+        AdapterRefundAction::$ran = false;
+
+        return (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addGatewayFactory(
+                'acme_factory',
+                static fn (array $config, GatewayFactoryInterface $coreGatewayFactory): AdapterGatewayFactory => new AdapterGatewayFactory($config, $coreGatewayFactory)
+            )
+            ->addGateway('acme', [
+                'factory' => 'acme_factory',
+            ])
+            ->getPayum();
+    }
+}
+
+/**
+ * Untouched 1.x wiring, except for the one action that has become a handler.
+ */
+final class AdapterGatewayFactory extends GatewayFactory
+{
+    protected function populateConfig(ArrayObject $config): void
+    {
+        $config->defaults([
+            'payum.factory_name' => 'acme_factory',
+            'payum.factory_title' => 'Acme',
+            'payum.api' => 'sk_test',
+            'payum.action.capture' => static fn (ArrayObject $config): HandlerToActionAdapter => new HandlerToActionAdapter(
+                new AdapterCaptureHandler($config['payum.api']),
+            ),
+            'payum.action.refund' => new AdapterRefundAction(),
+        ]);
+    }
+}
+
+final class AdapterCaptureHandler implements CaptureHandlerInterface
+{
+    public function __construct(
+        private readonly string $apiKey
+    ) {
+    }
+
+    public function handle(CaptureCommand $command, Context $context): CaptureResult
+    {
+        $state = $context->state();
+
+        if (! $state['checkout_id']) {
+            $state['checkout_id'] = 'chk_1';
+            // Throws when the gateway carries no token factory, which is the thing being asserted.
+            $context->tokens();
+            $state['has_tokens'] = true;
+            $state['api_key'] = $this->apiKey;
+
+            return CaptureResult::pending(new Redirect('https://psp.test/checkout'));
+        }
+
+        return CaptureResult::captured('txn_1');
+    }
+}
+
+final class AdapterRefundAction implements ActionInterface
+{
+    public static bool $ran = false;
+
+    public function execute($request): void
+    {
+        self::$ran = true;
+    }
+
+    public function supports($request): bool
+    {
+        return $request instanceof Refund;
+    }
+}
+
+class AdapterTrackedPayment extends Payment implements StatusAwareInterface
+{
+    private PaymentStatus $status = PaymentStatus::New;
+
+    public function getStatus(): PaymentStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(PaymentStatus $status): void
+    {
+        $this->status = $status;
+    }
+}

--- a/src/Payum/Core/Tests/Legacy/ReplyToResultTest.php
+++ b/src/Payum/Core/Tests/Legacy/ReplyToResultTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests\Legacy;
+
+use Payum\Core\Legacy\ReplyToResult;
+use Payum\Core\Reply\HttpPostRedirect;
+use Payum\Core\Reply\HttpRedirect;
+use Payum\Core\Reply\HttpResponse;
+use Payum\Core\Result\NextAction\PostRedirect;
+use Payum\Core\Result\NextAction\Redirect;
+use PHPUnit\Framework\TestCase;
+
+final class ReplyToResultTest extends TestCase
+{
+    public function testShouldTurnARedirectReplyIntoARedirect(): void
+    {
+        $next = ReplyToResult::translate(new HttpRedirect('https://psp.test/checkout', 303));
+
+        $this->assertInstanceOf(Redirect::class, $next);
+        $this->assertSame('https://psp.test/checkout', $next->url);
+        $this->assertSame(303, $next->statusCode);
+    }
+
+    public function testShouldTurnAPostRedirectReplyIntoAPostRedirect(): void
+    {
+        // HttpPostRedirect extends HttpResponse, so this is also the test that the specific reply is
+        // recognised before the general one.
+        $next = ReplyToResult::translate(new HttpPostRedirect('https://psp.test/pay', [
+            'token' => 'tok_1',
+        ]));
+
+        $this->assertInstanceOf(PostRedirect::class, $next);
+        $this->assertSame('https://psp.test/pay', $next->url);
+        $this->assertSame([
+            'token' => 'tok_1',
+        ], $next->fields);
+    }
+
+    public function testShouldTranslateNoRenderedResponse(): void
+    {
+        // A rendered page is not intent, and there is no next action to make it one.
+        $this->assertNull(ReplyToResult::translate(new HttpResponse('<form>')));
+    }
+}


### PR DESCRIPTION
`Gateway\DeclaresActions` already lets a gateway keep unported 1.x actions beside its handlers, which moves a gateway across one **operation kind** at a time. This adds the finer grain: a **single operation**, without rewriting it yet.

- `Legacy\ActionToHandlerAdapter` — wraps one `ActionInterface` and presents it as the matching handler interface, so an existing `CaptureAction` answers a `CaptureCommand`.
- `Legacy\HandlerToActionAdapter` — the reverse, for a gateway still assembled by a 1.x factory: register one where the action used to be, and the handler behind it is reached by everything that already talks to that gateway.

Together these turn "port the gateway" from one large commit into a sequence of reviewable ones, which matters most for third-party gateways whose authors have limited time.

## Action → handler

One adapter per command in `Payum\Core\Legacy\Handler` — `Capture`, `Authorize`, `Refund`, `Cancel`, `Sync`, `Payout`, `Notify` — over a shared `ActionToHandlerAdapter` base. Separate classes because PHP will not let one class declare `handle()` twice.

```php
public function handlers(): array
{
    return [CaptureActionHandler::class];
}

public function configureContainer(): array
{
    return [
        CaptureActionHandler::class => fn (ContainerInterface $c) => new CaptureActionHandler(
            new CaptureAction($c->get(AcmeApi::class)),
        ),
    ];
}
```

The action does not change. It gets the details array as its model, the token the command arrived on, the gateway to dispatch sub-requests at, and the token factory if it asks for one. Status is read the 1.x way — `GetHumanStatus` is dispatched after the action returns — because a 1.x action reports status by answering rather than by returning it.

## Handler → action

```php
$config->defaults([
    'payum.action.capture' => fn (ArrayObject $config) => new HandlerToActionAdapter(
        new CaptureHandler($config['payum.api']),
    ),
]);
```

Which request it answers is read off the handler via `HandlerMap`, so there is nothing to keep in step. It is prepended, because a handler wants the payment the request is about and core's own actions would otherwise have unwrapped it to a details array first. The handler gets a real `Context` and the middleware that persists what it writes and records the status it declares; what it returns becomes a reply and is thrown, so callers catch what they always caught.

## Supporting changes

- **`Legacy\ReplyToResult`** — the inverse of `ResultToReply`. `HttpRedirect` → `Redirect`, `HttpPostRedirect` → `PostRedirect`. Anything else answers null and the caller rethrows, mirroring the limit already documented in the other direction.
- **`Gateway::handle()`** sets the gateway on a `GatewayAwareInterface` handler — an adapted action still dispatches `GetHttpRequest` at it.
- **`CoreGatewayFactory::createGateway()`** keeps core's actions and extensions when a handler *is* an adapted action, not only when the gateway implements `DeclaresActions`.
- **`PayumBuilder`** binds a handler interface to the container entry (`DI\get`) rather than a fresh `autowire()`, and registers those bindings *before* the gateway's own definitions. This is what makes the "a decorated handler" case that `ContainerConfiguration` documents actually work — previously the default binding silently won.
- **`Handler\Context`** takes a nullable gateway and token factory. `gateway()` is null under `HandlerToActionAdapter` (a factory-assembled gateway has no gateway class); `tokens()` throws a specific message rather than returning null.

## Deliberate limits, documented

- A rendered `HttpResponse` is rethrown rather than swallowed — no `NextAction` means "here is a page". A 1.x caller catches it as before; a caller working with results sees it escape, which is honest rather than reporting a payment finished when it is not.
- A notify action keeps verifying inside `execute()`. 2.0 splits deciding a message is genuine from acting on it and 1.x does both in one method, so `NotifyActionHandler::verify()` reports `WebhookEvent::unverified()` and the response the action throws becomes the result's `Acknowledgement`. No weaker than 1.x, and no stronger.
- Under `HandlerToActionAdapter`, `$context->execute()` cannot dispatch a sub-command: the gateway has no handlers registered on it.

## Verification

Full suite `3295 tests, OK`. PHPStan reports the same 79 errors as a pristine `2.x` worktree in this environment, none of them in the changed files. ECS and Rector are clean. The registration forms shown in `docs/gateways/migrating-from-v1.md` are the ones under test, including the closure-over-config form a 1.x factory uses to inject an api.

Relates to the "BC layer between v1 actions and v2 handlers" item on the [v2 board](https://github.com/orgs/Payum/projects/1).