### PR TITLE
Read the current time through a PSR-20 clock

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -67,6 +67,12 @@
     hash instead, which is what `HttpRequestVerifier` has always used. A handler is given its token on
     `Context::token()`.
   * `ObtainCreditCard` is unchanged: it stays with the framework integration for 2.0.
+* The current time is read through a PSR-20 clock. `Psr\Clock\ClockInterface` is registered in the global
+  container as a `Payum\Core\Clock\SystemClock`; register any other implementation with
+  `PayumBuilder::addGlobalService(ClockInterface::class, $clock)` — or from your own global container — and
+  every time read follows it, which is what lets a test freeze expiry at a fixed instant.
+  * `Payum\Sofort\Action\StatusAction` takes the clock as its first constructor argument. It defaults to a
+    system clock, so `new StatusAction()` keeps working.
 
 ## 1.5.0
 

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
         "php-di/php-di": "^7.0",
         "php-http/discovery": "^1.19",
         "php-http/message-factory": "^1.1",
+        "psr/clock": "^1.0",
         "psr/container": "^2.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.1 || ^2.0",

--- a/docs/di/framework-integration.md
+++ b/docs/di/framework-integration.md
@@ -440,6 +440,17 @@ use Psr\Http\Client\ClientInterface;
 ->addGlobalService(ClientInterface::class, $frameworkHttpClient)
 ```
 
+### 6. Clock Sharing
+
+Every time Payum reads goes through the PSR-20 clock in the global container. Register the application's
+own clock, so that a test which freezes time freezes it for Payum too:
+
+```php
+use Psr\Clock\ClockInterface;
+
+->addGlobalService(ClockInterface::class, $frameworkClock)
+```
+
 ## Troubleshooting
 
 ### Service Not Found

--- a/docs/di/getting-started.md
+++ b/docs/di/getting-started.md
@@ -26,6 +26,7 @@ Payum v2.0 uses a **hybrid container architecture**:
 │  - Storage Extensions                       │
 │  - PSR-18 HTTP Client (shared)              │
 │  - PSR-17 Factories                         │
+│  - PSR-20 Clock                             │
 │  - Anything from addGlobalService()         │
 └──────────────┬──────────────────────────────┘
                │ delegated to
@@ -123,6 +124,33 @@ $payum = (new PayumBuilder())
     ->getPayum();
 ```
 
+### Controlling the Clock
+
+Everything in Payum that depends on the current time reads it from the PSR-20 clock in the global
+container rather than calling `time()`. That clock is a `Payum\Core\Clock\SystemClock` unless you replace
+it.
+
+Replace it and time stands still, which is what makes expiry testable:
+
+```php
+<?php
+
+use Psr\Clock\ClockInterface;
+use Symfony\Component\Clock\MockClock;
+
+$payum = (new PayumBuilder())
+    ->addDefaultStorages()
+
+    ->addGlobalService(ClockInterface::class, new MockClock('2026-01-01 12:00:00'))
+
+    ->addGateway('stripe', ['factory' => 'stripe_checkout', /* ... */])
+    ->getPayum();
+```
+
+Any PSR-20 implementation will do -- `symfony/clock`, `lcobucci/clock`, or one of your own. Applications
+that already have a clock service should register that one, so that Payum and the rest of the application
+agree on what "now" is.
+
 ## Understanding the Container System
 
 ### Global Services
@@ -136,6 +164,7 @@ These services are instantiated once and shared across all gateways:
 - `ClientInterface` (PSR-18) - HTTP client
 - `StreamFactoryInterface` (PSR-17) - HTTP stream factory
 - `RequestFactoryInterface` (PSR-17) - HTTP request factory
+- `ClockInterface` (PSR-20) - the current time
 - Storage extensions for all registered models
 - Every service registered with `addGlobalService()`
 

--- a/src/Payum/Core/Clock/SystemClock.php
+++ b/src/Payum/Core/Clock/SystemClock.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Clock;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Psr\Clock\ClockInterface;
+
+/**
+ * The machine's own time, registered as {@see ClockInterface} in the global container.
+ *
+ * Replace it there -- with `PayumBuilder::addGlobalService(ClockInterface::class, $clock)`, or from the
+ * application's own container -- and every time Payum reads follows the replacement.
+ */
+final class SystemClock implements ClockInterface
+{
+    /**
+     * @param DateTimeZone|null $timezone null reads in PHP's default timezone
+     */
+    public function __construct(
+        private readonly ?DateTimeZone $timezone = null
+    ) {
+    }
+
+    public function now(): DateTimeImmutable
+    {
+        return new DateTimeImmutable('now', $this->timezone);
+    }
+}

--- a/src/Payum/Core/CoreGatewayFactory.php
+++ b/src/Payum/Core/CoreGatewayFactory.php
@@ -37,6 +37,7 @@ use Payum\Core\Bridge\Httplug\HttplugClient;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Bridge\Twig\TwigRenderer;
 use Payum\Core\Bridge\Twig\TwigUtil;
+use Payum\Core\Clock\SystemClock;
 use Payum\Core\DI\ContainerConfiguration;
 use Payum\Core\DI\CreatesGateway;
 use Payum\Core\Extension\EndlessCycleDetectorExtension;
@@ -52,6 +53,7 @@ use Payum\Core\Middleware\RecordPaymentStatusMiddleware;
 use Payum\Core\Middleware\TemplateRenderMiddleware;
 use Payum\Core\Registry\StorageRegistryInterface;
 use Payum\Core\Template\RendererInterface;
+use Psr\Clock\ClockInterface;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -260,6 +262,11 @@ class CoreGatewayFactory implements GatewayFactoryInterface, ContainerConfigurat
                 StreamFactoryInterface::class => Psr17FactoryDiscovery::findStreamFactory(...),
                 RequestFactoryInterface::class => Psr17FactoryDiscovery::findRequestFactory(...),
                 ServerRequestFactoryInterface::class => Psr17FactoryDiscovery::findServerRequestFactory(...),
+
+                // Every time read goes through this, so that expiry and staleness can be tested at a
+                // fixed instant. The application registers its own through PayumBuilder, which wins
+                // over this one.
+                ClockInterface::class => static fn (): ClockInterface => new SystemClock(),
 
                 // Middleware wrapping command execution. The collection is what decides the order;
                 // PayumBuilder replaces it with the defaults plus whatever the application and the

--- a/src/Payum/Core/PayumBuilder.php
+++ b/src/Payum/Core/PayumBuilder.php
@@ -18,6 +18,7 @@ use Payum\Be2Bill\Be2BillOffsiteGatewayFactory;
 use Payum\Core\Bridge\PlainPhp\Security\HttpRequestVerifier;
 use Payum\Core\Bridge\PlainPhp\Security\TokenFactory;
 use Payum\Core\Bridge\Twig\TwigRenderer;
+use Payum\Core\Clock\SystemClock;
 use Payum\Core\Config\GatewayConfig;
 use Payum\Core\DI\ContainerConfiguration;
 use Payum\Core\DI\CreatesGateway;
@@ -65,6 +66,7 @@ use Payum\Paypal\Rest\PaypalRestGatewayFactory;
 use Payum\Sofort\SofortGatewayFactory;
 use Payum\Stripe\StripeCheckoutGatewayFactory;
 use Payum\Stripe\StripeJsGatewayFactory;
+use Psr\Clock\ClockInterface;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -628,6 +630,10 @@ class PayumBuilder
             StreamFactoryInterface::class => Psr17FactoryDiscovery::findStreamFactory(...),
             RequestFactoryInterface::class => Psr17FactoryDiscovery::findRequestFactory(...),
 
+            // Shared, so that freezing time with addGlobalService() freezes it for every gateway at
+            // once rather than for whichever one happened to be asked.
+            ClockInterface::class => static fn (): ClockInterface => new SystemClock(),
+
             RendererInterface::class => fn (ContainerInterface $c): RendererInterface => new TwigRenderer(
                 $this->resolveTwigEnvironment($c),
                 $this->layout,
@@ -693,6 +699,7 @@ class PayumBuilder
             ClientInterface::class,
             StreamFactoryInterface::class,
             RequestFactoryInterface::class,
+            ClockInterface::class,
         ];
 
         foreach (array_keys($this->storages) as $modelClass) {

--- a/src/Payum/Core/Tests/Clock/SystemClockTest.php
+++ b/src/Payum/Core/Tests/Clock/SystemClockTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests\Clock;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Payum\Core\Clock\SystemClock;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+
+final class SystemClockTest extends TestCase
+{
+    public function testShouldImplementClockInterface(): void
+    {
+        $this->assertInstanceOf(ClockInterface::class, new SystemClock());
+    }
+
+    public function testShouldReturnTheCurrentTime(): void
+    {
+        $before = new DateTimeImmutable();
+        $now = (new SystemClock())->now();
+        $after = new DateTimeImmutable();
+
+        $this->assertGreaterThanOrEqual($before, $now);
+        $this->assertLessThanOrEqual($after, $now);
+    }
+
+    public function testShouldReturnADistinctInstanceOnEveryCall(): void
+    {
+        $clock = new SystemClock();
+
+        $this->assertNotSame($clock->now(), $clock->now());
+    }
+
+    public function testShouldReadInTheGivenTimezone(): void
+    {
+        $clock = new SystemClock(new DateTimeZone('Pacific/Auckland'));
+
+        $this->assertSame('Pacific/Auckland', $clock->now()->getTimezone()->getName());
+    }
+}

--- a/src/Payum/Core/Tests/CoreGatewayFactoryContainerConfigurationTest.php
+++ b/src/Payum/Core/Tests/CoreGatewayFactoryContainerConfigurationTest.php
@@ -23,6 +23,7 @@ use Payum\Core\Action\RenderTemplateAction;
 use Payum\Core\Bridge\Httplug\HttplugClient;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Bridge\Twig\TwigRenderer;
+use Payum\Core\Clock\SystemClock;
 use Payum\Core\CoreGatewayFactory;
 use Payum\Core\DI\ContainerConfiguration;
 use Payum\Core\Extension\Context;
@@ -34,6 +35,8 @@ use Payum\Core\GatewayFactoryConfigInterface;
 use Payum\Core\GatewayFactoryInterface;
 use Payum\Core\Storage\StorageInterface;
 use Payum\Core\Template\RendererInterface;
+use Payum\Core\Tests\Mocks\Clock\FrozenClock;
+use Psr\Clock\ClockInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -82,6 +85,7 @@ final class CoreGatewayFactoryContainerConfigurationTest extends TestCase
             StreamFactoryInterface::class,
             RequestFactoryInterface::class,
             ResponseFactoryInterface::class,
+            ClockInterface::class,
             'payum.http_client',
             'payum.http_stream_factory',
             'payum.http_message_factory',
@@ -173,6 +177,26 @@ final class CoreGatewayFactoryContainerConfigurationTest extends TestCase
         $this->assertInstanceOf(ClientInterface::class, $container->get(ClientInterface::class));
         $this->assertInstanceOf(StreamFactoryInterface::class, $container->get(StreamFactoryInterface::class));
         $this->assertInstanceOf(RequestFactoryInterface::class, $container->get(RequestFactoryInterface::class));
+    }
+
+    public function testShouldResolveASystemClockFromContainer(): void
+    {
+        $container = $this->buildContainer();
+
+        $this->assertInstanceOf(SystemClock::class, $container->get(ClockInterface::class));
+    }
+
+    public function testShouldLetTheGivenConfigReplaceTheClock(): void
+    {
+        $clock = new FrozenClock('2026-01-01 12:00:00');
+
+        $builder = new ContainerBuilder();
+        $builder->addDefinitions((new CoreGatewayFactory())->configureContainer());
+        $builder->addDefinitions([
+            ClockInterface::class => $clock,
+        ]);
+
+        $this->assertSame($clock, $builder->build()->get(ClockInterface::class));
     }
 
     public function testShouldBuildARequestWhoseBodyCanBeRead(): void

--- a/src/Payum/Core/Tests/Mocks/Clock/FrozenClock.php
+++ b/src/Payum/Core/Tests/Mocks/Clock/FrozenClock.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payum\Core\Tests\Mocks\Clock;
+
+use DateTimeImmutable;
+use Psr\Clock\ClockInterface;
+
+final class FrozenClock implements ClockInterface
+{
+    private readonly DateTimeImmutable $now;
+
+    public function __construct(DateTimeImmutable | string $now = 'now')
+    {
+        $this->now = $now instanceof DateTimeImmutable ? $now : new DateTimeImmutable($now);
+    }
+
+    public function now(): DateTimeImmutable
+    {
+        return $this->now;
+    }
+}

--- a/src/Payum/Core/Tests/PayumBuilderGlobalContainerTest.php
+++ b/src/Payum/Core/Tests/PayumBuilderGlobalContainerTest.php
@@ -10,6 +10,7 @@ use InvalidArgumentException;
 use Payum\Core\Action\ActionInterface;
 use Payum\Core\Action\GetHttpRequestAction;
 use Payum\Core\Bridge\PlainPhp\Security\HttpRequestVerifier;
+use Payum\Core\Clock\SystemClock;
 use Payum\Core\CoreGatewayFactory;
 use Payum\Core\DI\ContainerConfiguration;
 use Payum\Core\DI\CreatesGateway;
@@ -27,6 +28,8 @@ use Payum\Core\Security\GenericTokenFactoryInterface;
 use Payum\Core\Security\HttpRequestVerifierInterface;
 use Payum\Core\Security\TokenFactoryInterface;
 use Payum\Core\Storage\StorageInterface;
+use Payum\Core\Tests\Mocks\Clock\FrozenClock;
+use Psr\Clock\ClockInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Psr\Http\Client\ClientInterface;
@@ -142,6 +145,30 @@ final class PayumBuilderGlobalContainerTest extends TestCase
         $this->assertSame($container->get(ClientInterface::class), $container->get(ClientInterface::class));
         $this->assertSame($container->get(StreamFactoryInterface::class), $container->get(StreamFactoryInterface::class));
         $this->assertSame($container->get(RequestFactoryInterface::class), $container->get(RequestFactoryInterface::class));
+    }
+
+    public function testBuildGlobalContainerShouldProvideASystemClockByDefault(): void
+    {
+        $container = (new ExposedGlobalContainerPayumBuilder())
+            ->addDefaultStorages()
+            ->buildGlobalContainer()
+        ;
+
+        $this->assertInstanceOf(SystemClock::class, $container->get(ClockInterface::class));
+        $this->assertSame($container->get(ClockInterface::class), $container->get(ClockInterface::class));
+    }
+
+    public function testBuildGlobalContainerShouldLetTheApplicationReplaceTheClock(): void
+    {
+        $clock = new FrozenClock('2026-01-01 12:00:00');
+
+        $container = (new ExposedGlobalContainerPayumBuilder())
+            ->addDefaultStorages()
+            ->addGlobalService(ClockInterface::class, $clock)
+            ->buildGlobalContainer()
+        ;
+
+        $this->assertSame($clock, $container->get(ClockInterface::class));
     }
 
     public function testBuildGlobalContainerShouldAddDefaultStoragesWhenNoTokenStorageIsSet(): void
@@ -544,6 +571,26 @@ final class PayumBuilderGlobalContainerTest extends TestCase
         $this->assertInstanceOf(TokenFactoryInterface::class, $container->get(TokenFactoryInterface::class));
         $this->assertInstanceOf(StreamFactoryInterface::class, $container->get(StreamFactoryInterface::class));
         $this->assertInstanceOf(RequestFactoryInterface::class, $container->get(RequestFactoryInterface::class));
+        $this->assertInstanceOf(ClockInterface::class, $container->get(ClockInterface::class));
+    }
+
+    public function testShouldPassTheApplicationsClockToTheGatewayContainer(): void
+    {
+        $factory = new ContainerConfigurationGatewayFactoryStub();
+
+        $clock = new FrozenClock('2026-01-01 12:00:00');
+
+        (new PayumBuilder())
+            ->addDefaultStorages()
+            ->addGlobalService(ClockInterface::class, $clock)
+            ->addGatewayFactory('acme_factory', $factory)
+            ->addGateway('acme', [
+                'factory' => 'acme_factory',
+            ])
+            ->getPayum()
+        ;
+
+        $this->assertSame($clock, $factory->container->get(ClockInterface::class));
     }
 
     public function testShouldShareTheGlobalServicesBetweenAllGatewayContainers(): void
@@ -574,6 +621,7 @@ final class PayumBuilderGlobalContainerTest extends TestCase
             ClientInterface::class,
             StreamFactoryInterface::class,
             RequestFactoryInterface::class,
+            ClockInterface::class,
         ] as $serviceId) {
             $this->assertSame(
                 $firstFactory->container->get($serviceId),

--- a/src/Payum/Core/composer.json
+++ b/src/Payum/Core/composer.json
@@ -41,6 +41,7 @@
         "league/uri": "^6.4 || ^7.0",
         "league/uri-components": "^2.2 || ^7.0",
         "twig/twig": "^3.0",
+        "psr/clock": "^1.0",
         "psr/container": "^2.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.1 || ^2.0",

--- a/src/Payum/Sofort/Action/StatusAction.php
+++ b/src/Payum/Sofort/Action/StatusAction.php
@@ -5,12 +5,19 @@ namespace Payum\Sofort\Action;
 use ArrayAccess;
 use Payum\Core\Action\ActionInterface;
 use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Clock\SystemClock;
 use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\Request\GetStatusInterface;
 use Payum\Sofort\Api;
+use Psr\Clock\ClockInterface;
 
 class StatusAction implements ActionInterface
 {
+    public function __construct(
+        private readonly ClockInterface $clock = new SystemClock()
+    ) {
+    }
+
     /**
      * @param GetStatusInterface $request
      */
@@ -23,7 +30,7 @@ class StatusAction implements ActionInterface
         if (! isset($details['status'])
            && isset($details['transaction_id'])
            && isset($details['expires'])
-           && $details['expires'] < time()) {
+           && $details['expires'] < $this->clock->now()->getTimestamp()) {
             $request->markExpired();
 
             return;

--- a/src/Payum/Sofort/SofortGatewayFactory.php
+++ b/src/Payum/Sofort/SofortGatewayFactory.php
@@ -14,6 +14,8 @@ use Payum\Sofort\Action\NotifyAction;
 use Payum\Sofort\Action\RefundAction;
 use Payum\Sofort\Action\StatusAction;
 use Payum\Sofort\Action\SyncAction;
+use Psr\Clock\ClockInterface;
+use Psr\Container\ContainerInterface;
 use Sofort\SofortLib\Sofortueberweisung;
 
 class SofortGatewayFactory extends GatewayFactory
@@ -28,7 +30,7 @@ class SofortGatewayFactory extends GatewayFactory
             'payum.factory_name' => 'sofort',
             'payum.factory_title' => 'Sofort',
             'payum.action.capture' => new CaptureAction(),
-            'payum.action.status' => new StatusAction(),
+            'payum.action.status' => static fn (ContainerInterface $c): StatusAction => new StatusAction($c->get(ClockInterface::class)),
             'payum.action.notify' => new NotifyAction(),
             'payum.action.sync' => new SyncAction(),
             'payum.action.refund' => new RefundAction(),

--- a/src/Payum/Sofort/Tests/Action/StatusActionTest.php
+++ b/src/Payum/Sofort/Tests/Action/StatusActionTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Payum\Sofort\Tests\Action;
 
+use Payum\Core\Clock\SystemClock;
 use Payum\Core\Request\GetHumanStatus;
 use Payum\Core\Tests\GenericActionTest;
+use Payum\Core\Tests\Mocks\Clock\FrozenClock;
 use Payum\Sofort\Action\StatusAction;
 use Payum\Sofort\Api;
+use Psr\Clock\ClockInterface;
 
 final class StatusActionTest extends GenericActionTest
 {
@@ -19,13 +22,27 @@ final class StatusActionTest extends GenericActionTest
 
     public function testShouldMarkExpiredIfPaymentExpirationTimePassed(): void
     {
-        $expires = time();
+        $clock = new FrozenClock('2026-01-01 12:00:00');
+
         $request = $this->executeRequestWithDetails([
             'transaction_id' => self::TRANSACTION_ID,
-            'expires' => --$expires,
-        ]);
+            'expires' => $clock->now()->getTimestamp() - 1,
+        ], $clock);
 
         $this->assertTrue($request->isExpired());
+    }
+
+    public function testShouldNotMarkExpiredWhileTheExpirationTimeIsStillAhead(): void
+    {
+        $clock = new FrozenClock('2026-01-01 12:00:00');
+
+        $request = $this->executeRequestWithDetails([
+            'transaction_id' => self::TRANSACTION_ID,
+            'expires' => $clock->now()->getTimestamp() + 1,
+        ], $clock);
+
+        $this->assertFalse($request->isExpired());
+        $this->assertTrue($request->isNew());
     }
 
     public function testShouldMarkNewIfPaymentWithoutTransactionId(): void
@@ -147,9 +164,9 @@ final class StatusActionTest extends GenericActionTest
      * @param array $details
      * @return GetHumanStatus
      */
-    private function executeRequestWithDetails($details)
+    private function executeRequestWithDetails($details, ClockInterface $clock = new SystemClock())
     {
-        $action = new StatusAction();
+        $action = new StatusAction($clock);
         $request = new GetHumanStatus($details);
         $action->execute($request);
 

--- a/src/Payum/Sofort/Tests/SofortGatewayFactoryTest.php
+++ b/src/Payum/Sofort/Tests/SofortGatewayFactoryTest.php
@@ -4,9 +4,15 @@ declare(strict_types=1);
 
 namespace Payum\Sofort\Tests;
 
+use Payum\Core\CoreGatewayFactory;
 use Payum\Core\Exception\LogicException;
+use Payum\Core\GatewayInterface;
 use Payum\Core\Tests\AbstractGatewayFactoryTest;
+use Payum\Core\Tests\Mocks\Clock\FrozenClock;
+use Payum\Sofort\Action\StatusAction;
 use Payum\Sofort\SofortGatewayFactory;
+use Psr\Clock\ClockInterface;
+use ReflectionProperty;
 
 final class SofortGatewayFactoryTest extends AbstractGatewayFactoryTest
 {
@@ -65,6 +71,21 @@ final class SofortGatewayFactoryTest extends AbstractGatewayFactoryTest
         $factory->create();
     }
 
+    public function testShouldInjectTheContainersClockIntoTheStatusAction(): void
+    {
+        $clock = new FrozenClock('2026-01-01 12:00:00');
+
+        $factory = new SofortGatewayFactory([], new CoreGatewayFactory([
+            ClockInterface::class => $clock,
+        ]));
+
+        $action = $this->findStatusAction($factory->create($this->getRequiredOptions()));
+
+        $ref = new ReflectionProperty($action, 'clock');
+
+        $this->assertSame($clock, $ref->getValue($action));
+    }
+
     protected function getGatewayFactoryClass(): string
     {
         return SofortGatewayFactory::class;
@@ -75,5 +96,16 @@ final class SofortGatewayFactoryTest extends AbstractGatewayFactoryTest
         return [
             'config_key' => 'foo:bar:baz',
         ];
+    }
+
+    private function findStatusAction(GatewayInterface $gateway): StatusAction
+    {
+        foreach ($this->getPropertyValue($gateway, 'actions') as $action) {
+            if ($action instanceof StatusAction) {
+                return $action;
+            }
+        }
+
+        $this->fail('The gateway has no status action.');
     }
 }

--- a/src/Payum/Sofort/composer.json
+++ b/src/Payum/Sofort/composer.json
@@ -25,6 +25,7 @@
   ],
   "require": {
     "payum/core": "2.0.x-dev",
+    "psr/clock": "^1.0",
     "sofort/sofortlib-php": "^3.0"
   },
   "require-dev": {


### PR DESCRIPTION
Closes #1063.

Token expiry, retry backoff, webhook staleness and authorization expiry all want to read the current
time, and every one of them is awkward to test while that time comes from `time()`. This registers a
PSR-20 clock in the container and routes the existing time read through it, before the state machine,
locking and retry work adds more of them — retrofitting a clock through those later means touching the
same code twice.

## The clock

* `Payum\Core\Clock\SystemClock` — `Psr\Clock\ClockInterface` over `new DateTimeImmutable('now')`, with an
  optional timezone.
* `psr/clock: ^1.0` added to the root, `payum/core` and `payum/sofort` manifests. It is a tiny dependency
  with no transitive baggage.

## Registration

* `PayumBuilder::buildGlobalContainer()` registers `ClockInterface` as a `SystemClock`, and
  `buildSharedDefinitions()` shares it — so every gateway container resolves the *same* instance, and
  `addGlobalService(ClockInterface::class, $clock)` or a preset global container replaces it everywhere at
  once rather than for whichever gateway happened to be asked.
* `CoreGatewayFactory::configureContainer()` registers the same default, so a gateway built straight from
  the factory has a clock too. The container layering means the shared one still wins over it.

## Time reads routed through it

`Payum\Sofort\Action\StatusAction` was the only production call to `time()` in the repository. It now
takes the clock as a constructor argument, defaulting to a `SystemClock` so `new StatusAction()` keeps
working, and `SofortGatewayFactory` wires it from the container.

## Tests

`SystemClockTest`; a reusable `Payum\Core\Tests\Mocks\Clock\FrozenClock` (the `Payum\Core\Tests` namespace
is autoloaded for gateway packages, so every package can freeze time with it); container-registration and
override tests on both `PayumBuilder` and `CoreGatewayFactory`; a test that Sofort's factory injects the
container's clock; and the Sofort expiry test rewritten against a fixed instant, plus a new not-yet-expired
case that was not covered before.

## Deliberately left out

Two direct time reads remain, both in the `Payum\Core\Bridge\Symfony` namespace that is deprecated
wholesale in 2.0 and moving to PayumBundle:

* `Form/Type/CreditCardExpirationDateType` uses `date('Y')` for the expiry-year dropdown defaults.
  Injecting a clock means adding a constructor to a class being deleted in 3.0, and the fix would have to
  be duplicated in PayumBundle to matter.
* `Validator/Constraints/CreditCardDate` does `new DateTime($this->min)`, but `$min` is caller-supplied
  input rather than a clock read, and Symfony constraints cannot take services.

The docs are scoped accordingly rather than claiming `time()` appears nowhere.

## Docs

`docs/di/getting-started.md` gains a "Controlling the Clock" section and lists the clock among the global
services; `docs/di/framework-integration.md` gains a "Clock Sharing" note; `UPGRADE.md` documents both the
registration and the `StatusAction` signature.

## Verification

Full suite (3339 tests) green, ECS clean, Rector clean, PHPStan at the pre-change baseline.